### PR TITLE
x/ref/runtime/factories: changes to support cross-compilation

### DIFF
--- a/v23/query/engine/internal/query_checker/query_checker_test.go
+++ b/v23/query/engine/internal/query_checker/query_checker_test.go
@@ -19,7 +19,7 @@ import (
 	"v.io/v23/query/syncql"
 	"v.io/v23/vdl"
 	"v.io/v23/verror"
-	_ "v.io/x/ref/runtime/factories/roaming"
+	_ "v.io/x/ref/runtime/factories/generic"
 	"v.io/x/ref/test"
 )
 

--- a/v23/query/engine/internal/query_functions/query_functions_test.go
+++ b/v23/query/engine/internal/query_functions/query_functions_test.go
@@ -19,8 +19,7 @@ import (
 	"v.io/v23/query/syncql"
 	"v.io/v23/vdl"
 	"v.io/v23/verror"
-
-	_ "v.io/x/ref/runtime/factories/roaming"
+	_ "v.io/x/ref/runtime/factories/generic"
 	"v.io/x/ref/test"
 )
 

--- a/v23/query/engine/internal/query_parser/query_parser_test.go
+++ b/v23/query/engine/internal/query_parser/query_parser_test.go
@@ -17,7 +17,7 @@ import (
 	"v.io/v23/query/syncql"
 	"v.io/v23/vdl"
 	"v.io/v23/verror"
-	_ "v.io/x/ref/runtime/factories/roaming"
+	_ "v.io/x/ref/runtime/factories/generic"
 	"v.io/x/ref/test"
 )
 

--- a/v23/query/engine/query_test.go
+++ b/v23/query/engine/query_test.go
@@ -21,7 +21,7 @@ import (
 	"v.io/v23/vdl"
 	"v.io/v23/verror"
 	"v.io/v23/vom"
-	_ "v.io/x/ref/runtime/factories/roaming"
+	_ "v.io/x/ref/runtime/factories/generic"
 	"v.io/x/ref/test"
 )
 

--- a/v23/query/syncql/error_offset_test.go
+++ b/v23/query/syncql/error_offset_test.go
@@ -11,7 +11,7 @@ import (
 	"v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/query/syncql"
-	_ "v.io/x/ref/runtime/factories/roaming"
+	_ "v.io/x/ref/runtime/factories/generic"
 	"v.io/x/ref/test"
 )
 

--- a/v23/rpc/reflect_invoker_test.go
+++ b/v23/rpc/reflect_invoker_test.go
@@ -24,7 +24,7 @@ import (
 	"v.io/v23/vdl"
 	"v.io/v23/vdlroot/signature"
 	"v.io/v23/verror"
-	_ "v.io/x/ref/runtime/factories/roaming"
+	_ "v.io/x/ref/runtime/factories/generic"
 	"v.io/x/ref/test"
 	"v.io/x/ref/test/testutil"
 )

