### PR TITLE
x/ref/services/agent/agentlib: make sure that agent locking is always enabled for tests.

### DIFF
--- a/x/ref/services/agent/agentlib/principal_v23_test.go
+++ b/x/ref/services/agent/agentlib/principal_v23_test.go
@@ -40,11 +40,14 @@ func TestV23AgentPrincipal(t *testing.T) {
 	sh.PropagateChildOutput = true
 	// Make sure we enable launching an agent when loading credentials.
 	os.Unsetenv(ref.EnvCredentialsNoAgent)
+	// Make sure that locking is enabled.
+	os.Unsetenv(ref.EnvDisableCredentialsLocking)
 	// This is not strictly needed since we don't create child processes
 	// using the shell that need to load credentials using the agent, but
 	// it's good practice to use the same setting in the parent and any
 	// children.
 	delete(sh.Vars, ref.EnvCredentialsNoAgent)
+	delete(sh.Vars, ref.EnvDisableCredentialsLocking)
 	defer sh.Cleanup()
 
 	agentd := v23test.BuildGoPkg(sh, "v.io/x/ref/services/agent/v23agentd")


### PR DESCRIPTION
This change ensures that V23_CREDENTIALS_NO_LOCK is never set for this test and any subprocesses
that it runs. If it is set, even as V23_CREDENTIALS_NO_LOCK=0, then the test will fail. Another option would be to skip the test if env var is set.