### PR TITLE
v.io/x/ref/runtime: fix a bug affecting restarting of servers on the …

### DIFF
--- a/x/ref/runtime/internal/flow/conn/auth.go
+++ b/x/ref/runtime/internal/flow/conn/auth.go
@@ -97,12 +97,6 @@ func (c *Conn) MatchesRID(ep naming.Endpoint) bool {
 		c.remote.RoutingID == ep.RoutingID
 }
 
-// MatchesAddress returns true if the given endpoint has the same address
-// as the remote server.
-func (c *Conn) MatchesAddress(ep naming.Endpoint) bool {
-	return ep.Address == c.remote.Address
-}
-
 func (c *Conn) acceptHandshake(
 	ctx *context.T,
 	versions version.RPCVersionRange,

--- a/x/ref/runtime/internal/flow/conn/auth.go
+++ b/x/ref/runtime/internal/flow/conn/auth.go
@@ -97,6 +97,12 @@ func (c *Conn) MatchesRID(ep naming.Endpoint) bool {
 		c.remote.RoutingID == ep.RoutingID
 }
 
+// MatchesAddress returns true if the given endpoint has the same address
+// as the remote server.
+func (c *Conn) MatchesAddress(ep naming.Endpoint) bool {
+	return ep.Address == c.remote.Address
+}
+
 func (c *Conn) acceptHandshake(
 	ctx *context.T,
 	versions version.RPCVersionRange,

--- a/x/ref/runtime/internal/flow/manager/manager.go
+++ b/x/ref/runtime/internal/flow/manager/manager.go
@@ -779,9 +779,12 @@ func (m *manager) internalDial(
 		return nil, iflow.MaybeWrapError(flow.ErrBadState, ctx, err)
 	}
 	c, _ := cached.(*conn.Conn)
-	// If the connection we found or dialed doesn't have the correct RID, assume it is a Proxy.
+
+	// If the connection we found or dialed doesn't have the correct RID, assume
+	// it is a Proxy, unless it the same address/port are used in which case
+	// it's more likely that it's the same server on a fixed port that's restarted.
 	// We now need to make a flow to a proxy and upgrade it to a conn to the final server.
-	if !c.MatchesRID(remote) {
+	if !c.MatchesRID(remote) && !c.MatchesAddress(remote) {
 		if c, names, rejected, err = m.dialProxyConn(ctx, remote, c, auth, channelTimeout); err != nil {
 			return nil, err
 		}
@@ -831,12 +834,16 @@ func (m *manager) dialReserved(
 			return
 		}
 	}
-	// If the connection we found or dialed doesn't have the correct RID, assume it is a Proxy.
+	// If the connection we found or dialed doesn't have the correct RID, assume
+	// it is a Proxy, unless it the same address/port are used in which case
+	// it's more likely that it's the same server on a fixed port that's restarted.
 	// We now need to make a flow to a proxy and upgrade it to a conn to the final server.
 	if !c.MatchesRID(remote) {
-		pc = c
-		if c, _, _, err = m.dialProxyConn(res.Context(), remote, pc, auth, channelTimeout); err != nil {
-			return
+		if !c.MatchesAddress(remote) {
+			pc = c
+			if c, _, _, err = m.dialProxyConn(res.Context(), remote, pc, auth, channelTimeout); err != nil {
+				return
+			}
 		}
 	} else if proxy {
 		pc, c = c, nil

--- a/x/ref/runtime/internal/flow/manager/manager.go
+++ b/x/ref/runtime/internal/flow/manager/manager.go
@@ -358,7 +358,7 @@ func (m *manager) updateEndpointBlessingsLocked(names []string) {
 // ProxyListen causes the Manager to accept flows from the specified endpoint.
 // The endpoint must correspond to a vanadium proxy.
 // If error != nil, establishing a connection to the Proxy failed.
-// Otherwise, if error == nil, the returned chan will block until the
+// Otherwise, if error == nil, the returned chan will block until
 // connection to the proxy endpoint fails. The caller may then choose to retry
 // the connection.
 // name is a identifier of the proxy. It can be used to access errors
@@ -780,11 +780,8 @@ func (m *manager) internalDial(
 	}
 	c, _ := cached.(*conn.Conn)
 
-	// If the connection we found or dialed doesn't have the correct RID, assume
-	// it is a Proxy, unless it the same address/port are used in which case
-	// it's more likely that it's the same server on a fixed port that's restarted.
-	// We now need to make a flow to a proxy and upgrade it to a conn to the final server.
-	if !c.MatchesRID(remote) && !c.MatchesAddress(remote) {
+	// If the connection we found or dialed doesn't have the correct RID, assume it is a Proxy.
+	if !c.MatchesRID(remote) {
 		if c, names, rejected, err = m.dialProxyConn(ctx, remote, c, auth, channelTimeout); err != nil {
 			return nil, err
 		}
@@ -834,16 +831,13 @@ func (m *manager) dialReserved(
 			return
 		}
 	}
-	// If the connection we found or dialed doesn't have the correct RID, assume
-	// it is a Proxy, unless it the same address/port are used in which case
-	// it's more likely that it's the same server on a fixed port that's restarted.
-	// We now need to make a flow to a proxy and upgrade it to a conn to the final server.
+
+	// If the connection we found or dialed doesn't have the correct RID, assume it is a Proxy.
 	if !c.MatchesRID(remote) {
-		if !c.MatchesAddress(remote) {
-			pc = c
-			if c, _, _, err = m.dialProxyConn(res.Context(), remote, pc, auth, channelTimeout); err != nil {
-				return
-			}
+		pc = c
+		if c, _, _, err = m.dialProxyConn(res.Context(), remote, c, auth, channelTimeout); err != nil {
+			pc, c = nil, pc
+			return
 		}
 	} else if proxy {
 		pc, c = c, nil

--- a/x/ref/services/xproxy/xproxy/proxy_test.go
+++ b/x/ref/services/xproxy/xproxy/proxy_test.go
@@ -120,7 +120,7 @@ func TestServerRestart(t *testing.T) {
 
 	testServerRestart(t, rpc.ListenSpec{
 		Addrs: rpc.ListenAddrs{
-			{Protocol: "tcp", Address: "127.0.01:0"},
+			{Protocol: "tcp", Address: "127.0.0.1:0"},
 		},
 	})
 	testServerRestart(t, rpc.ListenSpec{


### PR DESCRIPTION
…same host+port

Every Vanadium processes uses a different RID (Routing ID) to ensure
that clients can distinguish server instances. If a server uses
a fixed address and port, then clients of that server will
see different RIDs after the server restarts. The current code
assumes that this case of a changed RID implies the use of a proxy.
This revision changes this assumption so that a different RID on the
same address and port is not assumed to be a proxy. The old
behaviour leads to unexpected behaviour, and often to authentication
failures due to the server being treated as a proxy, in particular,
the client fails to send any matching blessings to the server (since
proxies should not be sent blessings intended for the servers
they are proxying).