### PR TITLE
x/ref/lib/flags: put default values into a separate file

### DIFF
--- a/x/ref/lib/flags/default_values.go
+++ b/x/ref/lib/flags/default_values.go
@@ -1,0 +1,21 @@
+// Copyright 2018 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package flags
+
+// This file is intended to be overriden by local installations to set
+// their site-specific defaults.
+
+var defaultValues = map[string]interface{}{
+	"namespaceRoots": []string{
+		"/(dev.v.io:r:vprod:service:mounttabled)@ns.dev.v.io:8101",
+	},
+	"credentialsDir":     "",
+	"i18nCatalogue":      "",
+	"protocol":           "wsh",
+	"hostPort":           ":0",
+	"proxy":              "",
+	"permissionsLiteral": "",
+	"permissions":        map[string]string{},
+}

--- a/x/ref/lib/flags/defaults.go
+++ b/x/ref/lib/flags/defaults.go
@@ -1,3 +1,7 @@
+// Copyright 2018 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package flags
 
 import (
@@ -8,17 +12,23 @@ import (
 )
 
 var (
-	defaultNamespaceRoots = []string{
-		"/(dev.v.io:r:vprod:service:mounttabled)@ns.dev.v.io:8101",
-	} // GUARDED_BY defaultMu
-	defaultCredentialsDir     string                // GUARDED_BY defaultMu
-	defaultI18nCatalogue      string                // GUARDED_BY defaultMu
-	defaultProtocol           = "wsh"               // GUARDED_BY defaultMu
-	defaultHostPort           = ":0"                // GUARDED_BY defaultMu
-	defaultProxy              = ""                  // GUARDED_BY defaultMu
-	defaultPermissionsLiteral = ""                  // GUARDED_BY defaultMu
-	defaultPermissions        = map[string]string{} // GUARDED_BY defaultMu
-	defaultMu                 sync.RWMutex
+	defaultNamespaceRoots = defaultValues["namespaceRoots"].([]string)
+	// GUARDED_BY defaultMu
+	defaultCredentialsDir = defaultValues["credentialsDir"].(string)
+	// GUARDED_BY defaultMu
+	defaultI18nCatalogue = defaultValues["i18nCatalogue"].(string)
+	// GUARDED_BY defaultMu
+	defaultProtocol = defaultValues["protocol"].(string)
+	// GUARDED_BY defaultMu
+	defaultHostPort = defaultValues["hostPort"].(string)
+	// GUARDED_BY defaultMu
+	defaultProxy = defaultValues["proxy"].(string)
+	// GUARDED_BY defaultMu
+	defaultPermissionsLiteral = defaultValues["permissionsLiteral"].(string)
+	// GUARDED_BY defaultMu
+	defaultPermissions = defaultValues["permissions"].(map[string]string)
+	// GUARDED_BY defaultMu
+	defaultMu sync.RWMutex
 )
 
 // SetDefaultProtocol sets the default protocol used when --v23.tcp.protocol is

--- a/x/ref/lib/flags/namespace.go
+++ b/x/ref/lib/flags/namespace.go
@@ -1,3 +1,7 @@
+// Copyright 2018 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package flags
 
 import "fmt"

--- a/x/ref/lib/flags/permissions.go
+++ b/x/ref/lib/flags/permissions.go
@@ -1,3 +1,7 @@
+// Copyright 2018 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package flags
 
 import (


### PR DESCRIPTION
Put the default values for flags into a separate file to make it easier to customize at each installation site.