### PR TITLE
v.io/x/ref/runtime: warn the user if command line permissions are not used

### DIFF
--- a/v23/model.go
+++ b/v23/model.go
@@ -298,7 +298,7 @@ func WithNewServer(ctx *context.T, name string, object interface{}, auth securit
 }
 
 // WithNewDispatchingServer creates a new flow.Manager instance and attaches it
-// to ctx, and creates a new 'dispatching' server on that flow.Manager.
+// to ctx, and creates a new dispatching server on that flow.Manager.
 func WithNewDispatchingServer(ctx *context.T, name string, disp rpc.Dispatcher, opts ...rpc.ServerOpt) (*context.T, rpc.Server, error) {
 	return initState.currentRuntime().WithNewDispatchingServer(ctx, name, disp, opts...)
 }

--- a/v23/model.go
+++ b/v23/model.go
@@ -298,7 +298,7 @@ func WithNewServer(ctx *context.T, name string, object interface{}, auth securit
 }
 
 // WithNewDispatchingServer creates a new flow.Manager instance and attaches it
-// to ctx, and creates a new server on that flow.Manager.
+// to ctx, and creates a new 'dispatching' server on that flow.Manager.
 func WithNewDispatchingServer(ctx *context.T, name string, disp rpc.Dispatcher, opts ...rpc.ServerOpt) (*context.T, rpc.Server, error) {
 	return initState.currentRuntime().WithNewDispatchingServer(ctx, name, disp, opts...)
 }

