### PR TITLE
x/runtime/factories/library: ensure flags are parsed before use

### DIFF
--- a/x/ref/runtime/factories/library/library.go
+++ b/x/ref/runtime/factories/library/library.go
@@ -168,6 +168,10 @@ func EnableFlags(fs *flag.FlagSet, parse bool) error {
 func configureLogging() error {
 	var err error
 	if ConfigureLoggingFromFlags {
+		// Ensure that command line flags are parsed before they are used.
+		if !flag.Parsed() {
+			flag.Parse()
+		}
 		err = logger.Manager(logger.Global()).ConfigureFromFlags(LoggingOpts...)
 	} else {
 		opts := []vlog.LoggingOpts{


### PR DESCRIPTION
Ensure that command line flags on the flag.CommandLine flagset are parsed before they are actually used.