### PR TITLE
v.io/x/ref/cmd/vdl: fix test

### DIFF
--- a/x/ref/cmd/vdl/vdl_test.go
+++ b/x/ref/cmd/vdl/vdl_test.go
@@ -78,7 +78,7 @@ func TestVDLGeneratorBuiltInVDLRoot(t *testing.T) {
 	env := envvar.SliceToMap(os.Environ())
 	delete(env, "JIRI_ROOT")
 	delete(env, "VDLROOT")
-	cmd := sh.Cmd(vdlBin, "-v", "generate", "--lang=go", outOpt, testDir)
+	cmd := sh.Cmd(vdlBin, "generate", "-v", "--lang=go", outOpt, testDir)
 	cmd.Vars = env
 	cmd.Run()
 	verifyOutput(t, outDir)


### PR DESCRIPTION
This fixes a unit test that breaks with go 1.12.5. I'm not sure why it worked before though. The correct usage is: `vdl generate -v ...` and not `vdl -v generate`, or `vdl -v=2 generate -v=true`.