### PR TITLE
Expose the real external address of a peer for a Vanadium call

### DIFF
--- a/v23/flow/model.go
+++ b/v23/flow/model.go
@@ -243,6 +243,8 @@ type Flow interface {
 	LocalEndpoint() naming.Endpoint
 	// RemoteEndpoint returns the remote vanadium Endpoint.
 	RemoteEndpoint() naming.Endpoint
+	// RemoteAddr returns the remote address of the peer.
+	RemoteAddr() net.Addr
 	// LocalBlessings returns the blessings presented by the local end of the flow
 	// during authentication.
 	LocalBlessings() security.Blessings
@@ -276,6 +278,9 @@ type Conn interface {
 
 	// LocalAddr returns the Conn's network address.
 	LocalAddr() net.Addr
+
+	// RemoteAddr returns the Conn's network address.
+	RemoteAddr() net.Addr
 }
 
 // Listener provides methods for accepting new Conns.

--- a/v23/rpc/model.go
+++ b/v23/rpc/model.go
@@ -487,6 +487,8 @@ type ServerCall interface {
 	// RemoteEndpoint returns the Endpoint at the remote end of
 	// communication.
 	RemoteEndpoint() naming.Endpoint
+	// RemoteAddr returns the net address of the peer.
+	RemoteAddr() net.Addr
 	// GrantedBlessings are blessings granted by the client to the server
 	// (bound to the server).  Typically provided by a client to delegate
 	// to the server, allowing the server to use the client's authority to

--- a/v23/rpc/reflect_invoker_test.go
+++ b/v23/rpc/reflect_invoker_test.go
@@ -10,6 +10,7 @@ package rpc_test
 import (
 	"errors"
 	"fmt"
+	"net"
 	"reflect"
 	"regexp"
 	"testing"
@@ -55,6 +56,7 @@ func (*FakeStreamServerCall) LocalBlessings() security.Blessings              { 
 func (*FakeStreamServerCall) RemoteBlessings() security.Blessings             { return security.Blessings{} }
 func (*FakeStreamServerCall) LocalEndpoint() naming.Endpoint                  { return naming.Endpoint{} }
 func (*FakeStreamServerCall) RemoteEndpoint() naming.Endpoint                 { return naming.Endpoint{} }
+func (*FakeStreamServerCall) RemoteAddr() net.Addr                            { return nil }
 func (*FakeStreamServerCall) Security() security.Call                         { return nil }
 
 var (

--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -6,6 +6,7 @@ package conn
 
 import (
 	"io"
+	"net"
 	"time"
 
 	"v.io/v23/context"
@@ -382,6 +383,11 @@ func (f *flw) LocalEndpoint() naming.Endpoint {
 // RemoteEndpoint returns the remote vanadium endpoint.
 func (f *flw) RemoteEndpoint() naming.Endpoint {
 	return f.remote
+}
+
+// RemoteAddr returns the remote address of the peer.
+func (f *flw) RemoteAddr() net.Addr {
+	return f.conn.remoteAddr
 }
 
 // LocalBlessings returns the blessings presented by the local end of the flow

--- a/x/ref/runtime/internal/rpc/server.go
+++ b/x/ref/runtime/internal/rpc/server.go
@@ -6,7 +6,6 @@ package rpc
 
 import (
 	"fmt"
-	"golang.org/x/net/trace"
 	"io"
 	"net"
 	"reflect"
@@ -14,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/trace"
 	"v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/flow"
@@ -1020,6 +1020,10 @@ func (fs *flowServer) LocalEndpoint() naming.Endpoint {
 func (fs *flowServer) RemoteEndpoint() naming.Endpoint {
 	//nologcall
 	return fs.flow.RemoteEndpoint()
+}
+func (fs *flowServer) RemoteAddr() net.Addr {
+	//nologcall
+	return fs.flow.RemoteAddr()
 }
 
 type leafDispatcher struct {

--- a/x/ref/runtime/protocols/debug/debug.go
+++ b/x/ref/runtime/protocols/debug/debug.go
@@ -68,6 +68,7 @@ type conn struct {
 }
 
 func (c *conn) LocalAddr() net.Addr                  { return c.addr }
+func (c *conn) RemoteAddr() net.Addr                 { return c.base.RemoteAddr() }
 func (c *conn) ReadMsg() ([]byte, error)             { return c.base.ReadMsg() }
 func (c *conn) WriteMsg(data ...[]byte) (int, error) { return c.base.WriteMsg(data...) }
 func (c *conn) Close() error                         { return c.base.Close() }

--- a/x/ref/runtime/protocols/lib/tcputil/tcputil.go
+++ b/x/ref/runtime/protocols/lib/tcputil/tcputil.go
@@ -94,16 +94,25 @@ func (ln *tcpListener) Close() error {
 }
 
 func NewTCPConn(c net.Conn) flow.Conn {
-	return tcpConn{framer.New(c), c.LocalAddr()}
+	return tcpConn{
+		framer.New(c),
+		c.LocalAddr(),
+		c.RemoteAddr(),
+	}
 }
 
 type tcpConn struct {
 	flow.MsgReadWriteCloser
-	localAddr net.Addr
+	localAddr  net.Addr
+	remoteAddr net.Addr
 }
 
 func (c tcpConn) LocalAddr() net.Addr {
 	return c.localAddr
+}
+
+func (c tcpConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
 }
 
 func TCPResolveAddrs(ctx *context.T, address string) ([]string, error) {

--- a/x/ref/runtime/protocols/lib/websocket/conn.go
+++ b/x/ref/runtime/protocols/lib/websocket/conn.go
@@ -86,6 +86,10 @@ func (c *wrappedConn) LocalAddr() net.Addr {
 	return c.ws.LocalAddr()
 }
 
+func (c *wrappedConn) RemoteAddr() net.Addr {
+	return c.ws.RemoteAddr()
+}
+
 // hybridConn is used by the 'hybrid' protocol that can accept
 // either 'tcp' or 'websocket' connections. In particular, it allows
 // for the reader to peek and buffer the first n bytes of a stream

--- a/x/ref/runtime/protocols/local/init.go
+++ b/x/ref/runtime/protocols/local/init.go
@@ -32,7 +32,8 @@ type conn struct {
 	*wire
 }
 
-func (c *conn) LocalAddr() net.Addr { return c.addr }
+func (c *conn) LocalAddr() net.Addr  { return c.addr }
+func (c *conn) RemoteAddr() net.Addr { return c.peer.addr }
 func (c *conn) ReadMsg() ([]byte, error) {
 	select {
 	case msg := <-c.incoming:

--- a/x/ref/runtime/protocols/vine/vine.go
+++ b/x/ref/runtime/protocols/vine/vine.go
@@ -276,6 +276,10 @@ func (c *conn) LocalAddr() net.Addr {
 	return c.addr
 }
 
+func (c *conn) RemoteAddr() net.Addr {
+	return c.base.RemoteAddr()
+}
+
 type listener struct {
 	base     flow.Listener
 	addr     addr

--- a/x/ref/services/mounttable/mounttablelib/mounttable_test.go
+++ b/x/ref/services/mounttable/mounttablelib/mounttable_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"reflect"
 	"runtime/debug"
 	"sort"
@@ -446,6 +447,7 @@ func (fakeServerCall) Security() security.Call              { return security.Ne
 func (fakeServerCall) Suffix() string                       { return "" }
 func (fakeServerCall) LocalEndpoint() naming.Endpoint       { return naming.Endpoint{} }
 func (fakeServerCall) RemoteEndpoint() naming.Endpoint      { return naming.Endpoint{} }
+func (fakeServerCall) RemoteAddr() net.Addr                 { return nil }
 func (fakeServerCall) GrantedBlessings() security.Blessings { return security.Blessings{} }
 func (fakeServerCall) Server() rpc.Server                   { return nil }
 func (c *fakeServerCall) SendStream() interface {


### PR DESCRIPTION
The v23/rpc/server/ServerCall interface doesn't expose via the
RemoteEndpoint() the real external address of the peer. This change
adds a RemoteAddr() method that does that.