### PR TITLE
go1.14 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 language: go
 go:
-- 1.12.5
+- 1.14
 go_import_path: v.io
 env:
   matrix:

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,12 @@
 SHELL := /bin/bash -euo pipefail
 
-GOPATH ?= $(shell pwd)
-export GOPATH
-
-VDLPATH ?= $(shell pwd)/src
+VDLPATH ?= $(shell pwd)
 export VDLPATH
 vdlgen:
 	go run v.io/x/ref/cmd/vdl generate --lang=go v.io/...	
 
 .PHONY: test-integration
 test-integration:
-	@echo "GOPATH" ${GOPATH}
 	@echo "VDLPATH" ${VDLPATH}
 	go test -tags travis \
 		v.io/x/ref/cmd/principal \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module v.io
 
-go 1.13.1
+go 1.13
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3
@@ -17,6 +17,7 @@ require (
 	github.com/shirou/gopsutil v2.19.9+incompatible
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/vanadium/go-mdns-sd v0.0.0-20181006014439-f1a1ccd1252e
+	golang.org/dl v0.0.0-20200225205303-b5f8f1376514 // indirect
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v2.19.9+incompatible h1:IrPVlK4nfwW10DF7pW+7YJKws9NkgNzWozwwWv9FsgY=
 github.com/shirou/gopsutil v2.19.9+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -68,6 +69,8 @@ github.com/vanadium/go-mdns-sd v0.0.0-20181006014439-f1a1ccd1252e h1:pHSeCN6iUoI
 github.com/vanadium/go-mdns-sd v0.0.0-20181006014439-f1a1ccd1252e/go.mod h1:35fXDjvKtzyf89fHHhyTTNLHaG2CkI7u/GvO59PIjP4=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
+golang.org/dl v0.0.0-20200225205303-b5f8f1376514 h1:tW1jGn959NJjjNqeqztQ1Aq8ojzSg6M0j0TCAnIK/F4=
+golang.org/dl v0.0.0-20200225205303-b5f8f1376514/go.mod h1:IUMfjQLJQd4UTqG1Z90tenwKoCX93Gn3MAQJMOSBsDQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 h1:Gv7RPwsi3eZ2Fgewe3CBsuOebPwO27PoXzRpJPsvSSM=
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/x/ref/cmd/vdl/doc.go
+++ b/x/ref/cmd/vdl/doc.go
@@ -325,7 +325,9 @@ explicitly.
 VDLPATH requires *.vdl source files and packages to appear directly under the
 VDLPATH directories. Note that when go modules are used VDLPATH should point to
 the location of the go.mod file. Also note that whereas GOPATH requires *.go
-source files and packages to appear under a "src" directory,
+source files and packages to appear under a "src" directory, VDLPATH requires
+*.vdl source files and packages to appear directly under the VDLPATH
+directories.
 
  Run "vdl help vdlpath" to see docs on VDLPATH.
  Run "go help packages" to see the standard go package docs.

--- a/x/ref/cmd/vdl/doc.go
+++ b/x/ref/cmd/vdl/doc.go
@@ -36,12 +36,34 @@ The vdl flags are:
    Basename of the optional per-package config file.
 
 The global flags are:
+ -alsologtostderr=true
+   log to standard error as well as files
+ -log_backtrace_at=:0
+   when logging hits line file:N, emit a stack trace
+ -log_dir=
+   if non-empty, write log files to this directory
+ -logtostderr=false
+   log to standard error instead of files
+ -max_stack_buf_size=4292608
+   max size in bytes of the buffer to use for logging stack traces
  -metadata=<just specify -metadata to activate>
    Displays metadata for the program and exits.
  -skip-go-methods=false
    Skip go generation of VDL{Read,Write,Zero} methods.
+ -stderrthreshold=2
+   logs at or above this threshold go to stderr
  -time=false
    Dump timing information to stderr before exiting the program.
+ -v=0
+   log level for V logs
+ -vmodule=
+   comma-separated list of globpattern=N settings for filename-filtered logging
+   (without the .go suffix).  E.g. foo/bar/baz.go is matched by patterns baz or
+   *az or b* but not by bar/baz or baz.go or az or b.*
+ -vpath=
+   comma-separated list of regexppattern=N settings for file pathname-filtered
+   logging (without the .go suffix).  E.g. foo/bar/baz.go is matched by patterns
+   foo/bar/baz or fo.*az or oo/ba or b.z but not by foo/bar/baz.go or fo*az
 
 Vdl generate - Compile packages and dependencies, and generate code
 
@@ -300,9 +322,10 @@ Import path elements and file names are not allowed to begin with "." or "_";
 such paths are ignored in wildcard matches, and return errors if specified
 explicitly.
 
-Note that whereas GOPATH requires *.go source files and packages to appear under
-a "src" directory, VDLPATH requires *.vdl source files and packages to appear
-directly under the VDLPATH directories.
+VDLPATH requires *.vdl source files and packages to appear directly under the
+VDLPATH directories. Note that when go modules are used VDLPATH should point to
+the location of the go.mod file. Also note that whereas GOPATH requires *.go
+source files and packages to appear under a "src" directory,
 
  Run "vdl help vdlpath" to see docs on VDLPATH.
  Run "go help packages" to see the standard go package docs.

--- a/x/ref/cmd/vdl/main.go
+++ b/x/ref/cmd/vdl/main.go
@@ -676,10 +676,9 @@ func handleErrorOrSkip(prefix string, err error, env *compile.Env) bool {
 
 var errSkip = fmt.Errorf("SKIP")
 
-// handle the case where go modules are used the directory structure
+// Handle the case where go modules are used the directory structure
 // on the local filesystem omits the portion of the package path
 // represented by the module definition in the go.mod file.
-// TODO(cnicolaou): move to vdl/build.
 func goModulePath(dir, path, outPkgPath string) (string, error) {
 	prefix, module, suffix := build.PackagePathSplit(dir, path)
 	if len(suffix) == 0 {

--- a/x/ref/cmd/vdl/main.go
+++ b/x/ref/cmd/vdl/main.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // The following enables go generate to generate the doc.go file.
-//go:generate gendoc .
+//go:generate go run v.io/x/lib/cmdline/gendoc .
 
 package main
 
@@ -101,9 +101,12 @@ Import path elements and file names are not allowed to begin with "." or "_";
 such paths are ignored in wildcard matches, and return errors if specified
 explicitly.
 
-Note that whereas GOPATH requires *.go source files and packages to appear
-under a "src" directory, VDLPATH requires *.vdl source files and packages to
-appear directly under the VDLPATH directories.
+
+
+VDLPATH requires *.vdl source files and packages to appear directly under the
+VDLPATH directories. Note that when go modules are used VDLPATH should point
+to the location of the go.mod file. Also note that whereas GOPATH requires
+*.go source files and packages to appear under a "src" directory,
 
  Run "vdl help vdlpath" to see docs on VDLPATH.
  Run "go help packages" to see the standard go package docs.
@@ -676,9 +679,11 @@ func handleErrorOrSkip(prefix string, err error, env *compile.Env) bool {
 
 var errSkip = fmt.Errorf("SKIP")
 
-// Handle the case where go modules are used the directory structure
-// on the local filesystem omits the portion of the package path
-// represented by the module definition in the go.mod file.
+// Handle the case where go modules are used and the directory structure
+// on the local filesystem omits the portion of the package path represented
+// by the module definition in the go.mod file. For vanadium, the code is
+// hosted as github.com/vanadium/core/... but the go.mod defines the packages
+// as v.io/... with the v.io portion not appearing in the local filesystem.
 func goModulePath(dir, path, outPkgPath string) (string, error) {
 	prefix, module, suffix := build.PackagePathSplit(dir, path)
 	if len(suffix) == 0 {

--- a/x/ref/cmd/vdl/main.go
+++ b/x/ref/cmd/vdl/main.go
@@ -101,12 +101,12 @@ Import path elements and file names are not allowed to begin with "." or "_";
 such paths are ignored in wildcard matches, and return errors if specified
 explicitly.
 
-
-
 VDLPATH requires *.vdl source files and packages to appear directly under the
 VDLPATH directories. Note that when go modules are used VDLPATH should point
 to the location of the go.mod file. Also note that whereas GOPATH requires
-*.go source files and packages to appear under a "src" directory,
+*.go source files and packages to appear under a "src" directory, VDLPATH
+requires *.vdl source files and packages to appear directly under the VDLPATH
+directories.
 
  Run "vdl help vdlpath" to see docs on VDLPATH.
  Run "go help packages" to see the standard go package docs.

--- a/x/ref/cmd/vdl/main.go
+++ b/x/ref/cmd/vdl/main.go
@@ -262,13 +262,16 @@ func (gls *genLangs) Set(value string) error {
 	return nil
 }
 
-// genOutDir has three modes:
+// genOutDir has four modes.
 //   1) If dir is non-empty, we use it as the out dir.
 //   2) If rules is non-empty, we translate using the xlate rules.
-//   3) If everything is empty, we generate in-place.
+//   3) if supportGoModules is set then go module directory structure
+//      is accounted for mode 4.
+//   4) If everything is empty, we generate in-place.
 type genOutDir struct {
-	dir   string
-	rules xlateRules
+	supportGoModules bool
+	dir              string
+	rules            xlateRules
 }
 
 // xlateSrcDst specifies a translation rule, where src must match the suffix of
@@ -335,7 +338,9 @@ var (
 	// Options for each command.
 	optCompileStatus bool
 	optGenStatus     bool
-	optGenGoOutDir   = genOutDir{}
+	optGenGoOutDir   = genOutDir{
+		supportGoModules: true,
+	}
 	optGenJavaOutDir = genOutDir{
 		rules: xlateRules{
 			{"release/go/src", "release/java/lib/generated-src/vdl"},
@@ -619,10 +624,12 @@ func writeFile(audit bool, data []byte, dirName, baseName string, env *compile.E
 	if oldData, err := ioutil.ReadFile(dstName); err == nil && bytes.Equal(oldData, data) {
 		return false
 	}
+
 	// At this point we know the old file is stale.
 	if audit {
 		return true
 	}
+
 	// Create containing directory, if it doesn't already exist.
 	if err := os.MkdirAll(dirName, os.FileMode(0777)); err != nil {
 		env.Errors.Errorf("Couldn't create directory %s: %v", dirName, err)
@@ -632,6 +639,7 @@ func writeFile(audit bool, data []byte, dirName, baseName string, env *compile.E
 		env.Errors.Errorf("Couldn't write file %s: %v", dstName, err)
 		return true
 	}
+
 	// Remove rmFiles now that we've succeeded.  This is only used for a temporary
 	// transition to new go file names.  Always try to remove all of them, even if
 	// the removal of some of them fails.
@@ -668,19 +676,43 @@ func handleErrorOrSkip(prefix string, err error, env *compile.Env) bool {
 
 var errSkip = fmt.Errorf("SKIP")
 
+// handle the case where go modules are used the directory structure
+// on the local filesystem omits the portion of the package path
+// represented by the module definition in the go.mod file.
+// TODO(cnicolaou): move to vdl/build.
+func goModulePath(dir, path, outPkgPath string) (string, error) {
+	prefix, module, suffix := build.PackagePathSplit(dir, path)
+	if len(suffix) == 0 {
+		return "", fmt.Errorf("package dir %q doesn't share a common suffix with package path %q", dir, path)
+	}
+	if gomod := build.HasGoModule(prefix); len(gomod) > 0 {
+		if gomod != module {
+			return "", fmt.Errorf("package dir %q and package %q do not match go module path %q != %q", dir, path, gomod, module)
+		}
+		return filepath.Join(prefix, strings.TrimPrefix(outPkgPath, gomod)), nil
+	}
+	return filepath.Join(dir, outPkgPath), nil
+}
+
 func xlateOutDir(dir, path string, outdir genOutDir, outPkgPath string) (string, error) {
 	path = filepath.FromSlash(path)
 	outPkgPath = filepath.FromSlash(outPkgPath)
-	// Strip package path from the directory.
-	if !strings.HasSuffix(dir, path) {
-		return "", fmt.Errorf("package dir %q doesn't end with package path %q", dir, path)
+
+	if !outdir.supportGoModules {
+		// Strip package path from the directory for all non go modules uses.
+		if !strings.HasSuffix(dir, path) {
+			return "", fmt.Errorf("package dir %q doesn't end with package path %q", dir, path)
+		}
+		dir = filepath.Clean(dir[:len(dir)-len(path)])
 	}
-	dir = filepath.Clean(dir[:len(dir)-len(path)])
 
 	switch {
 	case outdir.dir != "":
 		return filepath.Join(outdir.dir, outPkgPath), nil
 	case len(outdir.rules) == 0:
+		if outdir.supportGoModules {
+			return goModulePath(dir, path, outPkgPath)
+		}
 		return filepath.Join(dir, outPkgPath), nil
 	}
 	// Try translation rules in order.
@@ -695,7 +727,7 @@ func xlateOutDir(dir, path string, outdir genOutDir, outPkgPath string) (string,
 		d = filepath.Clean(d[:len(d)-len(xlate.src)])
 		return filepath.Join(d, xlate.dst, outPkgPath), nil
 	}
-	return "", fmt.Errorf("package prefix %q doesn't match translation rules %q", dir, outdir)
+	return "", fmt.Errorf("package prefix %q doesn't match translation rules %v", dir, outdir)
 }
 
 func xlatePkgPath(pkgPath string, rules xlateRules) (string, error) {

--- a/x/ref/cmd/vdl/main.go
+++ b/x/ref/cmd/vdl/main.go
@@ -689,7 +689,7 @@ func goModulePath(dir, path, outPkgPath string) (string, error) {
 	if len(suffix) == 0 {
 		return "", fmt.Errorf("package dir %q doesn't share a common suffix with package path %q", dir, path)
 	}
-	gomod, err := build.HasGoModule(prefix)
+	gomod, err := build.GoModuleName(prefix)
 	if err != nil {
 		return "", err
 	}

--- a/x/ref/cmd/vdl/main.go
+++ b/x/ref/cmd/vdl/main.go
@@ -689,7 +689,11 @@ func goModulePath(dir, path, outPkgPath string) (string, error) {
 	if len(suffix) == 0 {
 		return "", fmt.Errorf("package dir %q doesn't share a common suffix with package path %q", dir, path)
 	}
-	if gomod := build.HasGoModule(prefix); len(gomod) > 0 {
+	gomod, err := build.HasGoModule(prefix)
+	if err != nil {
+		return "", err
+	}
+	if len(gomod) > 0 {
 		if gomod != module {
 			return "", fmt.Errorf("package dir %q and package %q do not match go module path %q != %q", dir, path, gomod, module)
 		}

--- a/x/ref/lib/vdl/build/build.go
+++ b/x/ref/lib/vdl/build/build.go
@@ -891,7 +891,7 @@ func (ds *depSorter) deducePackagePath(dir string) (string, string, error) {
 				return "", "", err
 			}
 			pkgPath := path.Clean(filepath.ToSlash(relPath))
-			// allow for go module directory structure.
+			// Allow for go module directory structure.
 			if gomod, ok := ds.goModules[srcDir]; ok {
 				pkgPath = path.Join(gomod, pkgPath)
 			}

--- a/x/ref/lib/vdl/build/build.go
+++ b/x/ref/lib/vdl/build/build.go
@@ -684,7 +684,7 @@ func (ds *depSorter) resolveWildcardPath(isDirPath bool, prefix, suffix string) 
 				// directory is within a go module and hence the matching
 				// for the vdlroot directory must take this into account.
 				for goModRoot, goModPrefix := range ds.goModules {
-					// Test for dirPath being within s go module.
+					// Test for dirPath being within a go module.
 					if subdir := strings.TrimPrefix(dirPath, goModRoot); subdir != dirPath {
 						// Test to see if the subdir would match the vdlroot import.
 						if path.Join(goModPrefix, subdir) == vdlrootImportPrefix {

--- a/x/ref/lib/vdl/build/build.go
+++ b/x/ref/lib/vdl/build/build.go
@@ -312,9 +312,8 @@ func SrcDirs(errs *vdlutil.Errors) []string {
 	return append(srcDirs, vdlPathSrcDirs(errs)...)
 }
 
-// HasGoModule returns the value of the module statement in
-// the go.mod file in the directory specified by path, or an empty
-// string otherwise.
+// HasGoModule returns the value of the module statement in the go.mod file in
+// the directory specified by path, or an empty string otherwise.
 func HasGoModule(path string) string {
 	buf, err := ioutil.ReadFile(filepath.Join(path, "go.mod"))
 	path = filepath.Dir(path)
@@ -339,12 +338,15 @@ func HasGoModule(path string) string {
 // of the original path that is not part of the common prefix. This is useful
 // for working with the directory structure commonly used by go modules.
 // For example:
+//
 // PackagePathSplit("a/b/c", "/b/c") yields "a", "", "b/c"
 // PackagePathSplit("a/b/c", "m/b/c") yields "a", "m", "b/c"
+//
 // It is intended to work on Windows, as in:
+//
 // PackagePathSplit(`a\b\c`, "m/b/c") yields "a", "m", "b/c"
 func PackagePathSplit(dir, pkgPath string) (prefix string, body string, suffix string) {
-	// Normalize dir path to use / instead of possibly using
+	// Normalize dir path to use / instead of possibly using.
 	ndir := strings.Replace(dir, filePathSeparator, packagePathSeparator, -1)
 	suffix = pkgPath
 	for {
@@ -670,7 +672,7 @@ func (ds *depSorter) resolveWildcardPath(isDirPath bool, prefix, suffix string) 
 				}
 
 				// Special case to handle go modules, where the current
-				// directory is wuthin a go module and hence the matching
+				// directory is within a go module and hence the matching
 				// for the vdlroot directory must take this into account.
 				for goModRoot, goModPrefix := range ds.goModules {
 					// Test for dirPath being within s go module.

--- a/x/ref/lib/vdl/build/build.go
+++ b/x/ref/lib/vdl/build/build.go
@@ -312,9 +312,9 @@ func SrcDirs(errs *vdlutil.Errors) []string {
 	return append(srcDirs, vdlPathSrcDirs(errs)...)
 }
 
-// HasGoModule returns the value of the module statement in the go.mod file in
+// GoModuleName returns the value of the module statement in the go.mod file in
 // the directory specified by path, or an empty string otherwise.
-func HasGoModule(path string) (string, error) {
+func GoModuleName(path string) (string, error) {
 	gomod := filepath.Join(path, "go.mod")
 	buf, err := ioutil.ReadFile(gomod)
 	path = filepath.Dir(path)
@@ -373,7 +373,7 @@ func PackagePathSplit(dir, pkgPath string) (prefix string, body string, suffix s
 func goModules(errs *vdlutil.Errors) map[string]string {
 	modPrefix := map[string]string{}
 	for _, srcDir := range SrcDirs(errs) {
-		goMod, err := HasGoModule(srcDir)
+		goMod, err := GoModuleName(srcDir)
 		if err != nil {
 			errs.Errorf("failed to read go.mod: %v", err)
 			continue

--- a/x/ref/lib/vdl/build/build.go
+++ b/x/ref/lib/vdl/build/build.go
@@ -41,6 +41,7 @@
 package build
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -311,6 +312,68 @@ func SrcDirs(errs *vdlutil.Errors) []string {
 	return append(srcDirs, vdlPathSrcDirs(errs)...)
 }
 
+// HasGoModule returns the value of the module statement in
+// the go.mod file in the directory specified by path, or an empty
+// string otherwise.
+func HasGoModule(path string) string {
+	buf, err := ioutil.ReadFile(filepath.Join(path, "go.mod"))
+	path = filepath.Dir(path)
+	if err != nil && os.IsNotExist(err) {
+		return ""
+	}
+	sc := bufio.NewScanner(bytes.NewBuffer(buf))
+	for sc.Scan() {
+		parts := strings.Fields(sc.Text())
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[0] == "module" {
+			return parts[1]
+		}
+	}
+	return ""
+}
+
+// PackagePathSplit returns the longest common suffix in dir and path,
+// the prefix in dir after the common suffix is removed and the portion of the
+// of the original path that is not part of the common prefix. This is useful
+// for working with the directory structure commonly used by go modules.
+// For example:
+// PackagePathSplit("a/b/c", "/b/c") yields "a", "", "b/c"
+// PackagePathSplit("a/b/c", "m/b/c") yields "a", "m", "b/c"
+// It is intended to work on Windows, as in:
+// PackagePathSplit(`a\b\c`, "m/b/c") yields "a", "m", "b/c"
+func PackagePathSplit(dir, pkgPath string) (prefix string, body string, suffix string) {
+	// Normalize dir path to use / instead of possibly using
+	ndir := strings.Replace(dir, filePathSeparator, packagePathSeparator, -1)
+	suffix = pkgPath
+	for {
+		idx := strings.Index(suffix, packagePathSeparator)
+		if idx < 0 {
+			break
+		}
+		if strings.HasSuffix(ndir, suffix) {
+			break
+		}
+		suffix = suffix[idx+1:]
+	}
+	prefix = strings.TrimSuffix(ndir, suffix)
+	body = strings.TrimSuffix(strings.TrimSuffix(pkgPath, suffix), packagePathSeparator)
+	prefix = strings.Replace(prefix, packagePathSeparator, filePathSeparator, -1)
+	prefix = strings.TrimSuffix(prefix, filePathSeparator)
+	return
+}
+
+func goModules(errs *vdlutil.Errors) map[string]string {
+	modPrefix := map[string]string{}
+	for _, srcDir := range SrcDirs(errs) {
+		if goMod := HasGoModule(srcDir); len(goMod) > 0 {
+			modPrefix[srcDir] = goMod
+		}
+	}
+	return modPrefix
+}
+
 // RootDir returns the VDL root directory, based on the VDLROOT environment
 // variable.
 //
@@ -394,6 +457,7 @@ type depSorter struct {
 	opts        Opts
 	rootDir     string
 	srcDirs     []string
+	goModules   map[string]string
 	builtInRoot map[string]*Package
 	pathMap     map[string]*Package
 	dirMap      map[string]*Package
@@ -404,11 +468,12 @@ type depSorter struct {
 
 func newDepSorter(opts Opts, errs *vdlutil.Errors) *depSorter {
 	ds := &depSorter{
-		opts:    opts,
-		rootDir: RootDir(errs),
-		srcDirs: SrcDirs(errs),
-		errs:    errs,
-		vdlenv:  compile.NewEnvWithErrors(errs),
+		opts:      opts,
+		rootDir:   RootDir(errs),
+		srcDirs:   SrcDirs(errs),
+		goModules: goModules(errs),
+		errs:      errs,
+		vdlenv:    compile.NewEnvWithErrors(errs),
 	}
 	ds.reset()
 	// If VDLROOT isn't set, we must initialize the builtInRoot, to allow
@@ -542,6 +607,7 @@ func (ds *depSorter) resolveWildcardPath(isDirPath bool, prefix, suffix string) 
 	type dirAndSrc struct {
 		dir, src string
 	}
+
 	var walkDirs []dirAndSrc // directories to walk through
 	var pattern string       // pattern to match against, starting after root dir
 	if isDirPath {
@@ -555,6 +621,10 @@ func (ds *depSorter) resolveWildcardPath(isDirPath bool, prefix, suffix string) 
 		pattern = filepath.Clean(pre + filepath.FromSlash(suffix))
 		dir := filepath.FromSlash(slashDir)
 		for _, srcDir := range ds.srcDirs {
+			if gomod, ok := ds.goModules[srcDir]; ok {
+				walkDirs = append(walkDirs, dirAndSrc{filepath.Join(srcDir, strings.TrimPrefix(dir, gomod)), srcDir})
+				continue
+			}
 			walkDirs = append(walkDirs, dirAndSrc{filepath.Join(srcDir, dir), srcDir})
 		}
 		// Look in our built-in vdlroot for matches against standard packages.
@@ -575,8 +645,10 @@ func (ds *depSorter) resolveWildcardPath(isDirPath bool, prefix, suffix string) 
 		ds.errorf("%v", err)
 		return false
 	}
+
 	// Walk through root dirs and subdirs, looking for matches.
 	for _, walk := range walkDirs {
+		goModule, isGoModule := ds.goModules[walk.dir]
 		filepath.Walk(walk.dir, func(dirPath string, info os.FileInfo, err error) error {
 			// Ignore errors and non-directory elements.
 			if err != nil || !info.IsDir() {
@@ -596,7 +668,22 @@ func (ds *depSorter) resolveWildcardPath(isDirPath bool, prefix, suffix string) 
 				if strings.HasPrefix(pkgPath, vdlrootImportPrefix) {
 					return filepath.SkipDir
 				}
+
+				// Special case to handle go modules, where the current
+				// directory is wuthin a go module and hence the matching
+				// for the vdlroot directory must take this into account.
+				for goModRoot, goModPrefix := range ds.goModules {
+					// Test for dirPath being within s go module.
+					if subdir := strings.TrimPrefix(dirPath, goModRoot); subdir != dirPath {
+						// Test to see if the subdir would match the vdlroot import.
+						if path.Join(goModPrefix, subdir) == vdlrootImportPrefix {
+							return filepath.SkipDir
+						}
+					}
+				}
+
 			}
+
 			// Ignore the dir if it doesn't match our pattern.  We still process the
 			// subdirs since they still might match.
 			//
@@ -604,12 +691,23 @@ func (ds *depSorter) resolveWildcardPath(isDirPath bool, prefix, suffix string) 
 			// possibly match the matcher.  E.g. given pattern "a..." we can skip
 			// the subdirs if the dir doesn't start with "a".
 			matchPath := dirPath[len(walk.dir):]
-			if strings.HasPrefix(matchPath, pathSeparator) {
-				matchPath = matchPath[len(pathSeparator):]
+			if strings.HasPrefix(matchPath, filePathSeparator) {
+				matchPath = matchPath[len(filePathSeparator):]
 			}
+
+			// Match agains the raw path, and also against one with the
+			// go module prefix prepended if go modules are in use.
 			if !matcher.MatchString(matchPath) {
-				return nil
+				if !isGoModule {
+					return nil
+				}
+				// Try prepending the missing gomodule prefix to the path
+				// and then match.
+				if !matcher.MatchString(filepath.Join(goModule, matchPath)) {
+					return nil
+				}
 			}
+
 			// Finally resolve the dir.
 			if ds.resolveDirPath(dirPath, UnknownPathIsIgnored) != nil {
 				resolvedAny = true
@@ -620,14 +718,16 @@ func (ds *depSorter) resolveWildcardPath(isDirPath bool, prefix, suffix string) 
 	return resolvedAny
 }
 
-const pathSeparator = string(filepath.Separator)
+var filePathSeparator = string(filepath.Separator)
+
+const packagePathSeparator = "/"
 
 // createMatcher creates a regexp matcher out of the file pattern.
 func createMatcher(pattern string) (*regexp.Regexp, error) {
 	rePat := regexp.QuoteMeta(pattern)
 	rePat = strings.Replace(rePat, `\.\.\.`, `.*`, -1)
 	// Add special-case so that x/... also matches x.
-	slashDotStar := regexp.QuoteMeta(pathSeparator) + ".*"
+	slashDotStar := regexp.QuoteMeta(filePathSeparator) + ".*"
 	if strings.HasSuffix(rePat, slashDotStar) {
 		rePat = rePat[:len(rePat)-len(slashDotStar)] + "(" + slashDotStar + ")?"
 	}
@@ -662,19 +762,26 @@ func (ds *depSorter) resolveDirPath(dir string, mode UnknownPathMode) *Package {
 		return nil
 	}
 	if !validPackagePath(pkgPath) {
-		mode.logOrErrorf(ds.errs, "%s: package path %q is invalid", absDir, pkgPath)
+		_, _, suffix := PackagePathSplit(absDir, pkgPath)
+		// Report the package suffix in the error to ensure that error messages
+		// are stable across both GOPATH and go module directory structures, that is,
+		// report the package path that was supplied rather than deduced.
+		mode.logOrErrorf(ds.errs, "--%s--: package path %q is invalid", absDir, suffix)
 		return nil
 	}
+
 	if pkg := ds.pathMap[pkgPath]; pkg != nil {
 		mode.logOrErrorf(ds.errs, "%s: package path %q already resolved from %s", absDir, pkgPath, pkg.Dir)
 		return nil
 	}
+
 	// Make sure the directory really exists, and add the package and deps.
 	fileInfo, err := os.Stat(absDir)
 	if err != nil {
 		mode.logOrErrorf(ds.errs, "%v", err)
 		return nil
 	}
+
 	if !fileInfo.IsDir() {
 		mode.logOrErrorf(ds.errs, "%s: package isn't a directory", absDir)
 		return nil
@@ -710,13 +817,24 @@ func (ds *depSorter) resolveImportPath(pkgPath string, mode UnknownPathMode, pre
 	}
 	// Look through srcDirs in-order until we find a valid package dir.
 	var dirs []string
-	for _, srcDir := range ds.srcDirs {
+	for _, srcDir := range append(ds.srcDirs) {
 		dir := filepath.Join(srcDir, filepath.FromSlash(pkgPath))
 		if pkg := ds.resolveDirPath(dir, UnknownPathIsIgnored); pkg != nil {
 			vdlutil.Vlog.Printf("%s: resolved import path %q", pkg.Dir, pkgPath)
 			return pkg
 		}
 		dirs = append(dirs, dir)
+
+		// Try again but as a go module.
+		if gomod, ok := ds.goModules[srcDir]; ok {
+			dir := filepath.Join(srcDir, filepath.FromSlash(strings.TrimPrefix(pkgPath, gomod)))
+			if pkg := ds.resolveDirPath(dir, UnknownPathIsIgnored); pkg != nil {
+				vdlutil.Vlog.Printf("%s: resolved import path %q using go.mod to %v", pkg.Dir, pkgPath, dir)
+				return pkg
+			}
+			dirs = append(dirs, dir)
+			return nil
+		}
 	}
 	// We can't find a valid dir corresponding to this import path.
 	detail := "   " + strings.Join(dirs, "\n   ")
@@ -773,6 +891,10 @@ func (ds *depSorter) deducePackagePath(dir string) (string, string, error) {
 				return "", "", err
 			}
 			pkgPath := path.Clean(filepath.ToSlash(relPath))
+			// allow for go module directory structure.
+			if gomod, ok := ds.goModules[srcDir]; ok {
+				pkgPath = path.Join(gomod, pkgPath)
+			}
 			genPath := pkgPath
 			if pre := vdlrootImportPrefix + "/"; strings.HasPrefix(pkgPath, pre) {
 				// The pkgPath should never include the vdlroot prefix.

--- a/x/ref/lib/vdl/build/build.go
+++ b/x/ref/lib/vdl/build/build.go
@@ -762,11 +762,7 @@ func (ds *depSorter) resolveDirPath(dir string, mode UnknownPathMode) *Package {
 		return nil
 	}
 	if !validPackagePath(pkgPath) {
-		_, _, suffix := PackagePathSplit(absDir, pkgPath)
-		// Report the package suffix in the error to ensure that error messages
-		// are stable across both GOPATH and go module directory structures, that is,
-		// report the package path that was supplied rather than deduced.
-		mode.logOrErrorf(ds.errs, "--%s--: package path %q is invalid", absDir, suffix)
+		mode.logOrErrorf(ds.errs, "%s: package path %q is invalid", absDir, pkgPath)
 		return nil
 	}
 

--- a/x/ref/lib/vdl/build/build_test.go
+++ b/x/ref/lib/vdl/build/build_test.go
@@ -645,6 +645,7 @@ func TestBuildExprs(t *testing.T) {
 }
 
 func TestPackageSplit(t *testing.T) {
+	defer build.SetFilePathSeparator(string(filepath.Separator))
 	for i, test := range []struct {
 		dir, path            string
 		prefix, body, suffix string

--- a/x/ref/lib/vdl/build/build_test.go
+++ b/x/ref/lib/vdl/build/build_test.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -674,7 +675,33 @@ func TestPackageSplit(t *testing.T) {
 			t.Errorf("(%v): got %q, want %q", i, got, want)
 		}
 		if got, want := suffix, test.suffix; got != want {
-			t.Errorf("(%v) got %q, want %q", i, got, want)
+			t.Errorf("(%v): got %q, want %q", i, got, want)
 		}
+	}
+}
+
+func here() string {
+	_, file, _, _ := runtime.Caller(1)
+	return file
+}
+
+func TestGoMod(t *testing.T) {
+	file := here()
+	root := filepath.Clean(strings.TrimSuffix(file, "x/ref/lib/vdl/build/build_test.go"))
+	if got, want := build.HasGoModule(root), "v.io"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	fmt.Printf("%v\n", filepath.Dir(file))
+	pkg := "x/ref/lib/vdl/build"
+	prefix, module, suffix := build.PackagePathSplit(filepath.Dir(file), "v.io/"+pkg)
+	if got, want := prefix, root; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := module, "v.io"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, want := suffix, pkg; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }

--- a/x/ref/lib/vdl/build/build_test.go
+++ b/x/ref/lib/vdl/build/build_test.go
@@ -693,20 +693,24 @@ func TestGoMod(t *testing.T) {
 	}
 	pkg := "x/ref/lib/vdl/build"
 	prefix, module, suffix := build.PackagePathSplit(filepath.Dir(file), "v.io/"+pkg)
-	if got, want := prefix, root; got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-	switch len(module) {
-	case 0:
-		if !strings.HasSuffix(root, "/v.io") {
-			t.Errorf("module name is inot in directory tree when it should be")
+
+	expect := func(p, m, s string) {
+		if got, want := prefix, p; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
-	default:
-		if got, want := module, "v.io"; got != want {
+		if got, want := module, m; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		if got, want := suffix, s; got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
 	}
-	if got, want := suffix, pkg; got != want {
-		t.Errorf("got %q, want %q", got, want)
+	switch len(module) {
+	case 0:
+		// v.io is in the directory structure.
+		expect(root, "", path.Join(gomod, pkg))
+	default:
+		// v.io is not in the directory structure.
+		expect(prefix, gomod, pkg)
 	}
 }

--- a/x/ref/lib/vdl/build/build_test.go
+++ b/x/ref/lib/vdl/build/build_test.go
@@ -687,7 +687,8 @@ func here() string {
 func TestGoMod(t *testing.T) {
 	file := here()
 	root := filepath.Clean(strings.TrimSuffix(file, "x/ref/lib/vdl/build/build_test.go"))
-	if got, want := build.HasGoModule(root), "v.io"; got != want {
+	gomod := build.HasGoModule(root)
+	if got, want := gomod, "v.io"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 	pkg := "x/ref/lib/vdl/build"
@@ -695,8 +696,15 @@ func TestGoMod(t *testing.T) {
 	if got, want := prefix, root; got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
-	if got, want := module, "v.io"; got != want {
-		t.Errorf("got %q, want %q", got, want)
+	switch len(module) {
+	case 0:
+		if !strings.HasSuffix(root, "/v.io") {
+			t.Errorf("module name is inot in directory tree when it should be")
+		}
+	default:
+		if got, want := module, "v.io"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
 	}
 	if got, want := suffix, pkg; got != want {
 		t.Errorf("got %q, want %q", got, want)

--- a/x/ref/lib/vdl/build/build_test.go
+++ b/x/ref/lib/vdl/build/build_test.go
@@ -413,8 +413,8 @@ func TestTransitivePackagesUnknownPathError(t *testing.T) {
 	setEnvironment(t, defaultVDLRoot, defaultVDLPath)
 	testTransitivePackagesUnknownPathError(t)
 	// Test with VDLROOT unset.
-	//setEnvironment(t, "", defaultVDLPath)
-	//testTransitivePackagesUnknownPathError(t)
+	setEnvironment(t, "", defaultVDLPath)
+	testTransitivePackagesUnknownPathError(t)
 }
 
 func testTransitivePackagesUnknownPathError(t *testing.T) {
@@ -450,19 +450,19 @@ func testTransitivePackagesUnknownPathError(t *testing.T) {
 		},
 		{
 			[]string{"../../../../../.foo"},
-			`package path ".foo" is invalid`,
+			`package path "v.io/.foo" is invalid`,
 		},
 		{
 			[]string{"../../../../../foo/.bar"},
-			`package path "foo/.bar" is invalid`,
+			`package path "v.io/foo/.bar" is invalid`,
 		},
 		{
 			[]string{"../../../../../_foo"},
-			`package path "_foo" is invalid`,
+			`package path "v.io/_foo" is invalid`,
 		},
 		{
 			[]string{"../../../../../foo/_bar"},
-			`package path "foo/_bar" is invalid`,
+			`package path "v.io/foo/_bar" is invalid`,
 		},
 		// Special-case error for packages under vdlroot, which can't be imported
 		// using the vdlroot prefix.
@@ -475,7 +475,7 @@ func testTransitivePackagesUnknownPathError(t *testing.T) {
 			`can't resolve "v.io/v23/vdlroot/..." to any packages`,
 		},
 	}
-	for i, test := range tests {
+	for _, test := range tests {
 		for _, mode := range allModes {
 			name := fmt.Sprintf("%v %v", mode, test.InPaths)
 			errs := vdlutil.NewErrors(-1)
@@ -485,8 +485,6 @@ func testTransitivePackagesUnknownPathError(t *testing.T) {
 				// Ignore mode returns success, while error mode returns error.
 				errRE = ""
 			}
-			fmt.Fprintf(os.Stderr, "FOR:(%v) %s: %s\n", i, test.InPaths, errRE)
-			fmt.Fprintf(os.Stderr, "GOT: %s\n", errs)
 			vdltestutil.ExpectResult(t, errs, name, errRE)
 			if pkgs != nil {
 				t.Errorf("%v got unexpected packages %v", name, pkgs)
@@ -692,8 +690,6 @@ func TestGoMod(t *testing.T) {
 	if got, want := build.HasGoModule(root), "v.io"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
-
-	fmt.Printf("%v\n", filepath.Dir(file))
 	pkg := "x/ref/lib/vdl/build"
 	prefix, module, suffix := build.PackagePathSplit(filepath.Dir(file), "v.io/"+pkg)
 	if got, want := prefix, root; got != want {

--- a/x/ref/lib/vdl/build/build_test.go
+++ b/x/ref/lib/vdl/build/build_test.go
@@ -708,7 +708,7 @@ func TestGoMod(t *testing.T) {
 	switch len(module) {
 	case 0:
 		// v.io is in the directory structure.
-		expect(root, "", path.Join(gomod, pkg))
+		expect(strings.TrimSuffix(root, "/"+gomod), "", path.Join(gomod, pkg))
 	default:
 		// v.io is not in the directory structure.
 		expect(prefix, gomod, pkg)

--- a/x/ref/lib/vdl/build/build_test.go
+++ b/x/ref/lib/vdl/build/build_test.go
@@ -687,7 +687,7 @@ func here() string {
 func TestGoMod(t *testing.T) {
 	file := here()
 	root := filepath.Clean(strings.TrimSuffix(file, "x/ref/lib/vdl/build/build_test.go"))
-	gomod, err := build.HasGoModule(root)
+	gomod, err := build.GoModuleName(root)
 	if err != nil {
 		t.Fatalf("failed to read go.mod: %v", err)
 	}

--- a/x/ref/lib/vdl/build/build_test.go
+++ b/x/ref/lib/vdl/build/build_test.go
@@ -687,7 +687,10 @@ func here() string {
 func TestGoMod(t *testing.T) {
 	file := here()
 	root := filepath.Clean(strings.TrimSuffix(file, "x/ref/lib/vdl/build/build_test.go"))
-	gomod := build.HasGoModule(root)
+	gomod, err := build.HasGoModule(root)
+	if err != nil {
+		t.Fatalf("failed to read go.mod: %v", err)
+	}
 	if got, want := gomod, "v.io"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}

--- a/x/ref/lib/vdl/build/support_test.go
+++ b/x/ref/lib/vdl/build/support_test.go
@@ -1,0 +1,7 @@
+package build
+
+// SetFilePathSeparator is for use from within tests to fake out working
+// on windows style filesytems.
+func SetFilePathSeparator(sep string) {
+	filePathSeparator = sep
+}

--- a/x/ref/lib/vdl/testdata/arith/arith.vdl.go
+++ b/x/ref/lib/vdl/testdata/arith/arith.vdl.go
@@ -232,7 +232,7 @@ type AdvancedMathServerStub interface {
 // an object that may be used by rpc.Server.
 func AdvancedMathServer(impl AdvancedMathServerMethods) AdvancedMathServerStub {
 	stub := implAdvancedMathServerStub{
-		impl: impl,
+		impl:                   impl,
 		TrigonometryServerStub: TrigonometryServer(impl),
 		ExpServerStub:          exp.ExpServer(impl),
 	}

--- a/x/ref/runtime/internal/rpc/testutil_test.go
+++ b/x/ref/runtime/internal/rpc/testutil_test.go
@@ -7,7 +7,7 @@ package rpc
 import (
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/security"

--- a/x/ref/runtime/internal/rt/rt_test.go
+++ b/x/ref/runtime/internal/rt/rt_test.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/security"
 	"v.io/x/lib/envvar"

--- a/x/ref/runtime/internal/rt/shutdown_test.go
+++ b/x/ref/runtime/internal/rt/shutdown_test.go
@@ -10,18 +10,10 @@ import (
 	"os"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/x/ref/lib/signals"
 	"v.io/x/ref/test/v23test"
 )
-
-var cstderr io.Writer
-
-func init() {
-	if testing.Verbose() {
-		cstderr = os.Stderr
-	}
-}
 
 func writeln(w io.Writer, s string) {
 	w.Write([]byte(s + "\n"))

--- a/x/ref/services/identity/internal/revocation/revocation.vdl.go
+++ b/x/ref/services/identity/internal/revocation/revocation.vdl.go
@@ -43,13 +43,8 @@ var NotRevokedCaveat = security.CaveatDescriptor{
 		128,
 		0,
 	},
-	ParamType: __VDLType_list_1,
+	ParamType: vdl.TypeOf((*[]byte)(nil)),
 }
-
-// Hold type definitions in package-level variables, for better performance.
-var (
-	__VDLType_list_1 *vdl.Type
-)
 
 var __VDLInitCalled bool
 
@@ -71,9 +66,6 @@ func __VDLInit() struct{} {
 		return struct{}{}
 	}
 	__VDLInitCalled = true
-
-	// Initialize type definitions.
-	__VDLType_list_1 = vdl.TypeOf((*[]byte)(nil))
 
 	return struct{}{}
 }

--- a/x/ref/services/role/roled/internal/internal.vdl.go
+++ b/x/ref/services/role/roled/internal/internal.vdl.go
@@ -284,7 +284,7 @@ var LoggingCaveat = security.CaveatDescriptor{
 		128,
 		0,
 	},
-	ParamType: __VDLType_list_2,
+	ParamType: vdl.TypeOf((*[]string)(nil)),
 }
 
 // Hold type definitions in package-level variables, for better performance.

--- a/x/ref/test/init.go
+++ b/x/ref/test/init.go
@@ -6,17 +6,24 @@ package test
 
 import (
 	"flag"
-
 	"os"
 	"os/signal"
+	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/v23/security"
 	"v.io/x/ref/services/debug/debug/browseserver"
 )
+
+func init() {
+	// Required to ensure that test related flags are defined.
+	// TODO(cnicolaou): rationalize the use of testing package flags from
+	//                  regression and integration tests.
+	testing.Init()
+}
 
 var debugOnShutdown = flag.String("v23.debug-address", "",
 	"If this is set then when a test runs, we start a debug browser (serving at the given address)"+


### PR DESCRIPTION
This PR provides go 1.14 compatibility. There are two changes:
1. calls to testing.Init() to initialize flags as required for regression tests
2. in celebration of go modules being declared 'production' ready, ensure that vdl can operate in a go module directory structure.