### PR TITLE
Add the Debug tag to the __debug/http service

### DIFF
--- a/v23/services/http/http.vdl
+++ b/v23/services/http/http.vdl
@@ -7,6 +7,10 @@
 // by Vanadium.
 package http
 
+import (
+	"v.io/v23/security/access"
+)
+
 // Url represents a url.URL struct.
 // The User field is skipped since it is a struct with only unexported fields.
 type Url struct {
@@ -43,5 +47,5 @@ type Request struct {
 
 type Http interface {
     // RawDo returns the server's response to req.
-    RawDo(req Request) (data []byte | error)
+    RawDo(req Request) (data []byte | error) {access.Debug}
 }

--- a/v23/services/http/http.vdl.go
+++ b/v23/services/http/http.vdl.go
@@ -14,6 +14,7 @@ import (
 	"v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
+	"v.io/v23/security/access"
 	"v.io/v23/vdl"
 )
 
@@ -660,6 +661,7 @@ var descHttp = rpc.InterfaceDesc{
 			OutArgs: []rpc.ArgDesc{
 				{"data", ``}, // []byte
 			},
+			Tags: []*vdl.Value{vdl.ValueOf(access.Tag("Debug"))},
 		},
 	},
 }


### PR DESCRIPTION
This allows controlling the permissions for the `__debug/http` service
via the `-v23.permissions.literal` and `-v23.permissions.file` flags.