### PR TITLE
Add support for JSON output to the vrpc tool

### DIFF
--- a/x/ref/cmd/vrpc/vrpc.go
+++ b/x/ref/cmd/vrpc/vrpc.go
@@ -37,6 +37,7 @@ var (
 	flagInsecure       bool
 	flagShowReserved   bool
 	flagShallowResolve bool
+	flagJSON bool
 	insecureOpts       = []rpc.CallOpt{
 		options.ServerAuthorizer{security.AllowEveryone()},
 		options.NameResolutionAuthorizer{security.AllowEveryone()},
@@ -59,6 +60,8 @@ func init() {
 
 	cmdSignature.Flags.BoolVar(&flagShowReserved, "show-reserved", false, "if true, also show the signatures of reserved methods")
 	cmdVRPC.Flags.BoolVar(&flagShallowResolve, "s", false, "if true, perform a shallow resolve")
+
+	cmdVRPC.Flags.BoolVar(&flagJSON, "json", false, "if true, output a JSON representation of the response")
 }
 
 var cmdVRPC = &cmdline.Command{
@@ -266,7 +269,11 @@ StreamingResultsLoop:
 		case err != nil:
 			return fmt.Errorf("call.Recv failed: %v", err)
 		}
-		fmt.Fprintf(env.Stdout, "<< %v\n", vdlgen.TypedConst(item, "", nil))
+		if flagJSON {
+			fmt.Fprintf(env.Stdout, "<< %v\n", vdlgen.JSON(item, "", nil))
+		} else {
+			fmt.Fprintf(env.Stdout, "<< %v\n", vdlgen.TypedConst(item, "", nil))
+		}
 	}
 	// Finish the method call.
 	outargs := make([]*vdl.Value, len(methodSig.OutArgs))
@@ -282,7 +289,11 @@ StreamingResultsLoop:
 		if i > 0 {
 			fmt.Fprint(env.Stdout, " ")
 		}
-		fmt.Fprint(env.Stdout, vdlgen.TypedConst(arg, "", nil))
+		if flagJSON {
+			fmt.Fprint(env.Stdout, vdlgen.JSON(arg, "", nil))
+		} else {
+			fmt.Fprint(env.Stdout, vdlgen.TypedConst(arg, "", nil))
+		}
 	}
 	fmt.Fprintln(env.Stdout)
 	return nil

--- a/x/ref/lib/vdl/codegen/vdlgen/const.go
+++ b/x/ref/lib/vdl/codegen/vdlgen/const.go
@@ -12,6 +12,7 @@ import (
 
 	"v.io/v23/vdl"
 	"v.io/x/ref/lib/vdl/codegen"
+	"v.io/x/ref/lib/vdl/vdlutil"
 )
 
 // TypedConst returns the explicitly-typed vdl const corresponding to v, in the
@@ -129,6 +130,92 @@ func UntypedConst(v *vdl.Value, pkgPath string, imports codegen.Imports) string 
 	}
 }
 
+// JSON returns a JSON representation of a value. This was adapted from
+// untypedConst function from v.io/x/ref/lib/vdl/codegen/javascript.
+func JSON(v *vdl.Value, pkgPath string, imports codegen.Imports) string {
+	switch v.Kind() {
+	case vdl.Bool:
+		if v.Bool() {
+			return "true"
+		} else {
+			return "false"
+		}
+	case vdl.Byte, vdl.Uint16, vdl.Uint32:
+		return strconv.FormatUint(v.Uint(), 10)
+	case vdl.Int8, vdl.Int16, vdl.Int32:
+		return strconv.FormatInt(v.Int(), 10)
+	case vdl.Uint64:
+		return fmt.Sprintf(`"%d"`, v.Uint())
+	case vdl.Int64:
+		return fmt.Sprintf(`"%d"`, v.Int())
+	case vdl.Float32, vdl.Float64:
+		return strconv.FormatFloat(v.Float(), 'g', -1, bitlen(v.Kind()))
+	case vdl.String:
+		return strconv.Quote(v.RawString())
+	case vdl.Any:
+		if elem := v.Elem(); elem != nil {
+			return JSON(elem, pkgPath, imports)
+		}
+		return "null"
+	case vdl.Optional:
+		if elem := v.Elem(); elem != nil {
+			return JSON(elem, pkgPath, imports)
+		}
+		return "null"
+	case vdl.Enum:
+		return fmt.Sprintf(`"%s"`, v.EnumLabel())
+	case vdl.Array, vdl.List:
+		result := "["
+		for ix := 0; ix < v.Len(); ix++ {
+			if ix > 0 {
+				result += ","
+			}
+			val := JSON(v.Index(ix), pkgPath, imports)
+			result += val
+		}
+		result += "]"
+		return result
+	case vdl.Set:
+		result := "["
+		for ix, key := range vdl.SortValuesAsString(v.Keys()) {
+			if ix > 0 {
+				result += ","
+			}
+			result += JSON(key, pkgPath, imports)
+		}
+		result += "]"
+		return result
+	case vdl.Map:
+		result := "{"
+		for i, key := range vdl.SortValuesAsString(v.Keys()) {
+			if i > 0 {
+				result += ","
+			}
+			result += fmt.Sprintf(`%s: %s`, quote(JSON(key, pkgPath, imports)), JSON(v.MapIndex(key), pkgPath, imports))
+		}
+		result += "}"
+		return result
+	case vdl.Struct:
+		result := "{"
+		t := v.Type()
+		for ix := 0; ix < t.NumField(); ix++ {
+			if ix > 0 {
+				result += ","
+			}
+			result += fmt.Sprintf(`"%s": %s`, vdlutil.FirstRuneToLower(t.Field(ix).Name), JSON(v.StructField(ix), pkgPath, imports))
+		}
+		return result + "}"
+	case vdl.Union:
+		ix, innerVal := v.UnionField()
+		return fmt.Sprintf("{ %q: %v }", vdlutil.FirstRuneToLower(v.Type().Field(ix).Name), JSON(innerVal, pkgPath, imports))
+	case vdl.TypeObject:
+		// TODO(razvanm): check it this is correct.
+		return Type(v.TypeObject(), pkgPath, imports)
+	default:
+		panic(fmt.Errorf("vdl: untypedConst unhandled type %v %v", v.Kind(), v.Type()))
+	}
+}
+
 func formatFloat(x float64, kind vdl.Kind) string {
 	var bitSize int
 	switch kind {
@@ -140,4 +227,21 @@ func formatFloat(x float64, kind vdl.Kind) string {
 		panic(fmt.Errorf("formatFloat unhandled kind: %v", kind))
 	}
 	return strconv.FormatFloat(x, 'g', -1, bitSize)
+}
+
+func bitlen(kind vdl.Kind) int {
+	switch kind {
+	case vdl.Float32:
+		return 32
+	case vdl.Float64:
+		return 64
+	}
+	panic(fmt.Errorf("vdl: bitLen unhandled kind %v", kind))
+}
+
+func quote(s string) string {
+	if len(s) > 2 && s[0] != '"' && s[len(s)-1] != '"' {
+		s = fmt.Sprintf(`"%s"`, s)
+	}
+	return s
 }


### PR DESCRIPTION
This feature make it possible to use the vrpc tool in programs like R or
in conjunctions with tools that know how to filter and process JSON
output (jq for example).

Internal GRAIL revisions: D3579, D10524.