### PR TITLE
x/ref/factories/roaming: explicitly enable netconfig for use with roaming

### DIFF
--- a/x/ref/runtime/factories/roaming/roaming.go
+++ b/x/ref/runtime/factories/roaming/roaming.go
@@ -14,6 +14,8 @@
 package roaming
 
 import (
+	"v.io/x/lib/netconfig"
+	"v.io/x/lib/netconfig/osnetconfig"
 	"v.io/x/ref/runtime/factories/library"
 
 	"v.io/v23/flow"
@@ -31,4 +33,5 @@ func init() {
 	library.ReservedNameDispatcher = true
 	flow.RegisterUnknownProtocol("wsh", websocket.WSH{})
 	library.EnableCommandlineFlags()
+	netconfig.SetOSNotifier(osnetconfig.NewNotifier(0))
 }


### PR DESCRIPTION
PR vanadium/go.lib#24 requires that os specific network configuration monitoring be explicitly enabled. This PR does so for the roaming profile.