--- a/v23/security/access/authorizer.go
+++ b/v23/security/access/authorizer.go
@@ -115,9 +115,9 @@ func PermissionsAuthorizerFromFile(filename string, tagType *vdl.Type) (security
 // PermissionsSpec represents a specification for permissions derived
 // from command line flags or some other means.
 type PermissionsSpec struct {
-	// Specified is true if any part of the specification was obtained
+	// ExplicitlySpecified is true if any part of the specification was obtained
 	// from an explicitly specified command line flag.
-	Specified bool
+	ExplicitlySpecified bool
 	// Files represents a set of named files that contain permissions.
 	// The name 'runtime' is reserved for use by the runtime.
 	Files map[string]string
@@ -131,7 +131,7 @@ func (ps *PermissionsSpec) Copy() PermissionsSpec {
 	for k, v := range ps.Files {
 		files[k] = v
 	}
-	return PermissionsSpec{ps.Specified, files, ps.Literal}
+	return PermissionsSpec{ps.ExplicitlySpecified, files, ps.Literal}
 }
 
 // AuthorizerFromSpec creates an authorizer as specified by the

--- a/x/ref/examples/echo/echod/echod.go
+++ b/x/ref/examples/echo/echod/echod.go
@@ -17,6 +17,7 @@ import (
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/x/ref/examples/echo"
+	"v.io/x/ref/lib/security/securityflag"
 	"v.io/x/ref/lib/signals"
 	_ "v.io/x/ref/runtime/factories/static"
 )
@@ -40,7 +41,7 @@ func (e *echod) Echo(ctx *context.T, call rpc.ServerCall, msg string) (response 
 func main() {
 	ctx, shutdown := v23.Init()
 	defer shutdown()
-	ctx, server, err := v23.WithNewServer(ctx, nameFlag, echo.EchoServiceServer(&echod{}), nil) //securityflag.NewAuthorizerOrDie(ctx))
+	ctx, server, err := v23.WithNewServer(ctx, nameFlag, echo.EchoServiceServer(&echod{}), securityflag.NewAuthorizerOrDie(ctx))
 	if err != nil {
 		ctx.Fatalf("Failure creating server: %v", err)
 	}

--- a/x/ref/examples/echo/echod/echod.go
+++ b/x/ref/examples/echo/echod/echod.go
@@ -17,7 +17,6 @@ import (
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/x/ref/examples/echo"
-	"v.io/x/ref/lib/security/securityflag"
 	"v.io/x/ref/lib/signals"
 	_ "v.io/x/ref/runtime/factories/static"
 )
@@ -41,7 +40,7 @@ func (e *echod) Echo(ctx *context.T, call rpc.ServerCall, msg string) (response 
 func main() {
 	ctx, shutdown := v23.Init()
 	defer shutdown()
-	ctx, server, err := v23.WithNewServer(ctx, nameFlag, echo.EchoServiceServer(&echod{}), securityflag.NewAuthorizerOrDie(ctx))
+	ctx, server, err := v23.WithNewServer(ctx, nameFlag, echo.EchoServiceServer(&echod{}), nil) //securityflag.NewAuthorizerOrDie(ctx))
 	if err != nil {
 		ctx.Fatalf("Failure creating server: %v", err)
 	}

--- a/x/ref/examples/echo/echod/echod.go
+++ b/x/ref/examples/echo/echod/echod.go
@@ -16,8 +16,8 @@ import (
 	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
-	"v.io/v23/security/access"
 	"v.io/x/ref/examples/echo"
+	"v.io/x/ref/lib/security/securityflag"
 	"v.io/x/ref/lib/signals"
 	_ "v.io/x/ref/runtime/factories/static"
 )
@@ -41,7 +41,7 @@ func (e *echod) Echo(ctx *context.T, call rpc.ServerCall, msg string) (response 
 func main() {
 	ctx, shutdown := v23.Init()
 	defer shutdown()
-	ctx, server, err := v23.WithNewServer(ctx, nameFlag, echo.EchoServiceServer(&echod{}), access.RuntimeAuthorizer(v23.GetPermissionsSpec(ctx)))
+	ctx, server, err := v23.WithNewServer(ctx, nameFlag, echo.EchoServiceServer(&echod{}), securityflag.NewAuthorizerOrDie(ctx))
 	if err != nil {
 		ctx.Fatalf("Failure creating server: %v", err)
 	}

--- a/x/ref/lib/flags/flags_test.go
+++ b/x/ref/lib/flags/flags_test.go
@@ -96,6 +96,24 @@ func TestPermissionsLiteralBoth(t *testing.T) {
 	if got, want := permsf.PermissionsLiteral(), `{"x":"hedgehog"}`; got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
+
+	for _, tc := range []struct {
+		args []string
+		set  bool
+	}{
+		{[]string{""}, false},
+		{[]string{"--v23.permissions.file=runtime:foo.json", `--v23.permissions.literal={"x":"hedgehog"}`}, true},
+		{[]string{"--v23.permissions.file=runtime:foo.json"}, true},
+		{[]string{`--v23.permissions.literal={"x":"hedgehog"}`}, true},
+	} {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fl := flags.CreateAndRegister(fs, flags.Runtime, flags.Permissions)
+		fl.Parse(tc.args, nil)
+		permsf = fl.PermissionsFlags()
+		if got, want := permsf.Specified(), tc.set; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	}
 }
 
 func TestFlagError(t *testing.T) {

--- a/x/ref/lib/flags/flags_test.go
+++ b/x/ref/lib/flags/flags_test.go
@@ -110,7 +110,7 @@ func TestPermissionsLiteralBoth(t *testing.T) {
 		fl := flags.CreateAndRegister(fs, flags.Runtime, flags.Permissions)
 		fl.Parse(tc.args, nil)
 		permsf = fl.PermissionsFlags()
-		if got, want := permsf.Specified(), tc.set; got != want {
+		if got, want := permsf.ExplicitlySpecified(), tc.set; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 	}

--- a/x/ref/lib/flags/permissions.go
+++ b/x/ref/lib/flags/permissions.go
@@ -104,3 +104,9 @@ func (af PermissionsFlags) AddPermissionsFile(arg string) error {
 func (af PermissionsFlags) AddPermissionsLiteral(arg string) error {
 	return af.Literal.Set(arg)
 }
+
+// Specified returns true if either of the permissions flags was
+// explicitly set on the command line.
+func (af PermissionsFlags) Specified() bool {
+	return af.Files.isSet || af.Literal.isSet
+}

--- a/x/ref/lib/flags/permissions.go
+++ b/x/ref/lib/flags/permissions.go
@@ -105,8 +105,8 @@ func (af PermissionsFlags) AddPermissionsLiteral(arg string) error {
 	return af.Literal.Set(arg)
 }
 
-// Specified returns true if either of the permissions flags was
+// ExplicitlySpecified returns true if either of the permissions flags was
 // explicitly set on the command line.
-func (af PermissionsFlags) Specified() bool {
+func (af PermissionsFlags) ExplicitlySpecified() bool {
 	return af.Files.isSet || af.Literal.isSet
 }

--- a/x/ref/lib/security/securityflag/flag.go
+++ b/x/ref/lib/security/securityflag/flag.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"os"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/x/lib/vlog"
 
 	"v.io/v23/context"
@@ -18,21 +18,16 @@ import (
 	"v.io/v23/security/access"
 )
 
-// NewAuthorizerOrDie is provided for backward compatibility except that
-// it must be called with a context.T. Use access.NewAuthorizer or
-// access.RuntimeAuthorizer in future.
+// NewAuthorizerOrDie returns an authorizer configured in the same way
+// as that for 'runtime', preferring a literal (ie. on the command line)
+// vs a file based specification, and assuming the typical set of access tags.
+// It will panic if it fails to create an authorizer.
 func NewAuthorizerOrDie(ctx *context.T) security.Authorizer {
 	auth, err := NewAuthorizer(ctx, "")
 	if err != nil {
 		vlog.Fatalf("%v", err)
 	}
 	return auth
-}
-
-// PermissionsFromFlag is provided for backward compatibility except that
-// it must be called with a context.T. Use PermissionsFromSpec in future.
-func PermissionsFromFlag(ctx *context.T) (access.Permissions, error) {
-	return PermissionsFromSpec(v23.GetPermissionsSpec(ctx), "")
 }
 
 // NewAuthorizer constructs an Authorizer based on the PermissionsSpec stored

--- a/x/ref/runtime/factories/generic/generic.go
+++ b/x/ref/runtime/factories/generic/generic.go
@@ -22,6 +22,7 @@ func init() {
 	library.CloudVM = false
 	library.ReservedNameDispatcher = false
 	library.ConfigureLoggingFromFlags = true
+	library.ConfigurePermissionsFromFlags = true
 	library.AllowMultipleInitializations = true
 	flow.RegisterUnknownProtocol("wsh", websocket.WSH{})
 	flags.SetDefaultHostPort(":0")

--- a/x/ref/runtime/factories/library/library.go
+++ b/x/ref/runtime/factories/library/library.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/flow"
 	"v.io/v23/rpc"
@@ -92,6 +92,15 @@ var (
 	// are used instead.
 	ConfigureLoggingFromFlags = false
 
+	// PermissionsSpec specifues the permissions to be stored in the context
+	// and thus used by default.
+	PermissionsSpec access.PermissionsSpec
+
+	// ConfigurePermissionsFromFlags controls whether the permissions
+	// related variable above is used for configuring permissions, or if
+	// command line flags are used instead.
+	ConfigurePermissionsFromFlags = false
+
 	// AllowMultipleInitializations controls whether the runtime can
 	// be initialized multiple times. The shutdown callback must be called
 	// between multiple initializations.
@@ -145,6 +154,17 @@ func init() {
 	flow.RegisterUnknownProtocol("wsh", websocket.WSH{})
 }
 
+func configuredFlags() []flags.FlagGroup {
+	if !ConfigurePermissionsFromFlags {
+		return []flags.FlagGroup{flags.Runtime, flags.Listen}
+	}
+	return []flags.FlagGroup{
+		flags.Runtime,
+		flags.Listen,
+		flags.Permissions,
+	}
+}
+
 // EnableCommandlineFlags enables use of command line flags.
 func EnableCommandlineFlags() {
 	EnableFlags(flag.CommandLine, false)
@@ -155,7 +175,7 @@ func EnableCommandlineFlags() {
 // parsing by the caller if need be. It will optionally parse the newly
 // created and registered flags.
 func EnableFlags(fs *flag.FlagSet, parse bool) error {
-	flagSet = flags.CreateAndRegister(fs, flags.Runtime, flags.Listen, flags.Permissions)
+	flagSet = flags.CreateAndRegister(fs, configuredFlags()...)
 	if parse {
 		if err := internal.ParseFlagsIncV23Env(flagSet); err != nil {
 			return err
@@ -215,8 +235,7 @@ func Init(ctx *context.T) (v23.Runtime, *context.T, v23.Shutdown, error) {
 	previousFlagSet := flagSet
 	if flagSet == nil {
 		dummy := &flag.FlagSet{}
-		flagSet = flags.CreateAndRegister(dummy,
-			flags.Runtime, flags.Listen, flags.Permissions)
+		flagSet = flags.CreateAndRegister(dummy, configuredFlags()...)
 	} else {
 		rtParsed := state.getParsingState()
 		if !rtParsed {
@@ -232,11 +251,14 @@ func Init(ctx *context.T) (v23.Runtime, *context.T, v23.Shutdown, error) {
 
 	runtimeFlags := flagSet.RuntimeFlags()
 	listenFlags := flagSet.ListenFlags()
-	permissionsFlags := flagSet.PermissionsFlags()
 
-	permissionsSpec := access.PermissionsSpec{
-		Files:   permissionsFlags.PermissionsNamesAndFiles(),
-		Literal: permissionsFlags.PermissionsLiteral(),
+	if ConfigurePermissionsFromFlags {
+		permissionsFlags := flagSet.PermissionsFlags()
+		PermissionsSpec = access.PermissionsSpec{
+			Specified: permissionsFlags.Specified(),
+			Files:     permissionsFlags.PermissionsNamesAndFiles(),
+			Literal:   permissionsFlags.PermissionsLiteral(),
+		}
 	}
 
 	ishutdown := func(sf ...func()) {
@@ -272,7 +294,7 @@ func Init(ctx *context.T) (v23.Runtime, *context.T, v23.Shutdown, error) {
 	var reservedDispatcher rpc.Dispatcher
 	if ReservedNameDispatcher {
 		authorizer, err := access.AuthorizerFromSpec(
-			permissionsSpec, "runtime", access.TypicalTagType())
+			PermissionsSpec, "runtime", access.TypicalTagType())
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -293,7 +315,7 @@ func Init(ctx *context.T) (v23.Runtime, *context.T, v23.Shutdown, error) {
 		publisher,
 		runtimeFlags,
 		reservedDispatcher,
-		permissionsSpec,
+		&PermissionsSpec,
 		ConnectionExpiryDuration)
 	if err != nil {
 		ishutdown(ac.Shutdown, cancelCloud, discoveryFactory.Shutdown)

--- a/x/ref/runtime/factories/library/library.go
+++ b/x/ref/runtime/factories/library/library.go
@@ -92,7 +92,7 @@ var (
 	// are used instead.
 	ConfigureLoggingFromFlags = false
 
-	// PermissionsSpec specifues the permissions to be stored in the context
+	// PermissionsSpec specifies the permissions to be stored in the context
 	// and thus used by default.
 	PermissionsSpec access.PermissionsSpec
 
@@ -255,9 +255,9 @@ func Init(ctx *context.T) (v23.Runtime, *context.T, v23.Shutdown, error) {
 	if ConfigurePermissionsFromFlags {
 		permissionsFlags := flagSet.PermissionsFlags()
 		PermissionsSpec = access.PermissionsSpec{
-			Specified: permissionsFlags.Specified(),
-			Files:     permissionsFlags.PermissionsNamesAndFiles(),
-			Literal:   permissionsFlags.PermissionsLiteral(),
+			ExplicitlySpecified: permissionsFlags.ExplicitlySpecified(),
+			Files:               permissionsFlags.PermissionsNamesAndFiles(),
+			Literal:             permissionsFlags.PermissionsLiteral(),
 		}
 	}
 

--- a/x/ref/runtime/factories/library/library_test.go
+++ b/x/ref/runtime/factories/library/library_test.go
@@ -9,7 +9,7 @@ import (
 
 	"v.io/x/ref/lib/flags"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/v23/security/access"
@@ -45,13 +45,14 @@ func TestStatic(t *testing.T) {
 	}
 }
 
-func TestDefaults(t *testing.T) {
+func TestCommandLineFlagDefaults(t *testing.T) {
 	old_protocol := flags.DefaultProtocol()
 	old_hostport := flags.DefaultHostPort()
 	old_proxy := flags.DefaultProxy()
 	old_roots := flags.DefaultNamespaceRootsNoEnv()
 	old_perms := flags.DefaultPermissions()
 	old_literal := flags.DefaultPermissionsLiteral()
+	old_permspec := library.ConfigurePermissionsFromFlags
 	defer func() {
 		flags.SetDefaultProtocol(old_protocol)
 		flags.SetDefaultHostPort(old_hostport)
@@ -61,6 +62,7 @@ func TestDefaults(t *testing.T) {
 		for k, v := range old_perms {
 			flags.SetDefaultPermissions(k, v)
 		}
+		library.ConfigurePermissionsFromFlags = old_permspec
 	}()
 	flags.SetDefaultProtocol("tcp6")
 	flags.SetDefaultHostPort("127.0.0.2:9999")
@@ -69,6 +71,7 @@ func TestDefaults(t *testing.T) {
 	flags.SetDefaultPermissions("a", "b")
 	flags.SetDefaultPermissions("c", "d")
 	flags.SetDefaultPermissionsLiteral("{ohmy}")
+	library.ConfigurePermissionsFromFlags = true
 
 	ctx, shutdown := v23.Init()
 	defer shutdown()

--- a/x/ref/runtime/factories/roaming/roaming.go
+++ b/x/ref/runtime/factories/roaming/roaming.go
@@ -31,6 +31,7 @@ import (
 func init() {
 	library.CloudVM = true
 	library.ConfigureLoggingFromFlags = true
+	library.ConfigurePermissionsFromFlags = true
 	library.ReservedNameDispatcher = true
 	flow.RegisterUnknownProtocol("wsh", websocket.WSH{})
 	library.EnableCommandlineFlags()

--- a/x/ref/runtime/factories/static/static.go
+++ b/x/ref/runtime/factories/static/static.go
@@ -25,6 +25,7 @@ func init() {
 	library.Roam = false
 	library.CloudVM = true
 	library.ConfigureLoggingFromFlags = true
+	library.ConfigurePermissionsFromFlags = true
 	library.ReservedNameDispatcher = true
 	flow.RegisterUnknownProtocol("wsh", websocket.WSH{})
 	library.EnableCommandlineFlags()

--- a/x/ref/runtime/internal/rpc/benchmark/benchmarkd/main.go
+++ b/x/ref/runtime/internal/rpc/benchmark/benchmarkd/main.go
@@ -9,11 +9,11 @@ package main
 
 import (
 	"v.io/x/lib/cmdline"
+	"v.io/x/ref/lib/security/securityflag"
 
 	"v.io/v23/context"
-	"v.io/v23/security/access"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/x/ref/lib/signals"
 	"v.io/x/ref/lib/v23cmd"
 	_ "v.io/x/ref/runtime/factories/roaming"
@@ -37,7 +37,7 @@ func runBenchmarkD(ctx *context.T, env *cmdline.Env, args []string) error {
 		ctx,
 		"",
 		internal.NewService(),
-		access.RuntimeAuthorizer(v23.GetPermissionsSpec(ctx)),
+		securityflag.NewAuthorizerOrDie(ctx),
 	)
 	if err != nil {
 		ctx.Fatalf("NewServer failed: %v", err)

--- a/x/ref/runtime/internal/rpc/resolve_test.go
+++ b/x/ref/runtime/internal/rpc/resolve_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/rpc"
@@ -49,7 +49,7 @@ func setupRuntime() {
 		nil,
 		commonFlags.RuntimeFlags(),
 		nil,
-		access.PermissionsSpec{},
+		&access.PermissionsSpec{},
 		0)
 	if err != nil {
 		panic(err)

--- a/x/ref/runtime/internal/rt/runtime.go
+++ b/x/ref/runtime/internal/rt/runtime.go
@@ -478,8 +478,10 @@ func (r *Runtime) commonServerInit(ctx *context.T, opts ...rpc.ServerOpt) (*pubs
 	return id.settingsPublisher, otherOpts, nil
 }
 
+// NOTE that this check may be defeated if the access package is changed
+// to accept different flags to the current permissions one.
 func (r *Runtime) warnIfPermissionsFlagsIgnored(ctx *context.T, auth security.Authorizer) {
-	if r.GetPermissionsSpec(ctx).Specified {
+	if r.GetPermissionsSpec(ctx).ExplicitlySpecified {
 		if auth == nil || reflect.TypeOf(auth).Elem().PkgPath() != "v.io/v23/security/access" {
 			ctx.Infof("WithNewServer using an authorizer that is not using access permissions specified on the command line")
 		}

--- a/x/ref/runtime/internal/rt/runtime.go
+++ b/x/ref/runtime/internal/rt/runtime.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -16,7 +17,7 @@ import (
 
 	"v.io/x/lib/metadata"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/discovery"
 	"v.io/v23/flow"
@@ -52,6 +53,7 @@ const (
 	backgroundKey
 	reservedNameKey
 	listenKey
+	permissionSpecKey
 
 	// initKey is used to store values that are only set at init time.
 	initKey
@@ -74,7 +76,6 @@ type initData struct {
 	protocols         []string
 	settingsPublisher *pubsub.Publisher
 	connIdleExpiry    time.Duration
-	permissionsSpec   access.PermissionsSpec
 }
 
 type vtraceDependency struct{}
@@ -97,7 +98,7 @@ func Init(
 	settingsPublisher *pubsub.Publisher,
 	flags flags.RuntimeFlags,
 	reservedDispatcher rpc.Dispatcher,
-	permissionsSpec access.PermissionsSpec,
+	permissionsSpec *access.PermissionsSpec,
 	connIdleExpiry time.Duration) (*Runtime, *context.T, v23.Shutdown, error) {
 	r := &Runtime{deps: dependency.NewGraph()}
 
@@ -108,7 +109,6 @@ func Init(
 		protocols:         protocols,
 		settingsPublisher: settingsPublisher,
 		connIdleExpiry:    connIdleExpiry,
-		permissionsSpec:   permissionsSpec,
 	})
 
 	if listenSpec != nil {
@@ -117,6 +117,10 @@ func Init(
 
 	if reservedDispatcher != nil {
 		ctx = context.WithValue(ctx, reservedNameKey, reservedDispatcher)
+	}
+
+	if permissionsSpec != nil {
+		ctx = context.WithValue(ctx, permissionSpecKey, permissionsSpec.Copy())
 	}
 
 	// Configure the context to use the global logger.
@@ -397,21 +401,10 @@ func (*Runtime) WithListenSpec(ctx *context.T, ls rpc.ListenSpec) *context.T {
 	return context.WithValue(ctx, listenKey, ls.Copy())
 }
 
-func copyFiles(old map[string]string) map[string]string {
-	r := make(map[string]string, len(old))
-	for k, v := range old {
-		r[k] = v
-	}
-	return r
-}
-
 func (*Runtime) GetPermissionsSpec(ctx *context.T) access.PermissionsSpec {
 	// nologcall
-	id, _ := ctx.Value(initKey).(*initData)
-	return access.PermissionsSpec{
-		Literal: id.permissionsSpec.Literal,
-		Files:   copyFiles(id.permissionsSpec.Files),
-	}
+	ps, _ := ctx.Value(permissionSpecKey).(access.PermissionsSpec)
+	return ps
 }
 
 func (*Runtime) WithBackgroundContext(ctx *context.T) *context.T {
@@ -485,12 +478,21 @@ func (r *Runtime) commonServerInit(ctx *context.T, opts ...rpc.ServerOpt) (*pubs
 	return id.settingsPublisher, otherOpts, nil
 }
 
+func (r *Runtime) warnIfPermissionsFlagsIgnored(ctx *context.T, auth security.Authorizer) {
+	if r.GetPermissionsSpec(ctx).Specified {
+		if auth == nil || reflect.TypeOf(auth).Elem().PkgPath() != "v.io/v23/security/access" {
+			ctx.Infof("WithNewServer using an authorizer that is not using access permissions specified on the command line")
+		}
+	}
+}
+
 func (r *Runtime) WithNewServer(ctx *context.T, name string, object interface{}, auth security.Authorizer, opts ...rpc.ServerOpt) (*context.T, rpc.Server, error) {
 	defer apilog.LogCall(ctx)(ctx) // gologcop: DO NOT EDIT, MUST BE FIRST STATEMENT
 	spub, opts, err := r.commonServerInit(ctx, opts...)
 	if err != nil {
 		return ctx, nil, err
 	}
+	r.warnIfPermissionsFlagsIgnored(ctx, auth)
 	newctx, s, err := irpc.WithNewServer(ctx, name, object, auth, spub, opts...)
 	if err != nil {
 		return ctx, nil, err


### PR DESCRIPTION
warn the user if permissions are configured on the command line but not used by an authorizer. The warning could be spurious if multiple servers are created, one of which uses the permissions, but the others don't etc. However, this does cover the vast majority of common use cases.