### PR TITLE
Add support for private IPs for EC2 and GCE VMs

### DIFF
--- a/go/src/v.io/x/ref/runtime/internal/address_chooser.go
+++ b/go/src/v.io/x/ref/runtime/internal/address_chooser.go
@@ -16,9 +16,9 @@ type addressChooser struct {
 }
 
 func (c *addressChooser) ChooseAddresses(protocol string, candidates []net.Addr) ([]net.Addr, error) {
-	if ipaddr := CloudVMPublicAddress(); ipaddr != nil {
-		c.logger.Infof("CloudVM public IP address: %v", ipaddr)
-		return []net.Addr{ipaddr}, nil
+	if ipaddrs := CloudVMAddresses(); ipaddrs != nil {
+		c.logger.Infof("CloudVM IP addresses: %v", ipaddrs)
+		return ipaddrs, nil
 	}
 	return candidates, nil
 }

--- a/go/src/v.io/x/ref/runtime/internal/cloudvm_linux.go
+++ b/go/src/v.io/x/ref/runtime/internal/cloudvm_linux.go
@@ -68,10 +68,10 @@ func InitCloudVM() (func(), error) {
 	}, nil
 }
 
-// CloudVMPublicAddress returns the public IP address of the Cloud VM instance
-// it is run from, or nil if run from anywhere else. The returned address is the
-// public address of a 1:1 NAT tunnel to this host.
-func CloudVMPublicAddress() *net.IPAddr {
+// CloudVMAddresses returns the private adn public IP addresses of the Cloud VM
+// instance it is run from, or nil if run from anywhere else. The returned
+// public address is the address of a 1:1 NAT tunnel to this host.
+func CloudVMAddresses() []net.Addr {
 	mu.Lock()
 	defer mu.Unlock()
 	if !initialized {
@@ -80,10 +80,10 @@ func CloudVMPublicAddress() *net.IPAddr {
 	if !cloudvm.RunningOnGCE() && !cloudvm.RunningOnAWS() {
 		return nil
 	}
-	// Determine the IP address from VM's metadata
+	r := []net.Addr{&net.IPAddr{IP: cloudvm.InternalIPAddress()}}
 	if ip := cloudvm.ExternalIPAddress(); ip != nil {
 		// 1:1 NAT case, our network config will not change.
-		return &net.IPAddr{IP: ip}
+		return append(r, &net.IPAddr{IP: ip})
 	}
-	return nil
+	return r
 }


### PR DESCRIPTION
The current behavior for Vanadium programs servers running on EC2 or GCE is to
detect the external IP and only use that. This is limiting because in many
realistic scenarios we want to be able to use both the local IPs and the
external IPs.