### PR TITLE
test,lint: use circleci for CI tests and lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - go/test:
           covermode: atomic
           failfast: true
-          race: true
+          race: false
 
   lint:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,50 @@
+jobs:
+  test:
+    executor:
+      name: go/default
+      tag: "1.14"
+    steps:
+      - checkout
+      - go/load-cache
+      - go/mod-download
+      - run:
+          name: goimports
+          command: |
+            go get golang.org/x/tools/cmd/goimports
+            go install -x golang.org/x/tools/cmd/goimports
+      - go/save-cache
+      - go/test:
+          covermode: atomic
+          failfast: true
+          race: true
+
+  lint:
+    executor:
+      name: go/default
+      tag: "1.14"
+    steps:
+      - checkout
+      - go/load-cache
+      - go/mod-download
+      - run:
+          name: downloads
+          command: |
+            go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0
+            go get github.com/matthewloring/validjson/cmd/validjson
+            go install -x github.com/golangci/golangci-lint/cmd/golangci-lint
+            go install -x github.com/matthewloring/validjson/cmd/validjson
+      - go/save-cache
+      - run:
+          name: lint
+          command: |
+            golangci-lint run ./...
+            validjson ./...
+
+version: 2.1
+orbs:
+  go: circleci/go@1.1.2
+workflows:
+  main:
+    jobs:
+      - test
+      - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ jobs:
     executor:
       name: go/default
       tag: "1.14"
+    environment:
+      VDLPATH:
     steps:
       - checkout
       - go/load-cache
@@ -13,8 +15,13 @@ jobs:
             go get golang.org/x/tools/cmd/goimports
             go install -x golang.org/x/tools/cmd/goimports
       - go/save-cache
+      - run:
+          name: vdlpath
+          command: |
+            echo "export VDLPATH=$CIRCLE_WORKING_DIRECTORY" >> $BASH_ENV
+            source $BASH_ENV
       - go/test:
-          covermode: atomic
+          covermode: set
           failfast: true
           race: false
 


### PR DESCRIPTION
Use circleci for tests and linting. However, the lint tests do not need to pass for a PR to be merged. This will be changed in a subsequent PR when the lint tests pass.