### PR TITLE
/x/ref/runtime/internal/flow/conn: use ctx based logging, not vlog

### DIFF
--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -20,7 +20,6 @@ import (
 	"v.io/v23/rpc/version"
 	"v.io/v23/security"
 	"v.io/v23/verror"
-	"v.io/x/lib/vlog"
 	slib "v.io/x/ref/lib/security"
 )
 
@@ -497,7 +496,7 @@ func (c *Conn) healthCheckNewFlowLocked(ctx *context.T, timeout time.Duration) {
 			// they have been initialized. The simplest fix is to just
 			// initialize them here.
 			c.hcstate = c.newHealthChecksLocked(ctx, timeout)
-			vlog.VI(0).Infof("healthCheckNewFlowLocked: initializing health checks on first refresh: conn %p, timeout: %v", c, timeout)
+			ctx.VI(0).Infof("healthCheckNewFlowLocked: initializing health checks on first refresh: conn %p, timeout: %v", c, timeout)
 			return
 		}
 		if min := minChannelTimeout[c.local.Protocol]; timeout < min {


### PR DESCRIPTION
Use ctx.VI(0).Infof rather than vlog.... to avoid introducing an unnecessary direct dependency.