### PR TITLE
x/ref/runtime/internal: fix flaky tests due to rare race conditions in the networking layer

### DIFF
--- a/v23/flow/model.go
+++ b/v23/flow/model.go
@@ -78,9 +78,10 @@ type Manager interface {
 	// closed.
 	Dial(ctx *context.T, remote naming.Endpoint, auth PeerAuthorizer, channelTimeout time.Duration) (Flow, error)
 
-	// DialSideChannel behaves the same as Dial, except that the returned flow is
-	// not factored in when deciding the underlying connection's idleness, etc.
-	DialSideChannel(ctx *context.T, remote naming.Endpoint, auth PeerAuthorizer, channelTimeout time.Duration) (Flow, error)
+	// DialSideChannelCached returns a new flow over an existing cached
+	// connection that is not factored in when deciding the underlying
+	// connection's idleness, etc.
+	DialSideChannelCached(ctx *context.T, remote naming.Endpoint, auth PeerAuthorizer, underlying ManagedConn, channelTimeout time.Duration) (Flow, error)
 
 	// DialCached creates a Flow to the provided remote endpoint using only cached
 	// connections from previous Listen or Dial calls.

--- a/x/ref/runtime/internal/flow/conn/auth.go
+++ b/x/ref/runtime/internal/flow/conn/auth.go
@@ -20,6 +20,7 @@ import (
 	"v.io/v23/security"
 	"v.io/v23/verror"
 	"v.io/v23/vom"
+	"v.io/x/lib/vlog"
 	iflow "v.io/x/ref/runtime/internal/flow"
 )
 
@@ -267,7 +268,11 @@ func (c *Conn) readRemoteAuth(ctx *context.T, binding []byte, dialer bool) (secu
 			// which will block until NewAccepted (which calls
 			// this method) returns. OpenFlow is generally expected
 			// to be handled by readLoop.
-			go c.handleMessage(ctx, msg)
+			go func() {
+				if err := c.handleMessage(ctx, msg); err != nil {
+					vlog.Infof("handleMessage: %v", err)
+				}
+			}()
 			continue
 		}
 		if err = c.handleMessage(ctx, msg); err != nil {

--- a/x/ref/runtime/internal/flow/conn/auth.go
+++ b/x/ref/runtime/internal/flow/conn/auth.go
@@ -261,6 +261,15 @@ func (c *Conn) readRemoteAuth(ctx *context.T, binding []byte, dialer bool) (secu
 			rttend = time.Now()
 			break
 		}
+		if _, ok := msg.(*message.OpenFlow); ok {
+			// If we get an OpenFlow message here it needs to be handled
+			// asynchronously since it will call the flow handler
+			// which will block until NewAccepted (which calls
+			// this method) returns. OpenFlow is generally expected
+			// to be handled by readLoop.
+			go c.handleMessage(ctx, msg)
+			continue
+		}
 		if err = c.handleMessage(ctx, msg); err != nil {
 			return security.Blessings{}, nil, rttend, err
 		}
@@ -418,7 +427,7 @@ func (b *blessingsFlow) getRemote(ctx *context.T, bkey, dkey uint64) (security.B
 			return security.Blessings{}, nil, err
 		}
 		if err := b.receiveLocked(ctx, received); err != nil {
-			b.f.conn.internalClose(ctx, false, err)
+			b.f.conn.internalClose(ctx, false, false, err)
 			return security.Blessings{}, nil, err
 		}
 	}

--- a/x/ref/runtime/internal/flow/manager/manager.go
+++ b/x/ref/runtime/internal/flow/manager/manager.go
@@ -93,6 +93,7 @@ func New(
 		acceptChannelTimeout: channelTimeout,
 		idleExpiry:           idleExpiry,
 	}
+
 	var valid <-chan struct{}
 	if rid != naming.NullRoutingID {
 		m.ls = &listenState{
@@ -369,7 +370,7 @@ func (m *manager) ProxyListen(ctx *context.T, name string, ep naming.Endpoint) (
 	if m.ls == nil {
 		return nil, NewErrListeningWithNullRid(ctx)
 	}
-	f, err := m.internalDial(ctx, ep, proxyAuthorizer{}, m.acceptChannelTimeout, true, false)
+	f, err := m.internalDial(ctx, ep, proxyAuthorizer{}, m.acceptChannelTimeout, true, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -619,6 +620,8 @@ func (m *manager) lnAcceptLoop(ctx *context.T, ln flow.Listener, local naming.En
 				ctx.Errorf("failed to cache conn %v: %v", c, err)
 				c.Close(ctx, err)
 			}
+			// Note: the flow handler created above will block until
+			// this channel is closed.
 			close(fh.cached)
 		}()
 	}
@@ -768,13 +771,14 @@ func (m *manager) Accept(ctx *context.T) (flow.Flow, error) {
 // that connections managed by this Manager are unhealthy and should be
 // closed.
 func (m *manager) Dial(ctx *context.T, remote naming.Endpoint, auth flow.PeerAuthorizer, channelTimeout time.Duration) (flow.Flow, error) {
-	return m.internalDial(ctx, remote, auth, channelTimeout, false, false)
+	return m.internalDial(ctx, remote, auth, channelTimeout, false, nil)
 }
 
-// DialSideChannel behaves the same as Dial, except that the returned flow is
-// not factored in when deciding the underlying connection's idleness, etc.
-func (m *manager) DialSideChannel(ctx *context.T, remote naming.Endpoint, auth flow.PeerAuthorizer, channelTimeout time.Duration) (flow.Flow, error) {
-	return m.internalDial(ctx, remote, auth, channelTimeout, false, true)
+// DialSideChannelCached returns a new flow over an existing cached
+// connection that is not factored in when deciding the underlying
+// connection's idleness, etc.
+func (m *manager) DialSideChannelCached(ctx *context.T, remote naming.Endpoint, auth flow.PeerAuthorizer, underlying flow.ManagedConn, channelTimeout time.Duration) (flow.Flow, error) {
+	return m.internalDial(ctx, remote, auth, channelTimeout, false, underlying)
 }
 
 // DialCached creates a Flow to the provided remote endpoint using only cached
@@ -809,7 +813,8 @@ func (m *manager) internalDial(
 	remote naming.Endpoint,
 	auth flow.PeerAuthorizer,
 	channelTimeout time.Duration,
-	proxy, sideChannel bool) (flow.Flow, error) {
+	proxy bool,
+	sideChannelChan flow.ManagedConn) (flow.Flow, error) {
 	if m.ls != nil && len(m.ls.serverAuthorizedPeers) > 0 {
 		auth = &peerAuthorizer{auth, m.ls.serverAuthorizedPeers}
 	}
@@ -818,10 +823,36 @@ func (m *manager) internalDial(
 		go m.dialReserved(res, remote, auth, channelTimeout, proxy)
 	}
 
-	cached, names, rejected, err := m.cache.Find(ctx, remote, auth)
-	if err != nil {
-		return nil, iflow.MaybeWrapError(flow.ErrBadState, ctx, err)
+	var cached CachedConn
+	var names []string
+	var rejected []security.RejectedBlessing
+	var err error
+	var forSideChannel = false
+	if sideChannelChan != nil {
+		forSideChannel = true
+		all, err := m.cache.FindAllCached(ctx, remote, auth)
+		if err == nil {
+			for i, c := range all {
+				sc := c.(flow.ManagedConn)
+				if sideChannelChan == sc {
+					cached = c
+					if i > 0 {
+						ctx.Infof("internalDial: side channel for %v, conn %p, index: %v", remote, c, i)
+					}
+					break
+				}
+			}
+		}
+		if cached == nil {
+			return nil, fmt.Errorf("failed to find cached conn %p", sideChannelChan)
+		}
+	} else {
+		cached, names, rejected, err = m.cache.Find(ctx, remote, auth)
+		if err != nil {
+			return nil, iflow.MaybeWrapError(flow.ErrBadState, ctx, err)
+		}
 	}
+
 	c, _ := cached.(*conn.Conn)
 
 	// If the connection we found or dialed doesn't have the correct RID, assume it is a Proxy.
@@ -830,7 +861,7 @@ func (m *manager) internalDial(
 			return nil, err
 		}
 	}
-	return dialFlow(ctx, c, remote, names, rejected, channelTimeout, auth, sideChannel)
+	return dialFlow(ctx, c, remote, names, rejected, channelTimeout, auth, forSideChannel)
 }
 
 func (m *manager) dialReserved(

--- a/x/ref/runtime/internal/naming/namespace/all_test.go
+++ b/x/ref/runtime/internal/naming/namespace/all_test.go
@@ -657,6 +657,7 @@ func TestAuthorizationDuringResolve(t *testing.T) {
 	// Setup the namespace root for all the "processes".
 	rootmt := runMT(t, rootMtCtx, "")
 	defer rootmt.stop()
+
 	for _, ctx := range []*context.T{mtCtx, serverCtx, clientCtx} {
 		v23.GetNamespace(ctx).SetRoots(rootmt.name)
 	}
@@ -666,9 +667,7 @@ func TestAuthorizationDuringResolve(t *testing.T) {
 
 	// Intermediate mounttables should be authenticated.
 	mt := runMT(t, mtCtx, "mt")
-	defer func() {
-		mt.stop()
-	}()
+	defer mt.stop()
 
 	// Mount a server on "mt".
 	if err := serverNs.Mount(serverCtx, "mt/server", serverEndpoint, time.Minute, naming.ReplaceMount(true)); err != nil {

--- a/x/ref/runtime/internal/rpc/client.go
+++ b/x/ref/runtime/internal/rpc/client.go
@@ -476,10 +476,11 @@ func (c *client) tryConnectToServer(
 		// This flow must outlive the flow we're currently creating.
 		// It lives as long as the connection to which it is bound.
 		tctx, tcancel := context.WithRootCancel(ctx)
-		tflow, err := c.flowMgr.DialSideChannel(tctx, flw.RemoteEndpoint(), typeFlowAuthorizer{}, 0)
+		tflow, err := c.flowMgr.DialSideChannelCached(tctx, flw.RemoteEndpoint(), typeFlowAuthorizer{}, flw.Conn(), 0)
 		if err != nil {
 			write(nil, tcancel)
 		} else if tflow.Conn() != flw.Conn() {
+			ctx.Infof("Existing: %p, new side channel: %p: %v", flw.Conn(), tflow.Conn(), flw.Conn().RemoteEndpoint())
 			tflow.Close()
 			write(nil, tcancel)
 		} else if _, err = tflow.Write([]byte{typeFlow}); err != nil {

--- a/x/ref/runtime/internal/rpc/server.go
+++ b/x/ref/runtime/internal/rpc/server.go
@@ -246,7 +246,7 @@ func WithNewDispatchingServer(ctx *context.T,
 			select {
 			case <-done:
 			case <-time.After(s.lameDuckTimeout):
-				s.ctx.Errorf("%s: Timed out waiting for active requests to complete", serverDebug)
+				s.ctx.Errorf("%s: Timed out after %v waiting for active requests to complete", serverDebug, s.lameDuckTimeout)
 			}
 		}
 		// Now we cancel the root context which closes all the connections


### PR DESCRIPTION
There are three race conditions that are addressed by this pull request that would show themselves in rare failures for the TestAuthorizationDuringResolve (naming/namespace) test when the tests are run on a heavily loaded. It was possible to repro them using as well as seeing them on travis at peak load times during the day, but not evenings/weekends.

$ seq 1 2000 | parallel -j 30 'go test -v -run=TestAuthorizationDuringResolve -count=1

- dialing a side channel via DialSideChannel is racy in that it relies on finding the same connection, in the cache, as the existing parent connection (see rpc/client.go:479 and below). The connection cache may end up with multiple entries for the same remote endpoint depending on relative arrival of messages, but the existing code would return only the first authorized one connection. The change made is to change the API to supply the existing connection (DialSideChannelCached) and to search the connection cache for that connection as expected by the cal site (rpc/client.go:479). The paranoid, though strictly unnecessary, checks at the call site are kept for now.

With the above problem fixed, two further ones showed themselves. The first was a deadlock that would result in the test itself timing out. The second, also a deadlock, that would result in a name resolution timeout.

- the first deadlock occurs because the race causes a connection close to hang which prevents the test from cleaning up after itself. The race is in NewAccepted, which uses a background goroutine to call acceptHandshake but waits for that goroutine to return, however, it is possible for the waiting select to timeout, or for its context to be cancelled, in which case the connection is closed via its Close method see, conn.go:358. However calling Close directly will cause it block on the loopWG wait group, which is only released when the prior background goroutine finishes, which may take a long time or forever if it's blocked on reading a connection that is never closed. The fix is to extend internalClose to not block on the loopWG waitgroup in this case.

NewAccepted calls acceptHandshake, but if that that times out or the call is cancelled, then it doesn't make sense to wait for it to finish, hence the change to conn.go:363, to close the connection but without on the loopWG waitgroup.

- the second timeout occurs due to a bug in the handling of OpenFlow messages via the NewAccepted method again. NewAccepted calls acceptHandshake and then remoteAuth to complete the authentication handshake. However remoteAuth calls handleMessage for all message types, including OpenFlow messages. handleMessage will call the flow handler supplied to it to pass the openflow message back to the flow manager. This has the potential to block, and at least for the call to NewAccepted from the flow manager that blocked call can only be unblocked when NewAccepted returns - hence the deadlock. The fix is to call handleMessage asynchronously in this case as is the normal code path (via readLoop). See manager.go:565 for the call site, not that the flow handler has a channel that HandleFlow will block on, but that that channel is not closed until NewAccepted returns (line 625).

