### PR TITLE
v.io/x/ref/factories: add a factory for use when creating Vanadium libraries

### DIFF
--- a/x/ref/examples/main.go
+++ b/x/ref/examples/main.go
@@ -1,0 +1,26 @@
+// Copyright 2015 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// An example using the 'library' factory which is configured via exported
+// variables rather than by command line flags.
+package main
+
+import (
+  "v.io/v23"
+  "v.io/x/ref/runtime/factories/library"
+)
+
+func init() {
+  library.ListenProxy = "test-proxy"
+  library.AlsoLogToStderr = true
+}
+
+func main() {
+  ctx, shutdown := v23.Init()
+  ctx.Infof("Listen spec %v", v23.GetListenSpec(ctx))
+  principal := v23.GetPrincipal(ctx)
+  ctx.Infof("Principal %s", principal.PublicKey())
+
+  defer shutdown()
+}

--- a/x/ref/examples/noflags/main.go
+++ b/x/ref/examples/noflags/main.go
@@ -1,0 +1,23 @@
+// Copyright 2015 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The following enables go generate to generate the doc.go file.
+//go:generate go run $GOPATH/src/v.io/vendor/v.io/x/lib/cmdline/testdata/gendoc.go . -help
+
+package main
+
+import (
+	"v.io/v23"
+	"v.io/x/ref/runtime/factories/library"
+)
+
+func init() {
+	library.AlsoLogToStderr = true
+}
+
+func main() {
+	ctx, shutdown := v23.Init()
+	ctx.Infof("hello world")
+	defer shutdown()
+}

