### PR TITLE
Add an env variable to avoid locking the credentials directory

### DIFF
--- a/x/ref/envvar.go
+++ b/x/ref/envvar.go
@@ -65,6 +65,10 @@ const (
 
 	// When set and non-empty, the namespace client will not use caching.
 	EnvDisableNamespaceCache = "V23_DISABLE_NS_CACHE"
+
+	// If the credentials are loaded from a directory then don't lock the
+	// directory. This allows running
+	EnvDisableCredentialsLocking = "V23_CREDENTIALS_NO_LOCK"
 )
 
 // EnvNamespaceRoots returns the set of namespace roots to be used by the

--- a/x/ref/services/agent/agentlib/principal.go
+++ b/x/ref/services/agent/agentlib/principal.go
@@ -37,13 +37,19 @@ type localPrincipal struct {
 }
 
 func (p *localPrincipal) Close() error {
-	return p.close()
+	if p.close != nil {
+		return p.close()
+	}
+	return nil
 }
 
 func loadPrincipalLocally(credentials string) (agent.Principal, error) {
 	p, err := vsecurity.LoadPersistentPrincipal(credentials, nil)
 	if err != nil {
 		return nil, err
+	}
+	if os.Getenv(ref.EnvDisableCredentialsLocking) != "" {
+		return &localPrincipal{Principal: p}, nil
 	}
 	agentDir := constants.AgentDir(credentials)
 	credsLock := lock.NewDirLock(credentials)


### PR DESCRIPTION
This commit allows disabling locking the credentials directory when
V23_CREDENTIALS_NO_LOCK environment variable is defined. This is useful when
the credentials are stored in a read-only location.

A realistic use case is when a Vanadium program is package in a Docker image
that doesn't have v23agentd and the credentials are mapped read-only using the
`docker run -v ...:ro`. In this case both V23_CREDENTIALS_NO_AGENT and
V23_CREDENTIALS_NO_LOCK need to be set. This can be done either in the
Dockerfile or via:

  docker run \
    --env V23_CREDENTIALS_NO_AGENT=1 \
    --env V23_CREDENTIALS_NO_LOCK=1 \
    ...