### PR TITLE
x/ref/runtime/internal/rpc: always print errors returned by net.Listen

### DIFF
--- a/x/ref/runtime/factories/library/library.go
+++ b/x/ref/runtime/factories/library/library.go
@@ -168,9 +168,6 @@ func EnableFlags(fs *flag.FlagSet, parse bool) error {
 func configureLogging() error {
 	var err error
 	if ConfigureLoggingFromFlags {
-		if !flag.Parsed() {
-			flag.Parse()
-		}
 		err = logger.Manager(logger.Global()).ConfigureFromFlags(LoggingOpts...)
 	} else {
 		opts := []vlog.LoggingOpts{

--- a/x/ref/runtime/factories/library/library.go
+++ b/x/ref/runtime/factories/library/library.go
@@ -168,6 +168,9 @@ func EnableFlags(fs *flag.FlagSet, parse bool) error {
 func configureLogging() error {
 	var err error
 	if ConfigureLoggingFromFlags {
+		if !flag.Parsed() {
+			flag.Parse()
+		}
 		err = logger.Manager(logger.Global()).ConfigureFromFlags(LoggingOpts...)
 	} else {
 		opts := []vlog.LoggingOpts{

--- a/x/ref/runtime/internal/rpc/server.go
+++ b/x/ref/runtime/internal/rpc/server.go
@@ -384,7 +384,7 @@ func (s *server) listen(ctx *context.T, listenSpec rpc.ListenSpec) {
 		if len(addr.Address) > 0 {
 			ch, err := s.flowMgr.Listen(ctx, addr.Protocol, addr.Address)
 			if err != nil {
-				s.ctx.VI(1).Infof("Listen(%q, %q, ...) failed: %v", addr.Protocol, addr.Address, err)
+				s.ctx.Infof("Listen(%q, %q, ...) failed: %v", addr.Protocol, addr.Address, err)
 			}
 			s.active.Add(1)
 			go s.relisten(lctx, addr.Protocol, addr.Address, ch, err)
@@ -423,7 +423,7 @@ func (s *server) relisten(ctx *context.T, protocol, address string, ch <-chan st
 			}
 		}
 		if ch, err = s.flowMgr.Listen(ctx, protocol, address); err != nil {
-			s.ctx.VI(1).Infof("Listen(%q, %q, ...) failed: %v", protocol, address, err)
+			s.ctx.Infof("Listen(%q, %q, ...) failed: %v", protocol, address, err)
 		}
 	}
 }


### PR DESCRIPTION
The previous code required --v=1 or greater on the command line before it would display errors about an attempt to bind an in-use port. This revision changes that to always display the error.