--- a/x/ref/internal/logger/logger.go
+++ b/x/ref/internal/logger/logger.go
@@ -38,6 +38,10 @@ type ManageLog interface {
 	// command line flags.
 	ConfigureFromFlags() error
 
+	// ConfigureFromArgs will configure the supplied logger using the supplied
+	// arguments.
+	ConfigureFromArgs(opts ...vlog.LoggingOpts) error
+
 	// ExplicitlySetFlags returns a map of the logging command line flags and their
 	// values formatted as strings.  Only the flags that were explicitly set are
 	// returned. This is intended for use when an application needs to know what
@@ -51,7 +55,9 @@ func (*dummy) LogDir() string { return "" }
 func (*dummy) Stats() (Info, Error struct{ Lines, Bytes int64 }) {
 	return struct{ Lines, Bytes int64 }{0, 0}, struct{ Lines, Bytes int64 }{0, 0}
 }
-func (*dummy) ConfigureFromFlags() error             { return nil }
+func (*dummy) ConfigureFromFlags() error                        { return nil }
+func (*dummy) ConfigureFromArgs(opts ...vlog.LoggingOpts) error { return nil }
+
 func (*dummy) ExplicitlySetFlags() map[string]string { return nil }
 
 // Manager determines if the supplied logging.Logger implements ManageLog and if so

--- a/x/ref/lib/flags/flags.go
+++ b/x/ref/lib/flags/flags.go
@@ -255,6 +255,9 @@ func (ip *ipHostPortFlagVar) Set(s string) error {
 // Implements flag.Value.String
 func (ip ipHostPortFlagVar) String() string {
 	s := ""
+	if ip.flags == nil {
+		return s
+	}
 	for _, a := range ip.flags.Addrs {
 		s += fmt.Sprintf("(%s %s)", a.Protocol, a.Address)
 	}

--- a/x/ref/lib/flags/flags.go
+++ b/x/ref/lib/flags/flags.go
@@ -29,6 +29,7 @@ const (
 	// used by the Vanadium process runtime. Namely:
 	// --v23.namespace.root (which may be repeated to supply multiple values)
 	// --v23.credentials
+	// --v23.i18n-catalogue
 	// --v23.vtrace.sample-rate
 	// --v23.vtrace.dump-on-shutdown
 	// --v23.vtrace.cache-size
@@ -39,7 +40,6 @@ const (
 	// --v23.tcp.protocol
 	// --v23.tcp.address
 	// --v23.proxy
-	// --v23.i18n-catalogue
 	Listen
 	// --v23.permissions.file (which may be repeated to supply multiple values)
 	// Permissions files are named - i.e. --v23.permissions.file=<name>:<file>

--- a/x/ref/runtime/factories/library/library.go
+++ b/x/ref/runtime/factories/library/library.go
@@ -14,45 +14,123 @@
 package library
 
 import (
+	"bytes"
 	"flag"
+	"os"
 
 	"v.io/v23"
 	"v.io/v23/context"
+	"v.io/v23/flow"
 	"v.io/v23/rpc"
+	"v.io/v23/security"
+	"v.io/v23/security/access"
 
 	"v.io/x/lib/vlog"
+	"v.io/x/ref"
 	"v.io/x/ref/internal/logger"
 	dfactory "v.io/x/ref/lib/discovery/factory"
 	"v.io/x/ref/lib/flags"
 	"v.io/x/ref/lib/pubsub"
-	"v.io/x/ref/lib/security/securityflag"
 	"v.io/x/ref/runtime/internal"
 	"v.io/x/ref/runtime/internal/lib/appcycle"
 	"v.io/x/ref/runtime/internal/rt"
+	"v.io/x/ref/runtime/protocols/lib/websocket"
 	_ "v.io/x/ref/runtime/protocols/tcp"
 	_ "v.io/x/ref/runtime/protocols/ws"
 	_ "v.io/x/ref/runtime/protocols/wsh"
 	"v.io/x/ref/services/debug/debuglib"
 )
 
+func defaultRoots() []string {
+	_, envRoots := ref.EnvNamespaceRoots()
+	if len(envRoots) > 0 {
+		return envRoots
+	}
+	return []string{flags.DefaultNamespaceRoot()}
+}
+
 var (
-	LogToStderr     vlog.LogToStderr
+	// LogToStderr is the equivalent of --logtostderr
+	LogToStderr vlog.LogToStderr
+	// AlsoLogToStderr is the equivalent of --alsologtostderr
 	AlsoLogToStderr vlog.AlsoLogToStderr
-	LogDir          vlog.LogDir
-	Level           vlog.Level
+	// LogDir is the equivalent of --log_dir
+	LogDir vlog.LogDir
+	// Level is the equivalent of --v
+	Level vlog.Level
+	// StderrThreshold is the equivalent of --stderrthreshold
 	StderrThreshold = vlog.StderrThreshold(vlog.ErrorLog)
-	ModuleSpec      vlog.ModuleSpec
-	FilepathSpec    vlog.FilepathSpec
-	TraceLocation   vlog.TraceLocation
+	// ModuleSpec is the equivalent of --vmodule
+	ModuleSpec vlog.ModuleSpec
+	// FilepathSpec is the equivalent of --vpath
+	FilepathSpec vlog.FilepathSpec
+	// TraceLocation is the equivalent of --log_backtrace_at
+	TraceLocation vlog.TraceLocation
+	// MaxStackBufSize is the equivalent of --max_stack_buf_size
 	MaxStackBufSize vlog.MaxStackBufSize
 
-	ListenFlags flags.ListenFlags
+	// RuntimeFlags is the equivalent of the following flags as per
+	// v.io/x/ref/lib/flags:
+	// --v23.namespace.root (which may be repeated to supply multiple values)
+	// --v23.credentials
+	// --v23.i18n-catalogue
+	// --v23.vtrace.sample-rate
+	// --v23.vtrace.dump-on-shutdown
+	// --v23.vtrace.cache-size
+	// --v23.vtrace.collect-regexp
+	RuntimeFlags = flags.RuntimeFlags{
+		NamespaceRoots: defaultRoots(),
+		Credentials:    os.Getenv(ref.EnvCredentials),
+		I18nCatalogue:  os.Getenv(ref.EnvI18nCatalogueFiles),
+		Vtrace: flags.VtraceFlags{
+			SampleRate:     0.0,
+			DumpOnShutdown: true,
+			CacheSize:      1024,
+			LogLevel:       0,
+			CollectRegexp:  "",
+		},
+	}
 
-	RuntimeFlags flags.RuntimeFlags
+	// ListenAddrs is the equivalent of the following flags as per flags.ListenFlags
+	// --v23.tcp.protocol
+	// --v23.tcp.address
+	ListenAddrs flags.ListenAddrs
+	// is the equivalent of --v23.proxy
+	ListenProxy string
+
+	// RuntimePermissionsFile is the equivalent of
+	// --v23.permissions.file=runtime:<file>
+	RuntimePermissionsFile string
+	// RuntimePermissionsLiteral is the equivalent of -v23.permissions.literal
+	RuntimePermissionsLiteral string
+
+	// Roam controls whether roaming is enabled.
+	Roam bool
 )
 
 func init() {
 	v23.RegisterRuntimeFactory(Init)
+	flow.RegisterUnknownProtocol("wsh", websocket.WSH{})
+}
+
+func newAuthorizer() (security.Authorizer, error) {
+	if RuntimePermissionsFile == "" && RuntimePermissionsLiteral == "" {
+		return nil, nil
+	}
+	var a security.Authorizer
+	var err error
+	if RuntimePermissionsLiteral == "" {
+		a, err = access.PermissionsAuthorizerFromFile(RuntimePermissionsFile, access.TypicalTagType())
+	} else {
+		var perms access.Permissions
+		if perms, err = access.ReadPermissions(bytes.NewBufferString(RuntimePermissionsLiteral)); err == nil {
+			a = access.TypicalTagTypePermissionsAuthorizer(perms)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return a, err
 }
 
 // AddAndParseFlags adds Vanadium-specific flags to the provided FlagSet, which
@@ -60,8 +138,7 @@ func init() {
 func AddAndParseFlags(fs *flag.FlagSet) error { return nil }
 
 func Init(ctx *context.T) (v23.Runtime, *context.T, v23.Shutdown, error) {
-	l := logger.Manager(logger.Global()).(*vlog.Logger)
-	if err := l.Configure(
+	if err := logger.Manager(logger.Global()).ConfigureFromArgs(
 		LogToStderr,
 		AlsoLogToStderr,
 		LogDir,
@@ -88,13 +165,17 @@ func Init(ctx *context.T) (v23.Runtime, *context.T, v23.Shutdown, error) {
 		return nil, nil, nil, err
 	}
 
-	lf := ListenFlags
 	listenSpec := rpc.ListenSpec{
-		Addrs:          rpc.ListenAddrs(lf.Addrs),
-		Proxy:          lf.Proxy,
+		Addrs:          rpc.ListenAddrs(ListenAddrs),
+		Proxy:          ListenProxy,
 		AddressChooser: internal.NewAddressChooser(logger.Global()),
 	}
-	reservedDispatcher := debuglib.NewDispatcher(securityflag.NewAuthorizerOrDie())
+
+	authorizer, err := newAuthorizer()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	reservedDispatcher := debuglib.NewDispatcher(authorizer)
 
 	ishutdown := func() {
 		ac.Shutdown()
@@ -108,7 +189,10 @@ func Init(ctx *context.T) (v23.Runtime, *context.T, v23.Shutdown, error) {
 	// https://vanadium-review.googlesource.com/#/c/21954/ has been merged,
 	// I will try to remove the use of the publisher from here downstream
 	// completely (and enable "roaming" for all servers by default).
-	publisher := pubsub.NewPublisher()
+	var publisher *pubsub.Publisher
+	if Roam {
+		publisher = pubsub.NewPublisher()
+	}
 
 	runtime, ctx, shutdown, err := rt.Init(ctx, ac, discoveryFactory, nil, nil, &listenSpec, publisher, RuntimeFlags, reservedDispatcher, 0)
 	if err != nil {

--- a/x/ref/runtime/factories/library/library.go
+++ b/x/ref/runtime/factories/library/library.go
@@ -1,0 +1,124 @@
+// Copyright 2015 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux darwin
+
+// Package library implements a RuntimeFactory suitable for building a Vanadium
+// library that is linked into other applications. It is configured via a set
+// of exported variables rather than via command line flags.
+//
+// The pubsub.Publisher mechanism is used for communicating networking
+// settings to the rpc.Server implementation of the runtime and publishes
+// the Settings it expects.
+package library
+
+import (
+	"flag"
+
+	"v.io/v23"
+	"v.io/v23/context"
+	"v.io/v23/rpc"
+
+	"v.io/x/lib/vlog"
+	"v.io/x/ref/internal/logger"
+	dfactory "v.io/x/ref/lib/discovery/factory"
+	"v.io/x/ref/lib/flags"
+	"v.io/x/ref/lib/pubsub"
+	"v.io/x/ref/lib/security/securityflag"
+	"v.io/x/ref/runtime/internal"
+	"v.io/x/ref/runtime/internal/lib/appcycle"
+	"v.io/x/ref/runtime/internal/rt"
+	_ "v.io/x/ref/runtime/protocols/tcp"
+	_ "v.io/x/ref/runtime/protocols/ws"
+	_ "v.io/x/ref/runtime/protocols/wsh"
+	"v.io/x/ref/services/debug/debuglib"
+)
+
+var (
+	LogToStderr     vlog.LogToStderr
+	AlsoLogToStderr vlog.AlsoLogToStderr
+	LogDir          vlog.LogDir
+	Level           vlog.Level
+	StderrThreshold = vlog.StderrThreshold(vlog.ErrorLog)
+	ModuleSpec      vlog.ModuleSpec
+	FilepathSpec    vlog.FilepathSpec
+	TraceLocation   vlog.TraceLocation
+	MaxStackBufSize vlog.MaxStackBufSize
+
+	ListenFlags flags.ListenFlags
+
+	RuntimeFlags flags.RuntimeFlags
+)
+
+func init() {
+	v23.RegisterRuntimeFactory(Init)
+}
+
+// AddAndParseFlags adds Vanadium-specific flags to the provided FlagSet, which
+// for this factory has no effect.
+func AddAndParseFlags(fs *flag.FlagSet) error { return nil }
+
+func Init(ctx *context.T) (v23.Runtime, *context.T, v23.Shutdown, error) {
+	l := logger.Manager(logger.Global()).(*vlog.Logger)
+	if err := l.Configure(
+		LogToStderr,
+		AlsoLogToStderr,
+		LogDir,
+		Level,
+		StderrThreshold,
+		ModuleSpec,
+		FilepathSpec,
+		TraceLocation,
+		MaxStackBufSize,
+	); err != nil {
+		return nil, nil, nil, err
+	}
+
+	cancelCloud, err := internal.InitCloudVM()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	ac := appcycle.New()
+	discoveryFactory, err := dfactory.New(ctx)
+	if err != nil {
+		ac.Shutdown()
+		cancelCloud()
+		return nil, nil, nil, err
+	}
+
+	lf := ListenFlags
+	listenSpec := rpc.ListenSpec{
+		Addrs:          rpc.ListenAddrs(lf.Addrs),
+		Proxy:          lf.Proxy,
+		AddressChooser: internal.NewAddressChooser(logger.Global()),
+	}
+	reservedDispatcher := debuglib.NewDispatcher(securityflag.NewAuthorizerOrDie())
+
+	ishutdown := func() {
+		ac.Shutdown()
+		cancelCloud()
+		discoveryFactory.Shutdown()
+	}
+
+	// TODO(ashankar): As of April 2016, the only purpose this non-nil
+	// publisher was serving was to enable roaming in RPC servers (see
+	// runtime/internal/flow/manager/manager.go).  Once
+	// https://vanadium-review.googlesource.com/#/c/21954/ has been merged,
+	// I will try to remove the use of the publisher from here downstream
+	// completely (and enable "roaming" for all servers by default).
+	publisher := pubsub.NewPublisher()
+
+	runtime, ctx, shutdown, err := rt.Init(ctx, ac, discoveryFactory, nil, nil, &listenSpec, publisher, RuntimeFlags, reservedDispatcher, 0)
+	if err != nil {
+		ishutdown()
+		return nil, nil, nil, err
+	}
+
+	runtimeFactoryShutdown := func() {
+		ishutdown()
+		shutdown()
+	}
+	return runtime, ctx, runtimeFactoryShutdown, nil
+}


### PR DESCRIPTION
This pull request creates a new Vanadium factory that's suitable for use when creating Vanadium libraries. The main difference is that configuration is via export variables rather than command line flags.