### PR TITLE
Fix a fragmentation bug exhibit by xproxyd

### DIFF
--- a/v23/flow/model.go
+++ b/v23/flow/model.go
@@ -268,6 +268,10 @@ type Flow interface {
 	// Closed returns a channel that remains open until the flow has been closed or
 	// the ctx to the Dial or Accept call used to create the flow has been cancelled.
 	Closed() <-chan struct{}
+
+	// DisableFragmentation disables fragmentation of the []byte. This is used by
+	// xproxyd.
+	DisableFragmentation()
 }
 
 // Conn is the connection onto which flows are mulitplexed.

--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -24,6 +24,7 @@ type flw struct {
 	localBlessings, remoteBlessings   security.Blessings
 	localDischarges, remoteDischarges map[string]security.Discharge
 	noEncrypt                         bool
+	noFragment                        bool
 	writeCh                           chan struct{}
 	remote                            naming.Endpoint
 	channelTimeout                    time.Duration
@@ -103,6 +104,12 @@ func (f *flw) priority() int { return flowPriority }
 // disableEncrytion should not be called concurrently with Write* methods.
 func (f *flw) disableEncryption() {
 	f.noEncrypt = true
+}
+
+// DisableFragmentation should probably not be called concurrently with
+// Write* methods.
+func (f *flw) DisableFragmentation() {
+	f.noFragment = true
 }
 
 // Implement io.Reader.

--- a/x/ref/services/xproxy/xproxy/proxy.go
+++ b/x/ref/services/xproxy/xproxy/proxy.go
@@ -275,6 +275,8 @@ func (p *proxy) startRouting(ctx *context.T, f flow.Flow, m *message.Setup) erro
 		p.mu.Unlock()
 		return NewErrProxyAlreadyClosed(ctx)
 	}
+	f.DisableFragmentation()
+	fout.DisableFragmentation()
 	p.wg.Add(2)
 	p.mu.Unlock()
 	go p.forwardLoop(ctx, f, fout)


### PR DESCRIPTION
The existing logic to avoid fragmentation from flw.writeMsg doesn't
always work causing the xproxy to send to peers (either clients or
servers) incorrectly fragmented messages. As far as I can tell this
happens because the xproxy uses asymmetric connections: the one from
clients/servers to xproxy is *conn.flw while the one from xproxy to
clients/server is tcputil.tcpConn. This, in turn, is causing the
Conn.setup from x/ref/runtime/internal/flow/conn/auth.go to not be able
to detect that encryption is disabled which is the trigger used for
allowing or not the fragmention.

The solution in this commit is to add a dedicated function to disable
fragmentation and use it in the xproxyd code. I did not use chose to
export and use the existing flw.disableEncryption because in this case
we are not actually interested to disable the encryption.