--- a/x/ref/cmd/namespace/impl.go
+++ b/x/ref/cmd/namespace/impl.go
@@ -26,9 +26,8 @@ import (
 	"v.io/v23/security"
 	"v.io/v23/security/access"
 	"v.io/v23/verror"
-
 	"v.io/x/ref/lib/v23cmd"
-	_ "v.io/x/ref/runtime/factories/generic"
+	_ "v.io/x/ref/runtime/factories/static"
 )
 
 func main() {

--- a/x/ref/cmd/principal/main.go
+++ b/x/ref/cmd/principal/main.go
@@ -32,7 +32,7 @@ import (
 	vsecurity "v.io/x/ref/lib/security"
 	"v.io/x/ref/lib/security/passphrase"
 	"v.io/x/ref/lib/v23cmd"
-	_ "v.io/x/ref/runtime/factories/roaming"
+	_ "v.io/x/ref/runtime/factories/static"
 )
 
 var (

--- a/x/ref/runtime/factories/roaming/roaming-cgo.go
+++ b/x/ref/runtime/factories/roaming/roaming-cgo.go
@@ -1,0 +1,18 @@
+// Copyright 2018 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin,linux,!cgo
+
+package roaming
+
+import (
+	"v.io/x/lib/netconfig"
+	"v.io/x/lib/netconfig/osnetconfig"
+	"v.io/x/ref/runtime/factories/library"
+)
+
+func init() {
+	library.Roam = true
+	netconfig.SetOSNotifier(osnetconfig.NewNotifier(0))
+}

--- a/x/ref/runtime/factories/roaming/static.go
+++ b/x/ref/runtime/factories/roaming/static.go
@@ -1,0 +1,15 @@
+// Copyright 2018 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin,linux,cgo
+
+package roaming
+
+import (
+	"v.io/x/ref/runtime/factories/library"
+)
+
+func init() {
+	library.Roam = false
+}

--- a/x/ref/runtime/factories/static/static.go
+++ b/x/ref/runtime/factories/static/static.go
@@ -4,17 +4,10 @@
 
 // +build linux darwin
 
-// Package roaming implements a RuntimeFactory suitable for a variety of network
-// configurations, including 1-1 NATs, dhcp auto-configuration, Amazon Web
-// Services and Google Compute Engine. It will adapt to networking changes
-// such as the host obtaining a new IP address. This 'roaming' behaviour
-// is disabled if cross compilation is used since it relies on cgo to
-// access OS specific functionality for detecting and reading network
-// configuration changes.
-//
-// The pubsub.Publisher mechanism is used for communicating networking
-// settings to the rpc.Server implementation of the runtime and publishes
-// the Settings it expects.
+// Package static implements a RuntimeFactory suitable for a variety of network
+// configurations, including 1-1 NATs, Amazon Web Services and Google Compute
+// Engine but hosted on a static IP address with no support for adapting to
+// dhcp changes.
 package roaming
 
 import (
@@ -29,6 +22,7 @@ import (
 )
 
 func init() {
+	library.Roam = false
 	library.CloudVM = true
 	library.ConfigureLoggingFromFlags = true
 	library.ReservedNameDispatcher = true

--- a/x/ref/runtime/factories/static/static.go
+++ b/x/ref/runtime/factories/static/static.go
@@ -8,7 +8,7 @@
 // configurations, including 1-1 NATs, Amazon Web Services and Google Compute
 // Engine but hosted on a static IP address with no support for adapting to
 // dhcp changes.
-package roaming
+package static
 
 import (
 	"v.io/x/ref/runtime/factories/library"

--- a/x/ref/runtime/internal/loadbalancing_test.go
+++ b/x/ref/runtime/internal/loadbalancing_test.go
@@ -11,7 +11,7 @@ import (
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/rpc"
-	_ "v.io/x/ref/runtime/factories/roaming"
+	_ "v.io/x/ref/runtime/factories/generic"
 	"v.io/x/ref/test"
 	"v.io/x/ref/test/testutil"
 )

--- a/x/ref/services/mounttable/mounttabled/main.go
+++ b/x/ref/services/mounttable/mounttabled/main.go
@@ -11,7 +11,6 @@ import (
 	"v.io/v23/context"
 	"v.io/x/lib/cmdline"
 	"v.io/x/ref/lib/v23cmd"
-	_ "v.io/x/ref/runtime/factories/roaming"
 	"v.io/x/ref/services/mounttable/mounttablelib"
 )
 

--- a/x/ref/services/mounttable/mounttabled/main.go
+++ b/x/ref/services/mounttable/mounttabled/main.go
@@ -11,6 +11,7 @@ import (
 	"v.io/v23/context"
 	"v.io/x/lib/cmdline"
 	"v.io/x/ref/lib/v23cmd"
+	_ "v.io/x/ref/runtime/factories/roaming"
 	"v.io/x/ref/services/mounttable/mounttablelib"
 )
 

--- a/x/ref/test/v23test/v23test.go
+++ b/x/ref/test/v23test/v23test.go
@@ -275,7 +275,7 @@ func SkipUnlessRunningIntegrationTests(tb testing.TB) {
 // Methods for starting subprocesses
 
 func initSession(tb testing.TB, c *Cmd) {
-	c.S = expect.NewSession(tb, c.StdoutPipe(), 2*time.Minute)
+	c.S = expect.NewSession(tb, c.StdoutPipe(), time.Minute)
 	c.S.SetVerbosity(testing.Verbose())
 	c.S.SetContinueOnError(c.sh.ContinueOnError)
 }

--- a/x/ref/test/v23test/v23test.go
+++ b/x/ref/test/v23test/v23test.go
@@ -275,7 +275,7 @@ func SkipUnlessRunningIntegrationTests(tb testing.TB) {
 // Methods for starting subprocesses
 
 func initSession(tb testing.TB, c *Cmd) {
-	c.S = expect.NewSession(tb, c.StdoutPipe(), time.Minute)
+	c.S = expect.NewSession(tb, c.StdoutPipe(), 2*time.Minute)
 	c.S.SetVerbosity(testing.Verbose())
 	c.S.SetContinueOnError(c.sh.ContinueOnError)
 }


### PR DESCRIPTION
The roaming profile uses x/lib/osnetconfig to detect and read networking changes. osnetconfig requires the use of cgo which implies that any user of the roaming profile cannot be cross-compiled. This PR uses build constraints to disable the use of osnetconfig when cross compiling.
In addition, a new factory, static, is provided that explicitly does not enable roaming and it used where appropriate.