### PR TITLE
Wrap intermittent nil pointer dereference with a nil check

### DIFF
--- a/x/ref/runtime/internal/rpc/typecache.go
+++ b/x/ref/runtime/internal/rpc/typecache.go
@@ -112,7 +112,9 @@ func (tc *typeCache) collect() {
 				if tce.cancel != nil {
 					tce.cancel()
 				}
-				tce.dec.Stop()
+				if tce.dec != nil {
+					tce.dec.Stop()
+				}
 				delete(tc.flows, conn)
 			}
 		}


### PR DESCRIPTION
Wrap intermittent nil pointer dereference with a nil check in `typeCache.collect()`.
Fix #24