### PR TITLE
v.io/x/ref/runtime/internal/naming/namespace: add load simple load ba…

### DIFF
--- a/x/ref/runtime/internal/naming/namespace/cache.go
+++ b/x/ref/runtime/internal/naming/namespace/cache.go
@@ -141,6 +141,16 @@ func (c *ttlCache) lookup(ctx *context.T, name string) (naming.MountEntry, error
 		}
 		ctx.VI(2).Infof("namespace cache %s -> %v %s", name, e.Servers, e.Name)
 		e.Name = suffix
+		if l := len(e.Servers); l > 1 {
+			// Rotate returned servers to provide some degree of load balancing.
+			// The rotated set is stored and returned on the next invocation
+			// of lookup.
+			tmp := e
+			tmp.Servers = make([]naming.MountedServer, l)
+			copy(tmp.Servers, e.Servers[1:])
+			tmp.Servers[l-1] = e.Servers[0]
+			c.entries[prefix] = tmp
+		}
 		return e, nil
 	}
 	return naming.MountEntry{}, verror.New(naming.ErrNoSuchName, nil, name)

--- a/x/ref/runtime/internal/naming/namespace/cache.go
+++ b/x/ref/runtime/internal/naming/namespace/cache.go
@@ -146,9 +146,7 @@ func (c *ttlCache) lookup(ctx *context.T, name string) (naming.MountEntry, error
 			// The rotated set is stored and returned on the next invocation
 			// of lookup.
 			tmp := e
-			tmp.Servers = make([]naming.MountedServer, l)
-			copy(tmp.Servers, e.Servers[1:])
-			tmp.Servers[l-1] = e.Servers[0]
+			tmp.Servers = append(e.Servers[1:], e.Servers[0])
 			c.entries[prefix] = tmp
 		}
 		return e, nil


### PR DESCRIPTION
Add simple load balancing support to the local mounttable cache. The cache lookup
will no round-robin through the servers for a given name each time it is called.