### PR TITLE
context.WithRootCancel: fix interaction w/ FromGoContext

### DIFF
--- a/x/ref/lib/flags/sitedefaults/go.mod
+++ b/x/ref/lib/flags/sitedefaults/go.mod
@@ -1,1 +1,3 @@
 module v.io/x/ref/lib/flags/sitedefaults
+
+go 1.12


### PR DESCRIPTION
Fix a bug calling WithRootCancel w/ a context created by FromGoContext will
cause the cancellation handler to be attached to FromGoContext context, not the
root one.

The problem is that WithRootCancel walks up the "parent" link to find the root.
But this chain breaks at FromGoContext. So it mistakesly assumes that the
FromGoContext context is the root.

This change fixes the problem by explicitly storing the pointer to root
cancelState in a context value.