### PR TITLE
Some cleanups for x/ref/examples/echo

### DIFF
--- a/x/ref/examples/echo/echo/echo.go
+++ b/x/ref/examples/echo/echo/echo.go
@@ -16,7 +16,7 @@ import (
 	"v.io/v23/context"
 	"v.io/x/ref/examples/echo"
 	"v.io/x/ref/lib/signals"
-	_ "v.io/x/ref/runtime/factories/roaming"
+	_ "v.io/x/ref/runtime/factories/static"
 )
 
 var (

--- a/x/ref/examples/echo/echo/echo.go
+++ b/x/ref/examples/echo/echo/echo.go
@@ -8,14 +8,15 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/x/ref/examples/echo"
 	"v.io/x/ref/lib/signals"
-	_ "v.io/x/ref/runtime/factories/generic"
+	_ "v.io/x/ref/runtime/factories/roaming"
 )
 
 var (
@@ -27,11 +28,10 @@ var (
 )
 
 func init() {
-	flag.StringVar(&nameFlag, "name", "pingd", "Name of the server to connect to")
-	flag.BoolVar(&cancelFlag, "cancel", true, "cancel every RPC context once it has returned successfully")
+	flag.StringVar(&nameFlag, "name", os.ExpandEnv("users/${USER}/echod"), "Name of the server to connect to")
+	flag.BoolVar(&cancelFlag, "cancel", true, "Cancel every RPC context once it has returned successfully")
 	flag.DurationVar(&intervalFlag, "interval", time.Second, "Interval between client calls")
 	flag.DurationVar(&deadlineFlag, "deadline", time.Second*60, "Deadline for the rpc")
-
 }
 
 func main() {

--- a/x/ref/examples/echo/echod/echod.go
+++ b/x/ref/examples/echo/echod/echod.go
@@ -19,7 +19,7 @@ import (
 	"v.io/v23/security/access"
 	"v.io/x/ref/examples/echo"
 	"v.io/x/ref/lib/signals"
-	_ "v.io/x/ref/runtime/factories/roaming"
+	_ "v.io/x/ref/runtime/factories/static"
 )
 
 var nameFlag string


### PR DESCRIPTION
The included cleanups are:

- switch to v.io/x/ref/runtime/factories/roaming
- add a name flag to echod and make it consistent with echo
- add the user in the name flag to avoid conflicts between users
- fix a typo in a comment.