### PR TITLE
lint: fix lint 'errcheck' errors

### DIFF
--- a/v23/i18n/i18n_test.go
+++ b/v23/i18n/i18n_test.go
@@ -6,10 +6,11 @@
 
 package i18n
 
-import "strings"
-import "testing"
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	"v.io/v23/context"
 )
 
@@ -204,7 +205,7 @@ func TestMergeAndOutput(t *testing.T) {
 	cat := new(Catalogue)
 
 	// Check that Merge() works.
-	cat.Merge(strings.NewReader(mergeData))
+	cat.Merge(strings.NewReader(mergeData)) // nolint: errcheck
 	expectLookup(t, cat, "{1} foo to {2}", "fwd", "foo", "1")
 	expectLookup(t, cat, "", "back", "foo", "2")
 	expectLookup(t, cat, "{1} bar to {2}", "fwd", "bar", "3")

--- a/v23/naming/routingid_test.go
+++ b/v23/naming/routingid_test.go
@@ -13,7 +13,7 @@ import (
 func compress(id []byte, level int) (len int) {
 	var z bytes.Buffer
 	f, _ := flate.NewWriter(&z, level)
-	f.Write(id)
+	f.Write(id) // nolint: errcheck
 	f.Close()
 	return z.Len()
 }

--- a/v23/rpc/util.go
+++ b/v23/rpc/util.go
@@ -38,6 +38,7 @@ func (o obj) GlobChildren__(_ *context.T, call GlobChildrenServerCall, matcher *
 	sender := call.SendStream()
 	for _, v := range o.children {
 		if matcher.Match(v) {
+			// nolint: errcheck
 			sender.Send(naming.GlobChildrenReplyName{Value: v})
 		}
 	}

--- a/v23/security/access/caveat_test.go
+++ b/v23/security/access/caveat_test.go
@@ -31,7 +31,9 @@ func TestAccessTagCaveat(t *testing.T) {
 			{[]*vdl.Value{vdl.ValueOf("Debug"), vdl.ValueOf("Resolve")}, false},
 		}
 	)
-	security.AddToRoots(server, bserver)
+	if err := security.AddToRoots(server, bserver); err != nil {
+		t.Fatal(err)
+	}
 	ctx, cancel := context.RootContext()
 	defer cancel()
 	for idx, test := range tests {

--- a/v23/security/authorizer_test.go
+++ b/v23/security/authorizer_test.go
@@ -208,7 +208,9 @@ func TestEndpointAuthorizer(t *testing.T) {
 		ctx, cancel = context.RootContext()
 	)
 	defer cancel()
-	AddToRoots(pali, ali)
+	if err := AddToRoots(pali, ali); err != nil {
+		t.Fatal(err)
+	}
 	for _, test := range tests {
 		err := EndpointAuthorizer().Authorize(ctx, NewCall(&CallParams{
 			RemoteEndpoint:  test.ep,

--- a/v23/security/caveat_test.go
+++ b/v23/security/caveat_test.go
@@ -50,7 +50,9 @@ func TestStandardCaveatFactories(t *testing.T) {
 		}
 	)
 
-	AddToRoots(self, balice)
+	if err := AddToRoots(self, balice); err != nil {
+		t.Fatal(err)
+	}
 
 	ctx, cancel := context.RootContext()
 	defer cancel()
@@ -341,6 +343,8 @@ func BenchmarkValidateCaveat(b *testing.B) {
 	defer cancel()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cav.Validate(ctx, call)
+		if err := cav.Validate(ctx, call); err != nil {
+			b.Fatal(b)
+		}
 	}
 }

--- a/v23/security/principal_blessings_test.go
+++ b/v23/security/principal_blessings_test.go
@@ -919,7 +919,9 @@ func BenchmarkRemoteBlessingNames(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	AddToRoots(p, remote)
+	if err := AddToRoots(p, remote); err != nil {
+		b.Fatal(err)
+	}
 	ctx, cancel := context.RootContext()
 	defer cancel()
 	call := NewCall(&CallParams{

--- a/v23/uniqueid/uniqueid_test.go
+++ b/v23/uniqueid/uniqueid_test.go
@@ -53,7 +53,9 @@ func BenchmarkNewIDParallel(b *testing.B) {
 	g := RandomGenerator{}
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			g.NewID()
+			if _, err := g.NewID(); err != nil {
+				b.Fatal(err)
+			}
 		}
 	})
 }

--- a/v23/vdl/register_native.go
+++ b/v23/vdl/register_native.go
@@ -191,6 +191,7 @@ var errNoRegisterNativeError = errors.New(`vdl: RegisterNative must be called to
 // nolint: deadcode, unused
 func fromWireError(wire *WireError) error {
 	var err error
+	// nolint: errcheck
 	nativeInfoFromWire(reflect.TypeOf(wire)).ToNative(reflect.ValueOf(wire), reflect.ValueOf(&err))
 	return err
 }

--- a/v23/vdl/vdltest/entry_generator.go
+++ b/v23/vdl/vdltest/entry_generator.go
@@ -311,9 +311,9 @@ func (g *EntryGenerator) makeValue(tt *vdl.Type, label string, mode GenMode) *vd
 	// random source with a hash of the unique type string, gen mode and iteration
 	// counter i.
 	g.hasher.Reset()
-	g.hasher.Write([]byte(tt.Unique()))
-	g.hasher.Write([]byte(label))
-	g.hasher.Write([]byte(mode.String()))
+	g.hasher.Write([]byte(tt.Unique()))   // nolint: errcheck
+	g.hasher.Write([]byte(label))         // nolint: errcheck
+	g.hasher.Write([]byte(mode.String())) // nolint: errcheck
 	g.valueGen.RandSeed(g.randSeed + int64(g.hasher.Sum64()))
 	return g.valueGen.Gen(tt, mode)
 }
@@ -322,9 +322,9 @@ func (g *EntryGenerator) perm(n int, tt *vdl.Type, label string, mode sourceMode
 	// Similar to makeValue, we'd like to ensure that our choice of random
 	// candidate permutations don't change our test values spuriously.
 	g.hasher.Reset()
-	g.hasher.Write([]byte(tt.Unique()))
-	g.hasher.Write([]byte(label))
-	g.hasher.Write([]byte(mode.String()))
+	g.hasher.Write([]byte(tt.Unique()))   // nolint: errcheck
+	g.hasher.Write([]byte(label))         // nolint: errcheck
+	g.hasher.Write([]byte(mode.String())) // nolint: errcheck
 	g.rng.Seed(g.randSeed + int64(g.hasher.Sum64()))
 	return g.rng.Perm(n)
 }

--- a/v23/vdlroot/time/time.go
+++ b/v23/vdlroot/time/time.go
@@ -50,7 +50,7 @@ func (x Time) Normalize() Time {
 // Now returns the current time.
 func Now() Time {
 	var t Time
-	TimeFromNative(&t, time.Now())
+	TimeFromNative(&t, time.Now()) // nolint: errcheck
 	return t
 }
 

--- a/v23/verror/verror.go
+++ b/v23/verror/verror.go
@@ -424,7 +424,7 @@ func Stack(err error) PCs {
 
 func (st PCs) String() string {
 	buf := bytes.NewBufferString("")
-	StackToText(buf, st)
+	StackToText(buf, st) // nolint: errcheck
 	return buf.String()
 }
 
@@ -811,7 +811,7 @@ func debugStringInternal(err error, prefix string, name string) string {
 	// Append err's stack, indented a little.
 	prefix += "  "
 	buf := bytes.NewBufferString("")
-	stackToTextIndent(buf, Stack(err), prefix)
+	stackToTextIndent(buf, Stack(err), prefix) // nolint: errcheck
 	str += "\n" + buf.String()
 	// Print all the subordinate errors, even the ones that were not
 	// printed by Error(), indented a bit further.

--- a/v23/vom/decoder_test.go
+++ b/v23/vom/decoder_test.go
@@ -389,7 +389,7 @@ func TestFuzzTypeDecodeDeadlock(t *testing.T) {
 	var v interface{}
 	d := vom.NewDecoder(strings.NewReader("\x81\x30"))
 	// Before the fix, this line caused a deadlock and panic.
-	d.Decode(&v)
+	d.Decode(&v) // nolint: errcheck
 }
 
 // Tests that an input go-fuzz found will no longer cause a
@@ -398,7 +398,7 @@ func TestFuzzVdlPanic(t *testing.T) {
 	var v interface{}
 	d := vom.NewDecoder(strings.NewReader("\x81S*\x00\x00$000000000000000000000000000000000000\x01*\xe1U(\x05\x00 00000000000000000000000000000000\x01*\x02+\xe1"))
 	// Before this fix this line caused a panic.
-	d.Decode(&v)
+	d.Decode(&v) // nolint: errcheck
 }
 
 // In concurrent modes, one goroutine may try to read vom types before they are

--- a/v23/vom/internal/helpers.go
+++ b/v23/vom/internal/helpers.go
@@ -86,7 +86,7 @@ func vomDecodeMany(b *testing.B, value interface{}, make func() interface{}) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		reader.Seek(valueOffset, 0)
+		reader.Seek(valueOffset, 0) // nolint: errcheck
 		if err := dec.Decode(make()); err != nil {
 			b.Fatal(err)
 		}
@@ -120,7 +120,7 @@ func gobDecode(b *testing.B, value interface{}, make func() interface{}) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		reader.Seek(0, 0)
+		reader.Seek(0, 0) // nolint: errcheck
 		if err := gob.NewDecoder(reader).Decode(make()); err != nil {
 			b.Fatal(err)
 		}
@@ -134,7 +134,7 @@ func gobEncodeMany(b *testing.B, value interface{}) {
 	if err := enc.Encode(value); err != nil {
 		b.Fatal(err)
 	}
-	enc.Encode(value)
+	enc.Encode(value) // nolint: errcheck
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
@@ -167,7 +167,7 @@ func gobDecodeMany(b *testing.B, value interface{}, make func() interface{}) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		reader.Seek(valueOffset, 0)
+		reader.Seek(valueOffset, 0) // nolint: errcheck
 		if err := dec.Decode(make()); err != nil {
 			b.Fatal(err)
 		}

--- a/v23/vom/internal/vombenchgen/gen.go
+++ b/v23/vom/internal/vombenchgen/gen.go
@@ -24,6 +24,7 @@ func main() {
 		panic(err)
 	}
 
+	// nolint: errcheck
 	file.WriteString(`// Copyright 2016 The Vanadium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
@@ -48,7 +49,7 @@ import (
 
 	`)
 	for _, entry := range benchmarks {
-		file.WriteString(genBenchmark(entry))
+		file.WriteString(genBenchmark(entry)) // nolint: errcheck
 	}
 	file.Close()
 	exec.Command("go", "go")

--- a/v23/vom/splice_test.go
+++ b/v23/vom/splice_test.go
@@ -17,11 +17,12 @@ type m struct {
 	M string
 }
 
+// nolint: errcheck
 func ExampleMergeEncodedBytes() {
 
 	abuf := &bytes.Buffer{}
 	encA := vom.NewEncoder(abuf)
-	encA.Encode(&m{"stream-a"})
+	encA.Encode(&m{"stream-a"}) // nolint: errcheck
 
 	bbuf := &bytes.Buffer{}
 	encB := vom.NewEncoder(bbuf)
@@ -39,6 +40,7 @@ func ExampleMergeEncodedBytes() {
 	// stream-b
 }
 
+// nolint: errcheck
 func ExampleExtractEncodedBytes() {
 	abuf := &bytes.Buffer{}
 	encA := vom.NewEncoder(abuf)

--- a/v23/vom/testutil_test.go
+++ b/v23/vom/testutil_test.go
@@ -90,7 +90,7 @@ func (abc *abcRead) Read(p []byte) (int, error) {
 
 func ABCBytes(lim int) []byte {
 	b := make([]byte, lim)
-	io.ReadFull(ABCReader(lim), b)
+	io.ReadFull(ABCReader(lim), b) // nolint: errcheck
 	return b
 }
 

--- a/v23/vom/vomtest/internal/vomforever/main.go
+++ b/v23/vom/vomtest/internal/vomforever/main.go
@@ -149,10 +149,10 @@ func buildAndRunFromVdlFile(vv *vdl.Value, types []*vdl.Type, vdlFlags []string)
 	stdout, err := cmd.StdoutPipe()
 	panicOnError(err)
 	go func() {
-		io.Copy(os.Stderr, stderr)
+		io.Copy(os.Stderr, stderr) // nolint: errcheck
 	}()
 	go func() {
-		io.Copy(os.Stdout, stdout)
+		io.Copy(os.Stdout, stdout) // nolint: errcheck
 	}()
 	panicOnError(cmd.Run())
 
@@ -168,10 +168,10 @@ func buildAndRunFromVdlFile(vv *vdl.Value, types []*vdl.Type, vdlFlags []string)
 	stdout, err = cmd.StdoutPipe()
 	panicOnError(err)
 	go func() {
-		io.Copy(os.Stderr, stderr)
+		io.Copy(os.Stderr, stderr) // nolint: errcheck
 	}()
 	go func() {
-		io.Copy(os.Stdout, stdout)
+		io.Copy(os.Stdout, stdout) // nolint: errcheck
 	}()
 	panicOnError(cmd.Run())
 }

--- a/v23/vom/vomtest/internal/vomtestgen/main.go
+++ b/v23/vom/vomtest/internal/vomtestgen/main.go
@@ -133,7 +133,7 @@ func toVomHex(version vom.Version, value *vdl.Value) (_, _, _ string) {
 	panicOnError(enc.Encode(value))
 	versionByte, _ := buf.ReadByte() // Read the version byte.
 	if bufType.Len() > 0 {
-		bufType.ReadByte() // Remove the version byte.
+		bufType.ReadByte() // nolint: errcheck // Remove the version byte.
 	}
 	vomBytes := append([]byte{versionByte}, bufType.Bytes()...)
 	vomBytes = append(vomBytes, buf.Bytes()...)

--- a/x/jni/impl/google/services/vango/funcs.go
+++ b/x/jni/impl/google/services/vango/funcs.go
@@ -268,7 +268,7 @@ func AllFunc(ctx *context.T, output io.Writer) error {
 		statRequest <- r
 		return <-r
 	})
-	defer stats.Delete(vangoStat)
+	defer stats.Delete(vangoStat) // nolint: errcheck
 	fmt.Fprintln(output, "My AdID:", ad.Id)
 	fmt.Fprintln(output, "My addrs:", myaddrs)
 	ctx.Infof("SERVER STATUS: %+v", status)

--- a/x/ref/cmd/gclogs/gclogs.go
+++ b/x/ref/cmd/gclogs/gclogs.go
@@ -57,7 +57,7 @@ func main() {
 
 func garbageCollectLogs(env *cmdline.Env, args []string) error {
 	if len(args) == 0 {
-		env.UsageErrorf("gclogs requires at least one argument")
+		return env.UsageErrorf("gclogs requires at least one argument")
 	}
 	timeCutoff := time.Now().Add(-flagCutoff)
 	currentUser, err := user.Current()

--- a/x/ref/cmd/mounttable/impl_test.go
+++ b/x/ref/cmd/mounttable/impl_test.go
@@ -41,6 +41,7 @@ type server struct {
 func (s *server) Glob__(ctx *context.T, call rpc.GlobServerCall, g *glob.Glob) error {
 	ctx.VI(2).Infof("Glob() was called. suffix=%v pattern=%q", s.suffix, g.String())
 	sender := call.SendStream()
+	// nolint: errcheck
 	sender.Send(naming.GlobReplyEntry{
 		Value: naming.MountEntry{
 			Name: "name1",
@@ -50,6 +51,7 @@ func (s *server) Glob__(ctx *context.T, call rpc.GlobServerCall, g *glob.Glob) e
 			IsLeaf:           false,
 		},
 	})
+	// nolint: errcheck
 	sender.Send(naming.GlobReplyEntry{
 		Value: naming.MountEntry{
 			Name: "name2",
@@ -113,7 +115,10 @@ func TestMountTableClient(t *testing.T) {
 
 	// Make sure to use our newly created mounttable rather than the
 	// default.
-	v23.GetNamespace(ctx).SetRoots(endpoint.Name())
+	err = v23.GetNamespace(ctx).SetRoots(endpoint.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Setup the command-line.
 	var stdout, stderr bytes.Buffer

--- a/x/ref/cmd/principal/bless.go
+++ b/x/ref/cmd/principal/bless.go
@@ -166,7 +166,7 @@ func getMacaroonForBlessRPC(key security.PublicKey, blessServerURL string, bless
 		tmplArgs.Blessings = blessed
 		ln.Close()
 	})
-	go http.Serve(ln, nil)
+	go http.Serve(ln, nil) // nolint: errcheck
 
 	// Print the link to start the flow.
 	url, err := seekBlessingsURL(key, blessServerURL, redirectURL, state)
@@ -181,7 +181,7 @@ func getMacaroonForBlessRPC(key security.PublicKey, blessServerURL string, bless
 	// need to wait for the command to return (and indeed on some window managers,
 	// the command will not exit until the browser is closed).
 	if len(openCommand) != 0 && browser {
-		exec.Command(openCommand, url).Start()
+		exec.Command(openCommand, url).Start() // nolint: errcheck
 	}
 	return result, nil
 }

--- a/x/ref/cmd/vdl/arith_test.go
+++ b/x/ref/cmd/vdl/arith_test.go
@@ -63,7 +63,7 @@ func (*serverArith) StreamingAdd(_ *context.T, call arith.ArithStreamingAddServe
 	for call.RecvStream().Advance() {
 		value := call.RecvStream().Value()
 		total += value
-		call.SendStream().Send(total)
+		call.SendStream().Send(total) // nolint: errcheck
 	}
 	return total, call.RecvStream().Err()
 }

--- a/x/ref/cmd/vrpc/vrpc_test.go
+++ b/x/ref/cmd/vrpc/vrpc_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/x/lib/cmdline"
@@ -109,7 +109,7 @@ func (*server) ZStream(_ *context.T, call internal.TypeTesterZStreamServerCall, 
 	vlog.VI(2).Info("ZStream(%v,%v) was called.", nStream, item)
 	sender := call.SendStream()
 	for i := int32(0); i < nStream; i++ {
-		sender.Send(item)
+		sender.Send(item) // nolint: errcheck
 	}
 	return nil
 }

--- a/x/ref/envvar_test.go
+++ b/x/ref/envvar_test.go
@@ -50,7 +50,7 @@ func TestEnvClearCredentials(t *testing.T) {
 	if got, want := os.Getenv(EnvCredentials), "FOO"; got != want {
 		t.Errorf("Got %q, want %q", got, want)
 	}
-	EnvClearCredentials()
+	EnvClearCredentials() // nolint: errcheck
 	if got := os.Getenv(EnvCredentials); got != "" {
 		t.Errorf("Got %q, wanted empty string", got)
 	}

--- a/x/ref/lib/apilog/apilog_test.go
+++ b/x/ref/lib/apilog/apilog_test.go
@@ -54,7 +54,7 @@ func TestLogCall(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	l := vlog.NewLogger("testHeader")
-	l.Configure(vlog.LogDir(dir), vlog.Level(2))
+	l.Configure(vlog.LogDir(dir), vlog.Level(2)) // nolint: errcheck
 	ctx, _ := context.RootContext()
 	ctx = context.WithLogger(ctx, l)
 	myLoggedFunc(ctx)
@@ -69,7 +69,7 @@ func TestLogCallNoContext(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	l := vlog.NewLogger("testHeader")
-	l.Configure(vlog.LogDir(dir), vlog.Level(2))
+	l.Configure(vlog.LogDir(dir), vlog.Level(2)) // nolint: errcheck
 	saved := vlog.Log
 	vlog.Log = l
 	defer func() { vlog.Log = saved }()

--- a/x/ref/lib/discovery/advertise.go
+++ b/x/ref/lib/discovery/advertise.go
@@ -125,7 +125,7 @@ func (d *idiscovery) startAdvertising(ctx *context.T, adinfo *AdInfo) (func(), e
 	}
 
 	stop := func() {
-		_ = stats.Delete(statName)
+		stats.Delete(statName) // nolint: errcheck
 		cancel()
 		wg.Wait()
 	}

--- a/x/ref/lib/discovery/advertise.go
+++ b/x/ref/lib/discovery/advertise.go
@@ -125,7 +125,7 @@ func (d *idiscovery) startAdvertising(ctx *context.T, adinfo *AdInfo) (func(), e
 	}
 
 	stop := func() {
-		stats.Delete(statName)
+		_ = stats.Delete(statName)
 		cancel()
 		wg.Wait()
 	}

--- a/x/ref/lib/discovery/global/global_test.go
+++ b/x/ref/lib/discovery/global/global_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/discovery"
 	"v.io/v23/options"
 	"v.io/v23/security"
@@ -191,7 +191,7 @@ func TestRefresh(t *testing.T) {
 		t.Fatal(err)
 	}
 	ns := v23.GetNamespace(ctx)
-	ns.SetRoots(mtserver.Status().Endpoints[0].Name())
+	_ = ns.SetRoots(mtserver.Status().Endpoints[0].Name())
 
 	ad := discovery.Advertisement{
 		InterfaceName: "foo/bar/baz",

--- a/x/ref/lib/discovery/global/global_test.go
+++ b/x/ref/lib/discovery/global/global_test.go
@@ -191,7 +191,9 @@ func TestRefresh(t *testing.T) {
 		t.Fatal(err)
 	}
 	ns := v23.GetNamespace(ctx)
-	_ = ns.SetRoots(mtserver.Status().Endpoints[0].Name())
+	if err := ns.SetRoots(mtserver.Status().Endpoints[0].Name()); err != nil {
+		t.Fatal(err)
+	}
 
 	ad := discovery.Advertisement{
 		InterfaceName: "foo/bar/baz",

--- a/x/ref/lib/discovery/plugins/ble/ble.go
+++ b/x/ref/lib/discovery/plugins/ble/ble.go
@@ -80,7 +80,7 @@ func (p *plugin) Scan(ctx *context.T, interfaceName string, callback func(*idisc
 			}
 			return buf.String()
 		})
-		defer stats.Delete(stat)
+		defer stats.Delete(stat) // nolint: errcheck
 		for {
 			select {
 			case adinfo := <-listener:
@@ -134,6 +134,6 @@ func newWithTTL(ctx *context.T, host string, ttl time.Duration) (idiscovery.Plug
 		adStopper:  idiscovery.NewTrigger(),
 		statPrefix: statPrefix,
 	}
-	runtime.SetFinalizer(p, func(p *plugin) { stats.Delete(statPrefix) })
+	runtime.SetFinalizer(p, func(p *plugin) { _ = stats.Delete(statPrefix) })
 	return p, nil
 }

--- a/x/ref/lib/discovery/plugins/ble/ble.go
+++ b/x/ref/lib/discovery/plugins/ble/ble.go
@@ -134,6 +134,9 @@ func newWithTTL(ctx *context.T, host string, ttl time.Duration) (idiscovery.Plug
 		adStopper:  idiscovery.NewTrigger(),
 		statPrefix: statPrefix,
 	}
-	runtime.SetFinalizer(p, func(p *plugin) { _ = stats.Delete(statPrefix) })
+	runtime.SetFinalizer(p, func(p *plugin) {
+		// nolint: errcheck
+		stats.Delete(statPrefix)
+	})
 	return p, nil
 }

--- a/x/ref/lib/discovery/plugins/mdns/mdns.go
+++ b/x/ref/lib/discovery/plugins/mdns/mdns.go
@@ -114,8 +114,8 @@ func (p *plugin) Advertise(ctx *context.T, adinfo *idiscovery.AdInfo, done func(
 		return err
 	}
 	stop := func() {
-		p.mdns.RemoveService(serviceName, hostName, 0, txt...)
-		p.mdns.RemoveService(v23ServiceName, hostName, 0, txt...)
+		_ = p.mdns.RemoveService(serviceName, hostName, 0, txt...)
+		_ = p.mdns.RemoveService(v23ServiceName, hostName, 0, txt...)
 		done()
 	}
 	p.adStopper.Add(stop, ctx.Done())

--- a/x/ref/lib/discovery/plugins/mdns/mdns.go
+++ b/x/ref/lib/discovery/plugins/mdns/mdns.go
@@ -114,8 +114,8 @@ func (p *plugin) Advertise(ctx *context.T, adinfo *idiscovery.AdInfo, done func(
 		return err
 	}
 	stop := func() {
-		_ = p.mdns.RemoveService(serviceName, hostName, 0, txt...)
-		_ = p.mdns.RemoveService(v23ServiceName, hostName, 0, txt...)
+		p.mdns.RemoveService(serviceName, hostName, 0, txt...)    // nolint: errcheck
+		p.mdns.RemoveService(v23ServiceName, hostName, 0, txt...) // nolint: errcheck
 		done()
 	}
 	p.adStopper.Add(stop, ctx.Done())

--- a/x/ref/lib/discovery/util.go
+++ b/x/ref/lib/discovery/util.go
@@ -62,8 +62,7 @@ func hashAd(adinfo *AdInfo) {
 
 	field.Reset()
 	var buf bytes.Buffer
-	// nolint: errcheck
-	binary.Write(&buf, binary.LittleEndian, adinfo.EncryptionAlgorithm)
+	binary.Write(&buf, binary.LittleEndian, adinfo.EncryptionAlgorithm) // nolint: errcheck
 	w(field, buf.Bytes())
 	for _, key := range adinfo.EncryptionKeys {
 		w(field, []byte(key))

--- a/x/ref/lib/discovery/util.go
+++ b/x/ref/lib/discovery/util.go
@@ -18,7 +18,7 @@ import (
 func hashAd(adinfo *AdInfo) {
 	w := func(w io.Writer, data []byte) {
 		sum := sha256.Sum256(data)
-		w.Write(sum[:])
+		w.Write(sum[:]) // nolint: errcheck
 	}
 
 	hasher := sha256.New()
@@ -30,7 +30,7 @@ func hashAd(adinfo *AdInfo) {
 	for _, addr := range adinfo.Ad.Addresses {
 		w(field, []byte(addr))
 	}
-	hasher.Write(field.Sum(nil))
+	hasher.Write(field.Sum(nil)) // nolint: errcheck
 
 	field.Reset()
 	if n := len(adinfo.Ad.Attributes); n > 0 {
@@ -44,7 +44,7 @@ func hashAd(adinfo *AdInfo) {
 			w(field, []byte(adinfo.Ad.Attributes[k]))
 		}
 	}
-	hasher.Write(field.Sum(nil))
+	hasher.Write(field.Sum(nil)) // nolint: errcheck
 
 	field.Reset()
 	if n := len(adinfo.Ad.Attachments); n > 0 {
@@ -58,16 +58,17 @@ func hashAd(adinfo *AdInfo) {
 			w(field, []byte(adinfo.Ad.Attachments[k]))
 		}
 	}
-	hasher.Write(field.Sum(nil))
+	hasher.Write(field.Sum(nil)) // nolint: errcheck
 
 	field.Reset()
 	var buf bytes.Buffer
+	// nolint: errcheck
 	binary.Write(&buf, binary.LittleEndian, adinfo.EncryptionAlgorithm)
 	w(field, buf.Bytes())
 	for _, key := range adinfo.EncryptionKeys {
 		w(field, []byte(key))
 	}
-	hasher.Write(field.Sum(nil))
+	hasher.Write(field.Sum(nil)) // nolint: errcheck
 
 	// We use the first 8 bytes to reduce the advertise packet size.
 	copy(adinfo.Hash[:], hasher.Sum(nil))

--- a/x/ref/lib/flags/flags.go
+++ b/x/ref/lib/flags/flags.go
@@ -256,10 +256,10 @@ func refreshDefaults(f *Flags) {
 			}
 		case *ListenFlags:
 			if !v.Protocol.isSet {
-				v.Protocol.validator.Set(defaultProtocol)
+				v.Protocol.validator.Set(defaultProtocol) // nolint: errcheck
 			}
 			if !v.Addresses.isSet {
-				v.Addresses.validator.Set(defaultHostPort)
+				v.Addresses.validator.Set(defaultHostPort) // nolint: errcheck
 			}
 		}
 	}
@@ -333,7 +333,7 @@ func (f *Flags) Parse(args []string, cfg map[string]string) error {
 	}
 	for k, v := range cfg {
 		if f.FlagSet.Lookup(k) != nil {
-			f.FlagSet.Set(k, v)
+			f.FlagSet.Set(k, v) // nolint: errcheck
 		}
 	}
 	return nil

--- a/x/ref/lib/flags/flags_test.go
+++ b/x/ref/lib/flags/flags_test.go
@@ -27,7 +27,7 @@ func TestFlags(t *testing.T) {
 	creds := "creddir"
 	roots := []string{"ab:cd:ef"}
 	args := []string{"--v23.credentials=" + creds, "--v23.namespace.root=" + roots[0]}
-	fl.Parse(args, nil)
+	fl.Parse(args, nil) // nolint: errcheck
 	rtf := fl.RuntimeFlags()
 	if got, want := rtf.NamespaceRoots.Roots, roots; !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -50,7 +50,7 @@ func TestPermissionsFlags(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fl := flags.CreateAndRegister(fs, flags.Runtime, flags.Permissions)
 	args := []string{"--v23.permissions.file=runtime:foo.json", "--v23.permissions.file=bar:bar.json", "--v23.permissions.file=baz:bar:baz.json"}
-	fl.Parse(args, nil)
+	fl.Parse(args, nil) // nolint: errcheck
 	permsf := fl.PermissionsFlags()
 
 	if got, want := permsf.PermissionsFile("runtime"), "foo.json"; got != want {
@@ -72,7 +72,7 @@ func TestPermissionsLiteralFlags(t *testing.T) {
 	fl := flags.CreateAndRegister(fs, flags.Runtime, flags.Permissions)
 	args := []string{`--v23.permissions.literal={"x":"hedgehog"}`,
 		`--v23.permissions.literal={"y":"badger"}`}
-	fl.Parse(args, nil)
+	fl.Parse(args, nil) // nolint: errcheck
 	permsf := fl.PermissionsFlags()
 
 	if got, want := permsf.PermissionsFile("runtime"), ""; got != want {
@@ -87,7 +87,7 @@ func TestPermissionsLiteralBoth(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	fl := flags.CreateAndRegister(fs, flags.Runtime, flags.Permissions)
 	args := []string{"--v23.permissions.file=runtime:foo.json", `--v23.permissions.literal={"x":"hedgehog"}`}
-	fl.Parse(args, nil)
+	fl.Parse(args, nil) // nolint: errcheck
 	permsf := fl.PermissionsFlags()
 
 	if got, want := permsf.PermissionsFile("runtime"), "foo.json"; got != want {
@@ -108,7 +108,7 @@ func TestPermissionsLiteralBoth(t *testing.T) {
 	} {
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
 		fl := flags.CreateAndRegister(fs, flags.Runtime, flags.Permissions)
-		fl.Parse(tc.args, nil)
+		fl.Parse(tc.args, nil) // nolint: errcheck
 		permsf = fl.PermissionsFlags()
 		if got, want := permsf.ExplicitlySpecified(), tc.set; got != want {
 			t.Errorf("got %v, want %v", got, want)
@@ -122,7 +122,7 @@ func TestFlagError(t *testing.T) {
 	fl := flags.CreateAndRegister(fs, flags.Runtime)
 	addr := "192.168.10.1:0"
 	args := []string{"--xxxv23.tcp.address=" + addr, "not an arg"}
-	err := fl.Parse(args, nil)
+	err := fl.Parse(args, nil) // nolint: errcheck
 	if err == nil {
 		t.Fatalf("expected this to fail!")
 	}
@@ -147,7 +147,7 @@ func TestFlagsGroups(t *testing.T) {
 	addr := "192.168.10.1:0"
 	roots := []string{"ab:cd:ef"}
 	args := []string{"--v23.tcp.address=" + addr, "--v23.namespace.root=" + roots[0]}
-	fl.Parse(args, nil)
+	fl.Parse(args, nil) // nolint: errcheck
 	lf := fl.ListenFlags()
 	if got, want := fl.RuntimeFlags().NamespaceRoots.Roots, roots; !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -383,7 +383,7 @@ func TestRefreshDefaults(t *testing.T) {
 	flags.SetDefaultNamespaceRoots(nsRoot)
 	flags.SetDefaultHostPort(hostPort)
 	flags.SetDefaultProtocol("tcp6")
-	fl.Parse([]string{}, nil)
+	fl.Parse([]string{}, nil) // nolint: errcheck
 	rtf := fl.RuntimeFlags()
 	if got, want := rtf.NamespaceRoots.Roots, []string{nsRoot}; !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -395,7 +395,7 @@ func TestRefreshDefaults(t *testing.T) {
 	}
 	changed := "/128.1.1.1:1"
 	flags.SetDefaultNamespaceRoots(changed)
-	fl.Parse([]string{}, nil)
+	fl.Parse([]string{}, nil) // nolint: errcheck
 	rtf = fl.RuntimeFlags()
 	if got, want := rtf.NamespaceRoots.Roots, []string{changed}; !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -412,14 +412,14 @@ func TestRefreshAlreadySetDefaults(t *testing.T) {
 	fl := flags.CreateAndRegister(fs, flags.Runtime, flags.Listen)
 	nsRoot := "/127.0.1.1:10"
 	hostPort := "127.0.0.1:10"
-	fl.Parse([]string{"--v23.namespace.root", nsRoot, "--v23.tcp.address", hostPort}, nil)
+	fl.Parse([]string{"--v23.namespace.root", nsRoot, "--v23.tcp.address", hostPort}, nil) // nolint: errcheck
 	rtf := fl.RuntimeFlags()
 	if got, want := rtf.NamespaceRoots.Roots, []string{nsRoot}; !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 	flags.SetDefaultNamespaceRoots("/128.1.1.1:2")
 	flags.SetDefaultHostPort("128.0.0.1:11")
-	fl.Parse([]string{}, nil)
+	fl.Parse([]string{}, nil) // nolint: errcheck
 	rtf = fl.RuntimeFlags()
 	if got, want := rtf.NamespaceRoots.Roots, []string{nsRoot}; !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)

--- a/x/ref/lib/pubsub/config_test.go
+++ b/x/ref/lib/pubsub/config_test.go
@@ -20,7 +20,7 @@ import (
 func ExamplePublisher() {
 	in := make(chan pubsub.Setting)
 	pub := pubsub.NewPublisher()
-	pub.CreateStream("net", "network settings", in)
+	pub.CreateStream("net", "network settings", in) // nolint: errcheck
 
 	// A simple producer of IP address settings.
 	producer := func() {
@@ -94,7 +94,7 @@ func ExamplePublisher_Shutdown() {
 
 	consumer := func() {
 		ch := make(chan pubsub.Setting, 10)
-		pub.ForkStream("net", ch)
+		pub.ForkStream("net", ch) // nolint: errcheck
 		consumersReady.Done()
 		i := 0
 		for {

--- a/x/ref/lib/raft/client_test.go
+++ b/x/ref/lib/raft/client_test.go
@@ -111,7 +111,7 @@ func buildRafts(t *testing.T, ctx *context.T, n int, config *RaftConfig) ([]*raf
 	// Tell each server about the complete set.
 	for i := range rs {
 		for j := range rs {
-			rs[i].AddMember(ctx, rs[j].Id())
+			rs[i].AddMember(ctx, rs[j].Id()) // nolint: errcheck
 		}
 	}
 	// Start the servers up.
@@ -138,7 +138,7 @@ func restart(t *testing.T, ctx *context.T, rs []*raft, cs []*client, r *raft) {
 		}
 	}
 	for j := range rs {
-		rn.AddMember(ctx, rs[j].Id())
+		rn.AddMember(ctx, rs[j].Id()) // nolint: errcheck
 	}
 	rn.Start()
 }
@@ -159,7 +159,7 @@ func TestClientSnapshot(t *testing.T) {
 	// Make sure the test client works as expected.
 	c := new(client)
 	for i, cmd := range []string{"the", "rain", "in", "spain", "falls", "mainly", "on", "the", "plain"} {
-		c.Apply([]byte(cmd), Index(i))
+		c.Apply([]byte(cmd), Index(i)) // nolint: errcheck
 	}
 	fp, err := ioutil.TempFile(".", "TestClientSnapshot")
 	if err != nil {
@@ -170,8 +170,8 @@ func TestClientSnapshot(t *testing.T) {
 		t.Fatalf("can't write snapshot: %s", err)
 	}
 	<-done
-	fp.Sync()
-	fp.Seek(0, 0)
+	fp.Sync()     // nolint: errcheck
+	fp.Seek(0, 0) // nolint: errcheck
 	nc := new(client)
 	if err != nil {
 		t.Fatalf("can't open snapshot: %s", err)

--- a/x/ref/lib/raft/fspersistence.go
+++ b/x/ref/lib/raft/fspersistence.go
@@ -143,6 +143,7 @@ func (p *fsPersist) VotedFor() string {
 
 // Close implements persistent.Close.
 func (p *fsPersist) Close() {
+	// nolint: errcheck
 	p.lf.Sync()
 	p.lf.Close()
 }
@@ -197,6 +198,7 @@ func (p *fsPersist) ConsiderSnapshot(ctx *context.T, lastAppliedTerm Term, lastA
 	p.Unlock()
 
 	safeToProceed := make(chan struct{})
+	// nolint: errcheck
 	go p.takeSnapshot(ctx, lastAppliedTerm, lastAppliedIndex, safeToProceed)
 	<-safeToProceed
 }
@@ -258,7 +260,7 @@ func (p *fsPersist) trimLog(ctx *context.T, prevTerm Term, prevIndex Index) erro
 
 	// Start using new file.
 	p.encoder = encoder
-	p.syncLog()
+	p.syncLog() // nolint: errcheck
 
 	// Remove some logTail entries.  Try to keep at least half of the entries around in case
 	// we'll need them to update a lagging member.
@@ -420,7 +422,7 @@ func (p *fsPersist) syncLog() error {
 	if err := p.encoder.Encode(ce); err != nil {
 		return fmt.Errorf("syncLog: %s", err)
 	}
-	p.lf.Sync()
+	p.lf.Sync() // nolint: errcheck
 	return nil
 }
 
@@ -676,7 +678,7 @@ func (p *fsPersist) rotateLog() error {
 		return err
 	}
 	p.encoder = encoder
-	p.syncLog()
+	p.syncLog() // nolint: errcheck
 	return nil
 }
 

--- a/x/ref/lib/raft/fspersistence.go
+++ b/x/ref/lib/raft/fspersistence.go
@@ -143,8 +143,7 @@ func (p *fsPersist) VotedFor() string {
 
 // Close implements persistent.Close.
 func (p *fsPersist) Close() {
-	// nolint: errcheck
-	p.lf.Sync()
+	p.lf.Sync() // nolint: errcheck
 	p.lf.Close()
 }
 

--- a/x/ref/lib/raft/raft.go
+++ b/x/ref/lib/raft/raft.go
@@ -155,7 +155,7 @@ func newRaft(ctx *context.T, config *RaftConfig, client RaftClient) (*raft, erro
 	r.leader = ""
 	r.memberMap = make(map[string]*member)
 	r.memberSet = make([]*member, 0)
-	r.AddMember(ctx, config.HostPort)
+	r.AddMember(ctx, config.HostPort) // nolint: errcheck
 	r.me = r.memberMap[config.HostPort]
 
 	// Raft persistent state.
@@ -387,7 +387,7 @@ func (r *raft) startElection() {
 		members = append(members, k)
 	}
 	r.setRoleAndWatchdogTimer(RoleCandidate)
-	r.p.SetVotedFor(r.me.id)
+	r.p.SetVotedFor(r.me.id) // nolint: errcheck
 	r.leader = ""
 	r.Unlock()
 
@@ -428,7 +428,7 @@ func (r *raft) startElection() {
 		if highest > r.p.CurrentTerm() {
 			// If someone answered with a higher term, stop being a candidate.
 			r.setRoleAndWatchdogTimer(RoleFollower)
-			r.p.SetCurrentTerm(highest)
+			r.p.SetCurrentTerm(highest) // nolint: errcheck
 		}
 		vlog.VI(2).Infof("@%s lost election with %d votes", r.me.id, oks)
 		return
@@ -878,14 +878,14 @@ func (r *raft) syncWithLeader(ctx *context.T) error {
 
 		switch role {
 		case RoleLeader:
-			r.waitForApply(ctx, 0, commitIndex)
+			r.waitForApply(ctx, 0, commitIndex) // nolint: errcheck
 			return nil
 		case RoleFollower:
 			client := v23.GetClient(ctx)
 			var index Index
 			err := client.Call(ctx, leader, "Committed", []interface{}{}, []interface{}{&index}, options.Preresolved{})
 			if err == nil {
-				r.waitForApply(ctx, 0, index)
+				r.waitForApply(ctx, 0, index) // nolint: errcheck
 				return nil
 			}
 			// If the leader can't do it, give up.

--- a/x/ref/lib/raft/raft_test.go
+++ b/x/ref/lib/raft/raft_test.go
@@ -163,7 +163,7 @@ func syncer(t *testing.T, ctx *context.T, ch chan struct{}, r *raft, c *client, 
 		if c.TotalApplied() >= n {
 			break
 		}
-		r.Sync(ctx)
+		r.Sync(ctx) // nolint: errcheck
 	}
 	ch <- struct{}{}
 }

--- a/x/ref/lib/raft/service.go
+++ b/x/ref/lib/raft/service.go
@@ -9,7 +9,7 @@ import (
 
 	"v.io/x/lib/vlog"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/rpc"
@@ -97,7 +97,7 @@ func (s *service) RequestVote(ctx *context.T, call rpc.ServerCall, term Term, ca
 	// If the term is higher than the current election term, then we are into a new election.
 	if term > r.p.CurrentTerm() {
 		r.setRoleAndWatchdogTimer(RoleFollower)
-		r.p.SetCurrentTermAndVotedFor(term, "")
+		r.p.SetCurrentTermAndVotedFor(term, "") // nolint: errcheck
 	}
 	vf := r.p.VotedFor()
 
@@ -116,7 +116,7 @@ func (s *service) RequestVote(ctx *context.T, call rpc.ServerCall, term Term, ca
 
 	// Vote for candidate and make sure we're a follower.
 	r.setRole(RoleFollower)
-	r.p.SetCurrentTermAndVotedFor(term, candidate)
+	r.p.SetCurrentTermAndVotedFor(term, candidate) // nolint: errcheck
 	return r.p.CurrentTerm(), true, nil
 }
 
@@ -142,7 +142,7 @@ func (s *service) AppendToLog(ctx *context.T, call rpc.ServerCall, term Term, le
 
 	// Update our term if we are behind.
 	if term > r.p.CurrentTerm() {
-		r.p.SetCurrentTermAndVotedFor(term, "")
+		r.p.SetCurrentTermAndVotedFor(term, "") // nolint: errcheck
 	}
 
 	// Restart our timer since we just heard from the leader.
@@ -212,7 +212,7 @@ func (s *service) InstallSnapshot(ctx *context.T, call raftProtoInstallSnapshotS
 
 	// Update our term if we are behind.
 	if term > r.p.CurrentTerm() {
-		r.p.SetCurrentTermAndVotedFor(term, "")
+		r.p.SetCurrentTermAndVotedFor(term, "") // nolint: errcheck
 	}
 
 	// Restart our timer since we just heard from the leader.

--- a/x/ref/lib/security/blessingstore.go
+++ b/x/ref/lib/security/blessingstore.go
@@ -199,9 +199,9 @@ func dcacheKey(tp security.ThirdPartyCaveat, impetus security.DischargeImpetus) 
 		servers = strings.Join(bps, ",")
 	}
 	h := sha256.New()
-	h.Write(hashString(id))
-	h.Write(hashString(method))
-	h.Write(hashString(servers))
+	h.Write(hashString(id))      // nolint: errcheck
+	h.Write(hashString(method))  // nolint: errcheck
+	h.Write(hashString(servers)) // nolint: errcheck
 	copy(key[:], h.Sum(nil))
 	return key, true
 }

--- a/x/ref/lib/security/forked_principal_test.go
+++ b/x/ref/lib/security/forked_principal_test.go
@@ -22,8 +22,8 @@ func TestFixedBlessingStore(t *testing.T) {
 
 	// Set and SetDefault should fail, other than that, s2 should behave
 	// identically to s1 after setting s1 up
-	s1.Set(b1, security.AllPrincipals)
-	s1.SetDefault(b1)
+	s1.Set(b1, security.AllPrincipals) // nolint: errcheck
+	s1.SetDefault(b1)                  // nolint: errcheck
 
 	if _, err := s2.Set(b2, security.AllPrincipals); err == nil {
 		t.Fatalf("%T.Set should fail", s2)

--- a/x/ref/lib/security/prepare_discharges_test.go
+++ b/x/ref/lib/security/prepare_discharges_test.go
@@ -72,10 +72,22 @@ func TestPrepareDischarges(t *testing.T) {
 		d, _ := p.BlessingStore().Default()
 		return d
 	}
-	security.AddToRoots(pclient, defaultBlessings(pdischarger))
-	security.AddToRoots(pclient, defaultBlessings(v23.GetPrincipal(ctx)))
-	security.AddToRoots(pdischarger, defaultBlessings(pclient))
-	security.AddToRoots(pdischarger, defaultBlessings(v23.GetPrincipal(ctx)))
+	err = security.AddToRoots(pclient, defaultBlessings(pdischarger))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = security.AddToRoots(pclient, defaultBlessings(v23.GetPrincipal(ctx)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = security.AddToRoots(pdischarger, defaultBlessings(pclient))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = security.AddToRoots(pdischarger, defaultBlessings(v23.GetPrincipal(ctx)))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	expcav, err := security.NewExpiryCaveat(time.Now().Add(time.Hour))
 	if err != nil {

--- a/x/ref/lib/stats/histogram/histogram_test.go
+++ b/x/ref/lib/stats/histogram/histogram_test.go
@@ -68,6 +68,6 @@ func BenchmarkHistogram(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		h.Add(int64(i))
+		h.Add(int64(i)) // nolint: errcheck
 	}
 }

--- a/x/ref/lib/stats/stats_test.go
+++ b/x/ref/lib/stats/stats_test.go
@@ -252,8 +252,8 @@ func TestStats(t *testing.T) {
 
 	// Test histogram
 	h := libstats.NewHistogram("rpc/test/hhh", histogram.Options{NumBuckets: 5, GrowthFactor: 0})
-	h.Add(1)
-	h.Add(2)
+	h.Add(1) // nolint: errcheck
+	h.Add(2) // nolint: errcheck
 
 	result, err = doGlob("", "rpc/test/hhh", now, true)
 	if err != nil {
@@ -282,9 +282,9 @@ func TestStats(t *testing.T) {
 	}
 
 	now = now.Add(30 * time.Second)
-	h.Add(2)
+	h.Add(2) // nolint: errcheck
 	now = now.Add(30 * time.Second)
-	h.Add(3)
+	h.Add(3) // nolint: errcheck
 
 	result, err = doGlob("", "rpc/test/hhh/delta1m", now, true)
 	if err != nil {

--- a/x/ref/lib/vdl/build/build.go
+++ b/x/ref/lib/vdl/build/build.go
@@ -660,6 +660,7 @@ func (ds *depSorter) resolveWildcardPath(isDirPath bool, prefix, suffix string) 
 	// Walk through root dirs and subdirs, looking for matches.
 	for _, walk := range walkDirs {
 		goModule, isGoModule := ds.goModules[walk.dir]
+		// nolint: errcheck
 		filepath.Walk(walk.dir, func(dirPath string, info os.FileInfo, err error) error {
 			// Ignore errors and non-directory elements.
 			if err != nil || !info.IsDir() {
@@ -1005,7 +1006,9 @@ func ParsePackage(pkg *Package, opts parse.Opts, errs *vdlutil.Errors) (pfiles [
 		}
 	}
 	sort.Sort(byBaseName(pfiles))
-	pkg.CloseFiles()
+	if err := pkg.CloseFiles(); err != nil {
+		vdlutil.Vlog.Printf("Parsing package %s %q, dir %s: failed to close files: %v", pkg.Name, pkg.Path, pkg.Dir, err)
+	}
 	return
 }
 

--- a/x/ref/lib/vdl/build/build_test.go
+++ b/x/ref/lib/vdl/build/build_test.go
@@ -78,7 +78,7 @@ func TestSrcDirsVDLRoot(t *testing.T) {
 		vdlRoot := test.VDLRoot
 		if vdlRoot != "" && vdlRoot != "/noexist" {
 			vdlRoot = filepath.Join(tmpDir, vdlRoot)
-			os.MkdirAll(vdlRoot, os.ModePerm)
+			os.MkdirAll(vdlRoot, os.ModePerm) // nolint: errcheck
 		}
 		setEnvironment(t, vdlRoot, defaultVDLPath)
 		name := fmt.Sprintf("%+v", test)

--- a/x/ref/runtime/factories/library/library.go
+++ b/x/ref/runtime/factories/library/library.go
@@ -167,7 +167,7 @@ func configuredFlags() []flags.FlagGroup {
 
 // EnableCommandlineFlags enables use of command line flags.
 func EnableCommandlineFlags() {
-	EnableFlags(flag.CommandLine, false)
+	EnableFlags(flag.CommandLine, false) // nolint: errcheck
 }
 
 // EnableFlags enables the use of flags on the specified flag set and returns

--- a/x/ref/runtime/internal/flow/conn/auth_test.go
+++ b/x/ref/runtime/internal/flow/conn/auth_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/flow"
 	"v.io/v23/naming"
@@ -108,7 +108,9 @@ func BlessWithTPCaveat(t *testing.T, ctx *context.T, p security.Principal, s str
 func NewPrincipalWithTPCaveat(t *testing.T, rootCtx *context.T, root *bcrypter.Root, s string) (*context.T, map[string]security.Discharge) {
 	p := testutil.NewPrincipal()
 	blessings, discharges := BlessWithTPCaveat(t, rootCtx, p, s)
-	vsecurity.SetDefaultBlessings(p, blessings)
+	if err := vsecurity.SetDefaultBlessings(p, blessings); err != nil {
+		t.Fatal(err)
+	}
 	ctx, err := v23.WithPrincipal(rootCtx, p)
 	if err != nil {
 		t.Fatal(err)

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -456,6 +456,7 @@ func (c *Conn) newHealthChecksLocked(ctx *context.T, firstRTT time.Duration) *he
 	}
 	requestTimer := time.AfterFunc(c.acceptChannelTimeout/2, func() {
 		c.mu.Lock()
+		// nolint: errcheck
 		c.sendMessageLocked(ctx, true, expressPriority, &message.HealthCheckRequest{})
 		h.requestSent = time.Now()
 		c.mu.Unlock()
@@ -871,6 +872,7 @@ func (c *Conn) handleMessage(ctx *context.T, m message.Message) error {
 
 	case *message.HealthCheckRequest:
 		c.mu.Lock()
+		// nolint: errcheck
 		c.sendMessageLocked(ctx, true, expressPriority, &message.HealthCheckResponse{})
 		c.mu.Unlock()
 
@@ -913,7 +915,7 @@ func (c *Conn) handleMessage(ctx *context.T, m message.Message) error {
 		c.borrowing[msg.ID] = true
 		c.mu.Unlock()
 
-		c.handler.HandleFlow(f)
+		c.handler.HandleFlow(f) // nolint: errcheck
 
 		if err := f.q.put(ctx, msg.Payload); err != nil {
 			return err

--- a/x/ref/runtime/internal/flow/conn/readq_test.go
+++ b/x/ref/runtime/internal/flow/conn/readq_test.go
@@ -27,8 +27,8 @@ func TestReadqRead(t *testing.T) {
 	defer shutdown()
 
 	r := newReadQ(nil, 1)
-	r.put(ctx, mkBufs("one", "two"))
-	r.put(ctx, mkBufs("thre", "reallong"))
+	r.put(ctx, mkBufs("one", "two"))       // nolint: errcheck
+	r.put(ctx, mkBufs("thre", "reallong")) // nolint: errcheck
 	r.close(ctx)
 
 	read := make([]byte, 4)
@@ -54,8 +54,8 @@ func TestReadqGet(t *testing.T) {
 	defer shutdown()
 
 	r := newReadQ(nil, 1)
-	r.put(ctx, mkBufs("one", "two"))
-	r.put(ctx, mkBufs("thre", "reallong"))
+	r.put(ctx, mkBufs("one", "two"))       // nolint: errcheck
+	r.put(ctx, mkBufs("thre", "reallong")) // nolint: errcheck
 	r.close(ctx)
 
 	want := []string{"one", "two", "thre", "reallong"}
@@ -80,8 +80,8 @@ func TestReadqMixed(t *testing.T) {
 	defer shutdown()
 
 	r := newReadQ(nil, 1)
-	r.put(ctx, mkBufs("one", "two"))
-	r.put(ctx, mkBufs("thre", "reallong"))
+	r.put(ctx, mkBufs("one", "two"))       // nolint: errcheck
+	r.put(ctx, mkBufs("thre", "reallong")) // nolint: errcheck
 	r.close(ctx)
 
 	want := []string{"one", "two", "thre", "real", "long"}

--- a/x/ref/runtime/internal/flow/manager/conncache_test.go
+++ b/x/ref/runtime/internal/flow/manager/conncache_test.go
@@ -124,7 +124,9 @@ func TestCacheReserve(t *testing.T) {
 	defer proxycaf.stop(ctx)
 	onecaf := makeConnAndFlow(t, ctx, oneep)
 	defer onecaf.stop(ctx)
-	r1.Unreserve(onecaf.c, proxycaf.c, nil)
+	if err := r1.Unreserve(onecaf.c, proxycaf.c, nil); err != nil {
+		t.Fatal(err)
+	}
 
 	// Now, asking for the ProxyConn on the proxy reservation should find
 	// the proxy, since we just inserted it.
@@ -152,7 +154,9 @@ func TestCacheReserve(t *testing.T) {
 	twocaf := makeConnAndFlow(t, ctx, twoep)
 	defer twocaf.stop(ctx)
 
-	r2.Unreserve(twocaf.c, pc, nil)
+	if err := r2.Unreserve(twocaf.c, pc, nil); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestCacheFind(t *testing.T) {

--- a/x/ref/runtime/internal/flow/manager/manager.go
+++ b/x/ref/runtime/internal/flow/manager/manager.go
@@ -135,13 +135,13 @@ func New(
 			case <-ctx.Done():
 				m.stopListening()
 				m.cache.Close(ctx)
-				stats.Delete(statsPrefix)
+				stats.Delete(statsPrefix) // nolint: errcheck
 				close(m.closed)
 				return
 			case <-m.cacheTicker.C:
 				// Periodically kill closed connections and remove expired connections,
 				// based on the idleExpiry passed to the NewConnCache constructor.
-				m.cache.KillConnections(ctx, 0)
+				m.cache.KillConnections(ctx, 0) // nolint: errcheck
 			}
 		}
 	}()
@@ -882,7 +882,7 @@ func (m *manager) dialReserved(
 		if pc != nil {
 			cpc = pc
 		}
-		res.Unreserve(cc, cpc, err)
+		res.Unreserve(cc, cpc, err) // nolint: errcheck
 		// Note: 'proxy' is true when we are server "listening on" the
 		// proxy. 'pc != nil' is true when we are connecting through a
 		// proxy as a client. Thus, we only want to enable the

--- a/x/ref/runtime/internal/flow/manager/manager_test.go
+++ b/x/ref/runtime/internal/flow/manager/manager_test.go
@@ -163,7 +163,7 @@ func testFlows(t testing.TB, ctx *context.T, dm, am flow.Manager, auth flow.Peer
 		t.Fatal(err)
 	}
 	want := "do you read me?"
-	writeLine(df, want)
+	writeLine(df, want) // nolint: errcheck
 	af, err = am.Accept(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/x/ref/runtime/internal/lib/appcycle/appcycle.go
+++ b/x/ref/runtime/internal/lib/appcycle/appcycle.go
@@ -149,7 +149,7 @@ func (d *invoker) Stop(ctx *context.T, call public.AppCycleStopServerCall) error
 		}
 		actask := public.Task{Progress: task.Progress, Goal: task.Goal}
 		ctx.Infof("AppCycle Stop progress %d/%d", task.Progress, task.Goal)
-		call.SendStream().Send(actask)
+		call.SendStream().Send(actask) // nolint: errcheck
 	}
 	ctx.Infof("AppCycle Stop done")
 	return nil

--- a/x/ref/runtime/internal/lib/pcqueue/pcqueue_test.go
+++ b/x/ref/runtime/internal/lib/pcqueue/pcqueue_test.go
@@ -25,7 +25,7 @@ func TestSimplePut(t *testing.T) {
 	queue := New(0)
 	done := make(chan struct{}, 1)
 	go func() {
-		queue.Put(1, nil)
+		queue.Put(1, nil) // nolint: errcheck
 		done <- struct{}{}
 	}()
 
@@ -68,7 +68,9 @@ func TestSimpleGet(t *testing.T) {
 	default:
 	}
 
-	queue.Put(1, nil)
+	if err := queue.Put(1, nil); err != nil {
+		t.Fatal(err)
+	}
 	<-done
 }
 
@@ -100,7 +102,9 @@ func TestSequential(t *testing.T) {
 	// Generate the sequential ints.
 	logger.Global().VI(1).Infof("Put values")
 	for i := 0; i != elementCount; i++ {
-		queue.Put(i, nil)
+		if err := queue.Put(i, nil); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// Wait for the consumer.
@@ -278,7 +282,7 @@ func TestConcurrentPutNoTimeouts(t *testing.T) {
 		pending.Add(1)
 		go func() {
 			for j := 0; j != elementCount; j++ {
-				queue.Put(j, nil)
+				queue.Put(j, nil) // nolint: errcheck
 			}
 			pending.Done()
 		}()

--- a/x/ref/runtime/internal/lib/pcqueue/pcqueue_test.go
+++ b/x/ref/runtime/internal/lib/pcqueue/pcqueue_test.go
@@ -67,10 +67,7 @@ func TestSimpleGet(t *testing.T) {
 		t.Errorf("Unexpected completion")
 	default:
 	}
-
-	if err := queue.Put(1, nil); err != nil {
-		t.Fatal(err)
-	}
+	queue.Put(1, nil) // nolint: errcheck
 	<-done
 }
 
@@ -102,9 +99,7 @@ func TestSequential(t *testing.T) {
 	// Generate the sequential ints.
 	logger.Global().VI(1).Infof("Put values")
 	for i := 0; i != elementCount; i++ {
-		if err := queue.Put(i, nil); err != nil {
-			t.Fatal(err)
-		}
+		queue.Put(i, nil) // nolint: errcheck
 	}
 
 	// Wait for the consumer.

--- a/x/ref/runtime/internal/lib/sync/semaphore.go
+++ b/x/ref/runtime/internal/lib/sync/semaphore.go
@@ -142,10 +142,10 @@ func (s *Semaphore) TryDecN(n uint) error {
 }
 
 // IncN increments the semaphore.  Wakes any potential waiters.
-func (s *Semaphore) IncN(n uint) error {
+func (s *Semaphore) IncN(n uint) {
 	if n == 0 {
 		// Avoid notifications when there is no change to the value.
-		return nil
+		return
 	}
 
 	s.mu.Lock()
@@ -156,7 +156,6 @@ func (s *Semaphore) IncN(n uint) error {
 	case s.notify <- true:
 	default:
 	}
-	return nil
 }
 
 // Dec decrements the semaphore by 1.
@@ -170,6 +169,6 @@ func (s *Semaphore) TryDec() error {
 }
 
 // Inc increments the semaphore by 1.
-func (s *Semaphore) Inc() error {
-	return s.IncN(1)
+func (s *Semaphore) Inc() {
+	s.IncN(1)
 }

--- a/x/ref/runtime/internal/lib/upcqueue/upcqueue_test.go
+++ b/x/ref/runtime/internal/lib/upcqueue/upcqueue_test.go
@@ -62,9 +62,7 @@ func TestSimpleGet(t *testing.T) {
 	default:
 	}
 
-	if err := queue.Put(1); err != nil {
-		t.Fatal(err)
-	}
+	queue.Put(1) // nolint: errcheck
 	<-done
 }
 
@@ -96,9 +94,7 @@ func TestSequential(t *testing.T) {
 	// Generate the sequential ints.
 	logger.Global().VI(1).Infof("Put values")
 	for i := 0; i != elementCount; i++ {
-		if err := queue.Put(i); err != nil {
-			t.Fatal(err)
-		}
+		queue.Put(i) // nolint: errcheck
 	}
 
 	// Wait for the consumer.

--- a/x/ref/runtime/internal/lib/upcqueue/upcqueue_test.go
+++ b/x/ref/runtime/internal/lib/upcqueue/upcqueue_test.go
@@ -25,7 +25,7 @@ func TestSimplePut(t *testing.T) {
 	queue := New()
 	done := make(chan struct{}, 1)
 	go func() {
-		queue.Put(1)
+		queue.Put(1) // nolint: errcheck
 		done <- struct{}{}
 	}()
 
@@ -62,7 +62,9 @@ func TestSimpleGet(t *testing.T) {
 	default:
 	}
 
-	queue.Put(1)
+	if err := queue.Put(1); err != nil {
+		t.Fatal(err)
+	}
 	<-done
 }
 
@@ -94,7 +96,9 @@ func TestSequential(t *testing.T) {
 	// Generate the sequential ints.
 	logger.Global().VI(1).Infof("Put values")
 	for i := 0; i != elementCount; i++ {
-		queue.Put(i)
+		if err := queue.Put(i); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// Wait for the consumer.
@@ -245,7 +249,7 @@ func TestConcurrentPutNoTimeouts(t *testing.T) {
 		pending.Add(1)
 		go func() {
 			for j := 0; j != elementCount; j++ {
-				queue.Put(j)
+				queue.Put(j) // nolint: errcheck
 			}
 			pending.Done()
 		}()

--- a/x/ref/runtime/internal/naming/namespace/all_test.go
+++ b/x/ref/runtime/internal/naming/namespace/all_test.go
@@ -142,11 +142,11 @@ func (t *testServer) GlobChildren__(_ *context.T, call rpc.GlobChildrenServerCal
 	switch t.suffix {
 	case "":
 		if n := "level1"; m.Match(n) {
-			call.SendStream().Send(naming.GlobChildrenReplyName{Value: n})
+			return call.SendStream().Send(naming.GlobChildrenReplyName{Value: n})
 		}
 	case "level1":
 		if n := "level2"; m.Match(n) {
-			call.SendStream().Send(naming.GlobChildrenReplyName{Value: n})
+			return call.SendStream().Send(naming.GlobChildrenReplyName{Value: n})
 		}
 	default:
 		return nil
@@ -255,7 +255,9 @@ const (
 // in it: mt{1,2,3,4,5}
 func runMountTables(t *testing.T, ctx *context.T) (*serverEntry, map[string]*serverEntry) {
 	root := runMT(t, ctx, "")
-	v23.GetNamespace(ctx).SetRoots(root.name)
+	if err := v23.GetNamespace(ctx).SetRoots(root.name); err != nil {
+		t.Fatal(err)
+	}
 	t.Logf("mountTable %q -> %s", root.mountPoint, root.endpoint)
 
 	mps := make(map[string]*serverEntry)
@@ -354,7 +356,9 @@ func TestNamespaceDetails(t *testing.T) {
 	defer stopper()
 
 	ns := v23.GetNamespace(c)
-	ns.SetRoots(root.name)
+	if err := ns.SetRoots(root.name); err != nil {
+		t.Fatal(err)
+	}
 
 	// /mt2 is not an endpoint. Thus, the example below will fail.
 	mt3Server := mts[mt3MP].name
@@ -409,7 +413,9 @@ func TestNestedMounts(t *testing.T) {
 	defer stopper()
 
 	ns := v23.GetNamespace(c)
-	ns.SetRoots(root.name)
+	if err := ns.SetRoots(root.name); err != nil {
+		t.Fatal(err)
+	}
 
 	// Set up some nested mounts and verify resolution.
 	for _, m := range []string{"mt4/foo", "mt4/foo/bar"} {
@@ -432,7 +438,9 @@ func TestServers(t *testing.T) {
 	root, mts, jokes, stopper := createNamespace(t, sc)
 	defer stopper()
 	ns := v23.GetNamespace(c)
-	ns.SetRoots(root.name)
+	if err := ns.SetRoots(root.name); err != nil {
+		t.Fatal(err)
+	}
 
 	// Let's run some non-mount table services
 	for _, j := range []string{j1MP, j2MP, j3MP} {
@@ -458,7 +466,9 @@ func TestGlob(t *testing.T) {
 	runNestedMountTables(t, sc, mts)
 	defer stopper()
 	ns := v23.GetNamespace(c)
-	ns.SetRoots(root.name)
+	if err := ns.SetRoots(root.name); err != nil {
+		t.Fatal(err)
+	}
 
 	tln := []string{"baz", "mt1", "mt2", "mt3", "mt4", "mt5", "joke1", "joke2", "joke3"}
 	barbaz := []string{"mt4/foo/bar", "mt4/foo/baz"}
@@ -535,7 +545,9 @@ func TestGlobEarlyStop(t *testing.T) {
 	defer runningGlobServer.stop()
 
 	ns := v23.GetNamespace(c)
-	ns.SetRoots(root.name)
+	if err := ns.SetRoots(root.name); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		pattern       string
@@ -568,7 +580,9 @@ func TestCycles(t *testing.T) {
 	root, _, _, stopper := createNamespace(t, sc)
 	defer stopper()
 	ns := v23.GetNamespace(c)
-	ns.SetRoots(root.name)
+	if err := ns.SetRoots(root.name); err != nil {
+		t.Fatal(err)
+	}
 
 	c1 := runMT(t, c, "c1")
 	c2 := runMT(t, c, "c2")
@@ -656,17 +670,27 @@ func TestAuthorizationDuringResolve(t *testing.T) {
 	)
 
 	// Setup default blessings for the processes.
-	idp.Bless(v23.GetPrincipal(rootMtCtx), "rootmt")
-	idp.Bless(v23.GetPrincipal(serverCtx), "server")
-	idp.Bless(v23.GetPrincipal(mtCtx), "childmt")
-	idp.Bless(v23.GetPrincipal(clientCtx), "client")
+	if err := idp.Bless(v23.GetPrincipal(rootMtCtx), "rootmt"); err != nil {
+		t.Fatal(err)
+	}
+	if err := idp.Bless(v23.GetPrincipal(serverCtx), "server"); err != nil {
+		t.Fatal(err)
+	}
+	if err := idp.Bless(v23.GetPrincipal(mtCtx), "childmt"); err != nil {
+		t.Fatal(err)
+	}
+	if err := idp.Bless(v23.GetPrincipal(clientCtx), "client"); err != nil {
+		t.Fatal(err)
+	}
 
 	// Setup the namespace root for all the "processes".
 	rootmt := runMT(t, rootMtCtx, "")
 	defer rootmt.stop()
 
 	for _, ctx := range []*context.T{mtCtx, serverCtx, clientCtx} {
-		v23.GetNamespace(ctx).SetRoots(rootmt.name)
+		if err := v23.GetNamespace(ctx).SetRoots(rootmt.name); err != nil {
+			t.Fatal(err)
+		}
 	}
 	// Disable caching in the client so that any Mount calls by the server
 	// are noticed immediately.
@@ -734,7 +758,9 @@ func TestDelete(t *testing.T) {
 	// Create a root mount table with mount tables mounted at mt1, mt1, ...
 	root, _, _, stopper := createNamespace(t, c)
 	defer stopper()
-	ns.SetRoots(root.name)
+	if err := ns.SetRoots(root.name); err != nil {
+		t.Fatal(err)
+	}
 
 	// We should be able to remove servers below the root.
 	if err := ns.Delete(c, "mt1", false); err != nil {
@@ -770,7 +796,9 @@ func TestLeaf(t *testing.T) {
 	defer func() { root.stop() }()
 
 	ns := v23.GetNamespace(ctx)
-	ns.SetRoots(root.name)
+	if err := ns.SetRoots(root.name); err != nil {
+		t.Fatal(err)
+	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	_, server, err := v23.WithNewServer(ctx, "leaf", &leafObject{}, nil)

--- a/x/ref/runtime/internal/naming/namespace/perms_test.go
+++ b/x/ref/runtime/internal/naming/namespace/perms_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/rpc"
@@ -35,7 +35,9 @@ func initTest() (rootCtx *context.T, aliceCtx *context.T, bobCtx *context.T, shu
 	}
 	for _, r := range []*context.T{rootCtx, aliceCtx, bobCtx} {
 		// A hack to set the namespace roots to a value that won't work.
-		v23.GetNamespace(r).SetRoots()
+		if err := v23.GetNamespace(r).SetRoots(); err != nil {
+			panic(err)
+		}
 		// And have all principals recognize each others blessings.
 		p1 := v23.GetPrincipal(r)
 		for _, other := range []*context.T{rootCtx, aliceCtx, bobCtx} {
@@ -131,7 +133,9 @@ func TestPermissions(t *testing.T) {
 	fmt.Printf("rmt at %s\n", rmtAddr)
 	defer stop()
 	ns := v23.GetNamespace(rootCtx)
-	ns.SetRoots("/" + rmtAddr)
+	if err := ns.SetRoots("/" + rmtAddr); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create lower mount table.
 	stop1, mt1Addr := newMT(t, rootCtx)

--- a/x/ref/runtime/internal/rpc/benchmark/internal/server.go
+++ b/x/ref/runtime/internal/rpc/benchmark/internal/server.go
@@ -26,7 +26,7 @@ func (i *impl) EchoStream(_ *context.T, call benchmark.BenchmarkEchoStreamServer
 	rStream := call.RecvStream()
 	sStream := call.SendStream()
 	for rStream.Advance() {
-		sStream.Send(rStream.Value())
+		sStream.Send(rStream.Value()) // nolint: errcheck
 	}
 	if err := rStream.Err(); err != nil {
 		return err

--- a/x/ref/runtime/internal/rpc/benchmark/proto_test.go
+++ b/x/ref/runtime/internal/rpc/benchmark/proto_test.go
@@ -13,8 +13,9 @@
 package benchmark
 
 import (
-	"github.com/golang/protobuf/proto"
 	"testing"
+
+	"github.com/golang/protobuf/proto"
 )
 
 var echoStr = "Echo"
@@ -56,7 +57,9 @@ var protoResp = &RpcResponse{
 
 func BenchmarkProtoEncodeRequest(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		proto.Marshal(protoReq)
+		if _, err := proto.Marshal(protoReq); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -69,13 +72,17 @@ func BenchmarkProtoDecodeRequest(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		response := RpcResponse{}
-		proto.Unmarshal(bytes, &response)
+		if err := proto.Unmarshal(bytes, &response); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
 func BenchmarkProtoEncodeResponse(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		proto.Marshal(protoResp)
+		if _, err := proto.Marshal(protoResp); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -88,6 +95,8 @@ func BenchmarkProtoDecodeResponse(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		response := RpcResponse{}
-		proto.Unmarshal(bytes, &response)
+		if err := proto.Unmarshal(bytes, &response); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/x/ref/runtime/internal/rpc/reserved.go
+++ b/x/ref/runtime/internal/rpc/reserved.go
@@ -227,6 +227,7 @@ func (i *globInternal) Glob(ctx *context.T, call rpc.StreamServerCall, pattern s
 		suffix := subcall.Suffix()
 		if state.depth > maxRecursiveGlobDepth {
 			ctx.Errorf("rpc Glob: exceeded recursion limit (%d): %q", maxRecursiveGlobDepth, suffix)
+			// nolint: errcheck
 			subcall.Send(naming.GlobReplyError{
 				Value: naming.GlobError{Name: state.name, Error: reserved.NewErrGlobMaxRecursionReached(ctx)},
 			})
@@ -235,6 +236,7 @@ func (i *globInternal) Glob(ctx *context.T, call rpc.StreamServerCall, pattern s
 		obj, auth, err := disp.Lookup(ctx, suffix)
 		if err != nil {
 			ctx.VI(3).Infof("rpc Glob: Lookup failed for %q: %v", suffix, err)
+			// nolint: errcheck
 			subcall.Send(naming.GlobReplyError{
 				Value: naming.GlobError{Name: state.name, Error: verror.Convert(verror.ErrNoExist, ctx, err)},
 			})
@@ -242,6 +244,7 @@ func (i *globInternal) Glob(ctx *context.T, call rpc.StreamServerCall, pattern s
 		}
 		if obj == nil {
 			ctx.VI(3).Infof("rpc Glob: object not found for %q", suffix)
+			// nolint: errcheck
 			subcall.Send(naming.GlobReplyError{
 				Value: naming.GlobError{Name: state.name, Error: verror.New(verror.ErrNoExist, ctx, "nil object")},
 			})
@@ -260,6 +263,7 @@ func (i *globInternal) Glob(ctx *context.T, call rpc.StreamServerCall, pattern s
 		invoker, err := objectToInvoker(obj)
 		if err != nil {
 			ctx.VI(3).Infof("rpc Glob: object for %q cannot be converted to invoker: %v", suffix, err)
+			// nolint: errcheck
 			subcall.Send(naming.GlobReplyError{
 				Value: naming.GlobError{Name: state.name, Error: verror.Convert(verror.ErrInternal, ctx, err)},
 			})
@@ -268,10 +272,12 @@ func (i *globInternal) Glob(ctx *context.T, call rpc.StreamServerCall, pattern s
 		gs := invoker.Globber()
 		if gs == nil || (gs.AllGlobber == nil && gs.ChildrenGlobber == nil) {
 			if state.glob.Len() == 0 {
+				// nolint: errcheck
 				subcall.Send(naming.GlobReplyEntry{
 					Value: naming.MountEntry{Name: state.name, IsLeaf: true},
 				})
 			} else {
+				// nolint: errcheck
 				subcall.Send(naming.GlobReplyError{
 					Value: naming.GlobError{Name: state.name, Error: reserved.NewErrGlobNotImplemented(ctx)},
 				})
@@ -298,6 +304,7 @@ func (i *globInternal) Glob(ctx *context.T, call rpc.StreamServerCall, pattern s
 			}
 			if err := gs.AllGlobber.Glob__(ctx, &globServerCall{subcall, send}, state.glob); err != nil {
 				ctx.VI(3).Infof("rpc Glob: %q.Glob(%q) failed: %v", suffix, state.glob, err)
+				// nolint: errcheck
 				subcall.Send(naming.GlobReplyError{
 					Value: naming.GlobError{Name: state.name, Error: verror.Convert(verror.ErrInternal, ctx, err)},
 				})
@@ -309,6 +316,7 @@ func (i *globInternal) Glob(ctx *context.T, call rpc.StreamServerCall, pattern s
 			depth := state.depth
 			if state.glob.Len() == 0 {
 				// The glob pattern matches the current object.
+				// nolint: errcheck
 				subcall.Send(naming.GlobReplyEntry{
 					Value: naming.MountEntry{Name: state.name},
 				})
@@ -340,11 +348,13 @@ func (i *globInternal) Glob(ctx *context.T, call rpc.StreamServerCall, pattern s
 					queue = append(queue, gState{next, tail, depth})
 				case naming.GlobChildrenReplyError:
 					v.Value.Name = naming.Join(state.name, v.Value.Name)
+					// nolint: errcheck
 					return subcall.Send(naming.GlobReplyError(v))
 				}
 				return nil
 			}
 			if err := gs.ChildrenGlobber.GlobChildren__(ctx, &globChildrenServerCall{subcall, send}, matcher); err != nil {
+				// nolint: errcheck
 				subcall.Send(naming.GlobReplyError{
 					Value: naming.GlobError{Name: state.name, Error: verror.Convert(verror.ErrInternal, ctx, err)},
 				})
@@ -353,6 +363,7 @@ func (i *globInternal) Glob(ctx *context.T, call rpc.StreamServerCall, pattern s
 		}
 	}
 	if someMatchesOmitted {
+		// nolint: errcheck
 		call.Send(naming.GlobReplyError{
 			Value: naming.GlobError{Error: reserved.NewErrGlobMatchesOmitted(ctx)},
 		})

--- a/x/ref/runtime/internal/rpc/stats.go
+++ b/x/ref/runtime/internal/rpc/stats.go
@@ -71,7 +71,7 @@ func (o *outstandingStats) String() string {
 }
 
 func (o *outstandingStats) close() {
-	stats.Delete(o.prefix)
+	stats.Delete(o.prefix) // nolint: errcheck
 }
 
 func (o *outstandingStats) start(method string, remote naming.Endpoint) func() {
@@ -111,7 +111,7 @@ type perMethodStats struct {
 }
 
 func (s *rpcStats) stop() {
-	stats.Delete(s.prefix)
+	stats.Delete(s.prefix) // nolint: errcheck
 }
 
 func (s *rpcStats) record(method string, latency time.Duration) {
@@ -124,7 +124,7 @@ func (s *rpcStats) record(method string, latency time.Duration) {
 	if !ok {
 		m = s.newPerMethodStats(method)
 	}
-	m.latency.Add(int64(latency / time.Millisecond))
+	m.latency.Add(int64(latency / time.Millisecond)) // nolint: errcheck
 }
 
 // nolint: deadcode, unused

--- a/x/ref/runtime/internal/rpc/stress/internal/server.go
+++ b/x/ref/runtime/internal/rpc/stress/internal/server.go
@@ -47,7 +47,7 @@ func (s *impl) SumStream(_ *context.T, call stress.StressSumStreamServerCall) er
 		if err != nil {
 			return err
 		}
-		sStream.Send(sum)
+		sStream.Send(sum) // nolint: errcheck
 		bytesRecv += uint64(lenSumArg(&arg))
 		bytesSent += uint64(len(sum))
 	}

--- a/x/ref/runtime/internal/rpc/stress/mtstress/run.go
+++ b/x/ref/runtime/internal/rpc/stress/mtstress/run.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 
 	"v.io/x/ref/lib/stats/histogram"
@@ -74,7 +74,7 @@ func run(f func(*context.T) (time.Duration, error), p params) error {
 			go call(p.Context, f, p.Reauthenticate, latency)
 		case d := <-latency:
 			if ret.HistMS != nil {
-				ret.HistMS.Add(int64(d / time.Millisecond))
+				ret.HistMS.Add(int64(d / time.Millisecond)) // nolint: errcheck
 			}
 			ret.Count++
 			sumMS += int64(d / time.Millisecond)
@@ -123,7 +123,7 @@ func warmup(ctx *context.T, f func(*context.T) (time.Duration, error)) {
 	for i := 0; i < nWarmup; i++ {
 		wg.Add(1)
 		go func() {
-			f(ctx)
+			f(ctx) // nolint: errcheck
 			wg.Done()
 		}()
 	}

--- a/x/ref/runtime/internal/rpc/test/client_test.go
+++ b/x/ref/runtime/internal/rpc/test/client_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/flow"
 	"v.io/v23/flow/message"
@@ -288,7 +288,9 @@ func TestStartCallErrors(t *testing.T) {
 	// This will fail with NoServers, but because there is no mount table
 	// to communicate with. The error message should include a
 	// 'connection refused' string.
-	ns.SetRoots("/127.0.0.1:8101")
+	if err := ns.SetRoots("/127.0.0.1:8101"); err != nil {
+		t.Fatal(err)
+	}
 	_, err = client.StartCall(ctx, "noname", "nomethod", nil, options.NoRetry{})
 	if verror.ErrorID(err) != verror.ErrNoServers.ID {
 		t.Errorf("wrong error: %s", err)
@@ -339,7 +341,9 @@ func TestStartCallErrors(t *testing.T) {
 	}
 
 	// The following two tests will fail due to a timeout.
-	ns.SetRoots("/203.0.113.10:8101")
+	if err := ns.SetRoots("/203.0.113.10:8101"); err != nil {
+		t.Fatal(err)
+	}
 	var cancel context.CancelFunc
 	nctx, cancel = context.WithTimeout(ctx, 100*time.Millisecond)
 	// This call will either timeout talking to the mount table or indicate
@@ -495,7 +499,9 @@ func TestAccessDenied(t *testing.T) {
 	ctx1, err := v23.WithPrincipal(ctx, testutil.NewPrincipal("test-blessing"))
 	// Client must recognize the server, otherwise it won't even send the request.
 	bserver, _ := v23.GetPrincipal(ctx).BlessingStore().Default()
-	security.AddToRoots(v23.GetPrincipal(ctx1), bserver)
+	if err := security.AddToRoots(v23.GetPrincipal(ctx1), bserver); err != nil {
+		t.Fatal(err)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -640,7 +646,9 @@ func TestStreamAbort(t *testing.T) {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	}
-	call.CloseSend()
+	if err := call.CloseSend(); err != nil {
+		t.Fatal(err)
+	}
 	err = call.Send(100)
 	if got, want := verror.ErrorID(err), verror.ErrAborted.ID; got != want {
 		t.Fatalf("got %v, want %v", got, want)
@@ -679,7 +687,9 @@ func TestNoMountTable(t *testing.T) {
 	_, ctx, _, cleanup := testInit(t, false)
 	defer cleanup()
 
-	v23.GetNamespace(ctx).SetRoots()
+	if err := v23.GetNamespace(ctx).SetRoots(); err != nil {
+		t.Fatal(err)
+	}
 	name := "a_mount_table_entry"
 
 	// If there is no mount table, then we'll get a NoServers error message.
@@ -959,7 +969,9 @@ func TestPinConnection(t *testing.T) {
 	if got, want := call.Security().LocalEndpoint().String(), pinnedConn.Conn().LocalEndpoint().String(); got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
-	call.Finish()
+	if err := call.Finish(); err != nil {
+		t.Fatal(err)
+	}
 
 	// Closing the original conn should automatically reconnect to the server.
 	origConn := pinnedConn.Conn()

--- a/x/ref/runtime/internal/rpc/test/glob_test.go
+++ b/x/ref/runtime/internal/rpc/test/glob_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/glob"
 	"v.io/v23/i18n"
@@ -297,7 +297,7 @@ func (o *globObject) Glob__(ctx *context.T, call rpc.GlobServerCall, g *glob.Glo
 
 func (o *globObject) globLoop(call rpc.GlobServerCall, name string, g *glob.Glob, n *node) {
 	if g.Len() == 0 {
-		call.SendStream().Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: name}})
+		call.SendStream().Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: name}}) // nolint: errcheck
 	}
 	if g.Empty() {
 		return
@@ -318,7 +318,9 @@ func (o *vChildrenObject) GlobChildren__(ctx *context.T, call rpc.GlobChildrenSe
 	sender := call.SendStream()
 	for child := range o.n.children {
 		if m.Match(child) {
-			sender.Send(naming.GlobChildrenReplyName{Value: child})
+			if err := sender.Send(naming.GlobChildrenReplyName{Value: child}); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/x/ref/runtime/internal/rpc/test/server_test.go
+++ b/x/ref/runtime/internal/rpc/test/server_test.go
@@ -302,7 +302,9 @@ func TestUpdateServerBlessings(t *testing.T) {
 	idp := testutil.IDProviderFromPrincipal(v23.GetPrincipal(ctx))
 
 	serverp := testutil.NewPrincipal()
-	idp.Bless(serverp, "b1")
+	if err := idp.Bless(serverp, "b1"); err != nil {
+		t.Error(err)
+	}
 	sctx, err := v23.WithPrincipal(ctx, serverp)
 	if err != nil {
 		t.Error(err)
@@ -336,7 +338,9 @@ func TestUpdateServerBlessings(t *testing.T) {
 
 	// Now we bless the server with a new blessing (which will change its default
 	// blessing).  Then we wait for the new value to propogate to the remote end.
-	idp.Bless(serverp, "b2")
+	if err := idp.Bless(serverp, "b2"); err != nil {
+		t.Error(err)
+	}
 	want = "test-blessing:b2"
 	for {
 		bs, err := mountedBlessings(ctx, "server")

--- a/x/ref/runtime/internal/rt/rpc_test.go
+++ b/x/ref/runtime/internal/rt/rpc_test.go
@@ -97,8 +97,12 @@ func TestClientServerBlessings(t *testing.T) {
 		betaServer  = mkBlessings(rootBeta.NewBlessings(pserver, "server"))
 	)
 	// Setup the client's blessing store
-	pclient.BlessingStore().Set(alphaClient, "alpha:server")
-	pclient.BlessingStore().Set(betaClient, "beta")
+	if _, err := pclient.BlessingStore().Set(alphaClient, "alpha:server"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pclient.BlessingStore().Set(betaClient, "beta"); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		server security.Blessings // Blessings presented by the server.
@@ -332,6 +336,6 @@ func TestServerDischarges(t *testing.T) {
 	if err == nil {
 		remote, _ := call.RemoteBlessings()
 		t.Errorf("client.StartCall passed unexpectedly with remote end authenticated as: %v", remote)
-		call.Finish()
+		call.Finish() // nolint: errcheck
 	}
 }

--- a/x/ref/runtime/internal/rt/rt_test.go
+++ b/x/ref/runtime/internal/rt/rt_test.go
@@ -25,7 +25,9 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	ref.EnvClearCredentials()
+	if err := ref.EnvClearCredentials(); err != nil {
+		t.Fatal(err)
+	}
 	ctx, shutdown := test.V23Init()
 	defer shutdown()
 
@@ -82,7 +84,7 @@ func TestInitArgs(t *testing.T) {
 		"log_backtrace_at=:0",
 		os.TempDir()))
 	c.Terminate(os.Interrupt)
-	c.S.ExpectEOF()
+	c.S.ExpectEOF() // nolint: errcheck
 }
 
 func validatePrincipal(p security.Principal) error {

--- a/x/ref/runtime/internal/rt/shutdown_test.go
+++ b/x/ref/runtime/internal/rt/shutdown_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func writeln(w io.Writer, s string) {
-	w.Write([]byte(s + "\n"))
+	w.Write([]byte(s + "\n")) // nolint: errcheck
 }
 
 // TestSimpleServerSignal verifies that sending a signal to the simple server
@@ -33,7 +33,9 @@ func TestSimpleServerSignal(t *testing.T) {
 	c.S.Expect("Interruptible cleanup")
 	c.S.Expect("Deferred cleanup")
 	writeln(stdin, "close")
-	c.S.ExpectEOF()
+	if err := c.S.ExpectEOF(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestSimpleServerLocalStop verifies that sending a local stop command to the
@@ -50,7 +52,9 @@ func TestSimpleServerLocalStop(t *testing.T) {
 	c.S.Expect("Interruptible cleanup")
 	c.S.Expect("Deferred cleanup")
 	writeln(stdin, "close")
-	c.S.ExpectEOF()
+	if err := c.S.ExpectEOF(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestSimpleServerDoubleSignal verifies that sending a succession of two
@@ -135,7 +139,9 @@ func TestComplexServerSignal(t *testing.T) {
 		"Parallel interruptible cleanup1",
 		"Parallel interruptible cleanup2")
 	writeln(stdin, "close")
-	c.S.ExpectEOF()
+	if err := c.S.ExpectEOF(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestComplexServerLocalStop verifies that sending a local stop command to the
@@ -160,7 +166,9 @@ func TestComplexServerLocalStop(t *testing.T) {
 		"Parallel interruptible cleanup2",
 	)
 	writeln(stdin, "close")
-	c.S.ExpectEOF()
+	if err := c.S.ExpectEOF(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestComplexServerDoubleSignal verifies that sending a succession of two

--- a/x/ref/runtime/internal/rt/shutdown_test.go
+++ b/x/ref/runtime/internal/rt/shutdown_test.go
@@ -33,9 +33,7 @@ func TestSimpleServerSignal(t *testing.T) {
 	c.S.Expect("Interruptible cleanup")
 	c.S.Expect("Deferred cleanup")
 	writeln(stdin, "close")
-	if err := c.S.ExpectEOF(); err != nil {
-		t.Fatal(err)
-	}
+	c.S.ExpectEOF() // nolint: errcheck
 }
 
 // TestSimpleServerLocalStop verifies that sending a local stop command to the
@@ -52,9 +50,7 @@ func TestSimpleServerLocalStop(t *testing.T) {
 	c.S.Expect("Interruptible cleanup")
 	c.S.Expect("Deferred cleanup")
 	writeln(stdin, "close")
-	if err := c.S.ExpectEOF(); err != nil {
-		t.Fatal(err)
-	}
+	c.S.ExpectEOF() // nolint: errcheck
 }
 
 // TestSimpleServerDoubleSignal verifies that sending a succession of two
@@ -139,9 +135,7 @@ func TestComplexServerSignal(t *testing.T) {
 		"Parallel interruptible cleanup1",
 		"Parallel interruptible cleanup2")
 	writeln(stdin, "close")
-	if err := c.S.ExpectEOF(); err != nil {
-		t.Fatal(err)
-	}
+	c.S.ExpectEOF() // nolint: errcheck
 }
 
 // TestComplexServerLocalStop verifies that sending a local stop command to the
@@ -166,9 +160,7 @@ func TestComplexServerLocalStop(t *testing.T) {
 		"Parallel interruptible cleanup2",
 	)
 	writeln(stdin, "close")
-	if err := c.S.ExpectEOF(); err != nil {
-		t.Fatal(err)
-	}
+	c.S.ExpectEOF() // nolint: errcheck
 }
 
 // TestComplexServerDoubleSignal verifies that sending a succession of two

--- a/x/ref/runtime/internal/rt/signal_test.go
+++ b/x/ref/runtime/internal/rt/signal_test.go
@@ -49,10 +49,10 @@ func TestWithRuntime(t *testing.T) {
 	// The Vanadium runtime spawns a goroutine that listens for SIGHUP and
 	// prevents process exit.
 	c.Signal(syscall.SIGHUP)
-	stdin.Write([]byte("foo\n"))
+	stdin.Write([]byte("foo\n")) // nolint: errcheck
 	c.S.Expect("foo")
 	c.Terminate(os.Interrupt)
-	c.S.ExpectEOF()
+	c.S.ExpectEOF() // nolint: errcheck
 }
 
 func TestWithoutRuntime(t *testing.T) {
@@ -66,5 +66,5 @@ func TestWithoutRuntime(t *testing.T) {
 	c.S.Expect("ready")
 	// Processes without a Vanadium runtime should exit on SIGHUP.
 	c.Terminate(syscall.SIGHUP)
-	c.S.ExpectEOF()
+	c.S.ExpectEOF() // nolint: errcheck
 }

--- a/x/ref/runtime/internal/vtrace/store_test.go
+++ b/x/ref/runtime/internal/vtrace/store_test.go
@@ -118,8 +118,14 @@ func TestRegexp(t *testing.T) {
 			t.Fatalf("Could not create store: %v", err)
 		}
 
-		newSpan(traces[0], "foo", traces[0], st)
-		newSpan(traces[1], "foobar", traces[1], st)
+		_, err = newSpan(traces[0], "foo", traces[0], st)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = newSpan(traces[1], "foobar", traces[1], st)
+		if err != nil {
+			t.Fatal(err)
+		}
 		sp, err := newSpan(traces[2], "baz", traces[2], st)
 		if err != nil {
 			t.Fatal(err)

--- a/x/ref/runtime/internal/vtrace/vtrace_logging_test.go
+++ b/x/ref/runtime/internal/vtrace/vtrace_logging_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/v23/vtrace"
@@ -62,7 +62,7 @@ func startLoggingServer(ctx *context.T, idp *testutil.IDProvider) error {
 	}
 	// Make sure the server is mounted to avoid any retries in when StartCall
 	// is invoked in runCallChain which complicate the span comparisons.
-	verifyMount(ctx, "logger")
+	verifyMount(ctx, "logger") // nolint: errcheck
 	return nil
 }
 

--- a/x/ref/runtime/internal/vtrace/vtrace_test.go
+++ b/x/ref/runtime/internal/vtrace/vtrace_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/v23/security"
@@ -131,7 +131,7 @@ func makeChainedTestServers(ctx *context.T, idp *testutil.IDProvider, force ...b
 		out = append(out, c)
 		// Make sure the server is mounted to avoid any retries in when StartCall
 		// is invoked in runCallChain which complicate the span comparisons.
-		verifyMount(ctx, name)
+		verifyMount(ctx, name) // nolint: errcheck
 	}
 	return out, nil
 }
@@ -334,7 +334,9 @@ func TestTracePermissions(t *testing.T) {
 
 	// Create a different principal for the server.
 	pserver := testutil.NewPrincipal()
-	idp.Bless(pserver, "server")
+	if err := idp.Bless(pserver, "server"); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, tc := range cases {
 		ctx2 := v23.WithReservedNameDispatcher(ctx, debugDispatcher(tc.perms))

--- a/x/ref/runtime/protocols/lib/websocket/conn.go
+++ b/x/ref/runtime/protocols/lib/websocket/conn.go
@@ -76,6 +76,7 @@ func (c *wrappedConn) Close() error {
 	// Send an EOF control message to the remote end so that it can
 	// handle the close gracefully.
 	msg := websocket.FormatCloseMessage(websocket.CloseGoingAway, "EOF")
+	// nolint: errcheck
 	c.ws.WriteControl(websocket.CloseMessage, msg, time.Now().Add(time.Second))
 	return c.ws.Close()
 }

--- a/x/ref/runtime/protocols/lib/websocket/conn_test.go
+++ b/x/ref/runtime/protocols/lib/websocket/conn_test.go
@@ -23,7 +23,7 @@ import (
 func writer(c flow.Conn, data []byte, times int, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for i := 0; i < times; i++ {
-		c.WriteMsg(data)
+		c.WriteMsg(data) // nolint: errcheck
 	}
 }
 
@@ -90,5 +90,5 @@ func TestMultipleGoRoutines(t *testing.T) {
 		conn.Close()
 		l.Close()
 	}()
-	s.Serve(l)
+	s.Serve(l) // nolint: errcheck
 }

--- a/x/ref/runtime/protocols/lib/websocket/listener.go
+++ b/x/ref/runtime/protocols/lib/websocket/listener.go
@@ -49,7 +49,7 @@ func listener(protocol, address string, hybrid bool) (flow.Listener, error) {
 	}
 	go ln.netAcceptLoop()
 	httpsrv := http.Server{Handler: ln}
-	go httpsrv.Serve(&chanListener{Listener: netLn, c: ln.httpQ})
+	go httpsrv.Serve(&chanListener{Listener: netLn, c: ln.httpQ}) // nolint: errcheck
 	return ln, nil
 }
 
@@ -140,8 +140,8 @@ func (ln *wsTCPListener) classify(conn net.Conn, done *sync.WaitGroup) {
 	defer done.Done()
 	isHTTP := true
 	if ln.hybrid {
-		conn.SetReadDeadline(time.Now().Add(classificationTime))
-		defer conn.SetReadDeadline(time.Time{})
+		conn.SetReadDeadline(time.Now().Add(classificationTime)) // nolint: errcheck
+		defer conn.SetReadDeadline(time.Time{})                  // nolint: errcheck
 		var magic [1]byte
 		n, err := io.ReadFull(conn, magic[:])
 		if err != nil {

--- a/x/ref/runtime/protocols/lib/websocket/listener_test.go
+++ b/x/ref/runtime/protocols/lib/websocket/listener_test.go
@@ -47,7 +47,7 @@ func TestAcceptsAreNotSerialized(t *testing.T) {
 		close(portscan)
 		// Keep the connection alive by blocking on a read.  (The read
 		// should return once the test exits).
-		conn.Read(make([]byte, 1024))
+		conn.Read(make([]byte, 1024)) // nolint: errcheck
 	}()
 	// Another client that dials a legitimate connection should not be
 	// blocked on the portscanner.
@@ -87,8 +87,8 @@ func TestNonWebsocketRequest(t *testing.T) {
 		t.Error(err)
 	}
 	for i := 0; i < 2; i++ {
-		conn.Write([]byte("GET / HTTP/1.1\r\n\r\n"))
-		conn.Read(make([]byte, 1024))
+		conn.Write([]byte("GET / HTTP/1.1\r\n\r\n")) // nolint: errcheck
+		conn.Read(make([]byte, 1024))                // nolint: errcheck
 	}
 
 	logs := out.String()

--- a/x/ref/runtime/protocols/lib/websocket/ws.go
+++ b/x/ref/runtime/protocols/lib/websocket/ws.go
@@ -37,7 +37,7 @@ func (WS) Dial(ctx *context.T, protocol, address string, timeout time.Duration) 
 	if err != nil {
 		return nil, err
 	}
-	conn.SetReadDeadline(deadline)
+	conn.SetReadDeadline(deadline) // nolint: errcheck
 	if err := tcputil.EnableTCPKeepAlive(conn); err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (WS) Dial(ctx *context.T, protocol, address string, timeout time.Duration) 
 		return nil, err
 	}
 	var zero time.Time
-	conn.SetDeadline(zero)
+	conn.SetDeadline(zero) // nolint: errcheck
 	return WebsocketConn(ws), nil
 }
 

--- a/x/ref/services/agent/agentlib/agent_test.go
+++ b/x/ref/services/agent/agentlib/agent_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/security"
 	"v.io/x/lib/gosh"
 	_ "v.io/x/ref/runtime/factories/generic"
@@ -47,7 +47,7 @@ var getPrincipalAndHang = gosh.RegisterFunc("getPrincipalAndHang", func() {
 	defer shutdown()
 	b, _ := v23.GetPrincipal(ctx).BlessingStore().Default()
 	fmt.Printf("DEFAULT_BLESSING=%s\n", b)
-	ioutil.ReadAll(os.Stdin)
+	ioutil.ReadAll(os.Stdin) // nolint: errcheck
 })
 
 func newAgent(path string, cached bool) (security.Principal, error) {

--- a/x/ref/services/agent/agentlib/client.go
+++ b/x/ref/services/agent/agentlib/client.go
@@ -73,7 +73,9 @@ func results(inputs ...interface{}) []interface{} {
 func newUncachedPrincipalX(path string, timeout time.Duration) (*client, error) {
 	caller := new(ipcCaller)
 	i := ipc.NewIPC()
-	i.Serve(caller)
+	if err := i.Serve(caller); err != nil {
+		return nil, err
+	}
 	conn, err := i.Connect(path, timeout)
 	if err != nil {
 		return nil, err

--- a/x/ref/services/agent/agentlib/principal.go
+++ b/x/ref/services/agent/agentlib/principal.go
@@ -57,7 +57,7 @@ func loadPrincipalLocally(credentials string) (agent.Principal, error) {
 	if err := credsLock.Lock(); err != nil {
 		return nil, err
 	}
-	defer credsLock.Unlock()
+	defer credsLock.Unlock() // nolint: errcheck
 	if err := os.MkdirAll(agentDir, 0700); err != nil {
 		return nil, err
 	}

--- a/x/ref/services/agent/gcreds/main.go
+++ b/x/ref/services/agent/gcreds/main.go
@@ -106,7 +106,7 @@ func runGcreds(ctx *context.T, env *cmdline.Env, args []string) error {
 		return err
 	}
 
-	ref.EnvClearCredentials()
+	ref.EnvClearCredentials() // nolint: errcheck
 	if err := os.Setenv(ref.EnvAgentPath, socketPath); err != nil {
 		return err
 	}

--- a/x/ref/services/agent/internal/cache/cache_test.go
+++ b/x/ref/services/agent/internal/cache/cache_test.go
@@ -152,7 +152,7 @@ func TestRootsDump(t *testing.T) {
 		t.Errorf("Dump() got %v, want %v", got, orig)
 	}
 
-	impl.Add(key, "carol")
+	impl.Add(key, "carol") // nolint: errcheck
 	if got := cache.Dump(); !reflect.DeepEqual(orig, got) {
 		t.Errorf("Dump() got %v, want %v", got, orig)
 	}
@@ -234,7 +234,7 @@ func TestSet(t *testing.T) {
 	}
 	john, _ := testutil.NewPrincipal("john").BlessingStore().Default()
 
-	store.Set(noBlessings, "...")
+	store.Set(noBlessings, "...") // nolint: errcheck
 	if _, err := cache.Set(bob, "bob"); err != nil {
 		t.Errorf("Set() failed: %v", err)
 	}
@@ -290,14 +290,14 @@ func TestForPeerCaching(t *testing.T) {
 		t.Fatalf("BlessSelf failed: %v", err)
 	}
 
-	store.Set(security.Blessings{}, "...")
-	store.Set(bob, "bob")
+	store.Set(security.Blessings{}, "...") // nolint: errcheck
+	store.Set(bob, "bob")                  // nolint: errcheck
 
 	if got := cache.ForPeer("bob:server"); !reflect.DeepEqual(bob, got) {
 		t.Errorf("ForPeer(bob:server) got: %v, want: %v", got, bob)
 	}
 
-	store.Set(alice, "bob")
+	store.Set(alice, "bob") // nolint: errcheck
 	if got := cache.ForPeer("bob:server"); !reflect.DeepEqual(bob, got) {
 		t.Errorf("ForPeer(bob:server) got: %v, want: %v", got, bob)
 	}
@@ -326,7 +326,7 @@ func TestPeerBlessings(t *testing.T) {
 		t.Errorf("PeerBlessings() got %v, want %v", got, orig)
 	}
 
-	store.Set(alice, "carol")
+	store.Set(alice, "carol") // nolint: errcheck
 	if got := cache.PeerBlessings(); !reflect.DeepEqual(orig, got) {
 		t.Errorf("PeerBlessings() got %v, want %v", got, orig)
 	}

--- a/x/ref/services/agent/internal/ipc/ipc.go
+++ b/x/ref/services/agent/internal/ipc/ipc.go
@@ -445,7 +445,10 @@ func (ipc *IPC) handleResp(c *IPCConn, resp agent.RpcResponse) error {
 		info.done <- resp.Err
 	} else {
 		for i := uint32(0); i < resp.NumArgs; i++ {
-			c.dec.Decoder().SkipValue()
+			if err := c.dec.Decoder().SkipValue(); err != nil {
+				info.done <- fmt.Errorf("failed to skip value: %w", err)
+				return err
+			}
 		}
 		err := resp.Err
 		if err == nil {

--- a/x/ref/services/agent/internal/ipc/ipc_test.go
+++ b/x/ref/services/agent/internal/ipc/ipc_test.go
@@ -310,7 +310,9 @@ func TestBidi(t *testing.T) {
 	defer ipc2.Close()
 
 	var e echo
-	ipc2.Serve(e)
+	if err := ipc2.Serve(e); err != nil {
+		t.Fatal(err)
+	}
 	client, err := ipc2.Connect(path, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -327,7 +329,7 @@ func TestBidi(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	flag.Parse()
-	vlog.ConfigureLibraryLoggerFromFlags()
+	flag.Parse()                           // nolint: errcheck
+	vlog.ConfigureLibraryLoggerFromFlags() // nolint: errcheck
 	os.Exit(m.Run())
 }

--- a/x/ref/services/agent/internal/launcher/launcher.go
+++ b/x/ref/services/agent/internal/launcher/launcher.go
@@ -85,7 +85,7 @@ func LaunchAgent(credsDir, agentBin string, printCredsEnv bool, flags ...string)
 	// Make sure we don't leave a disfunctional or zombie agent behind upon
 	// error.
 	cleanUpAgent := func() {
-		defer cmd.Wait()
+		defer cmd.Wait() // nolint: errcheck
 		if err := syscall.Kill(pid, syscall.SIGINT); err == syscall.ESRCH {
 			return
 		}
@@ -95,7 +95,7 @@ func LaunchAgent(credsDir, agentBin string, printCredsEnv bool, flags ...string)
 				return
 			}
 		}
-		syscall.Kill(pid, syscall.SIGKILL)
+		syscall.Kill(pid, syscall.SIGKILL) // nolint: errcheck
 	}
 	scanner := bufio.NewScanner(agentRead)
 	if !scanner.Scan() || scanner.Text() != constants.ServingMsg {

--- a/x/ref/services/agent/internal/lock/lock.go
+++ b/x/ref/services/agent/internal/lock/lock.go
@@ -244,14 +244,14 @@ retry:
 				// remove all higher level locks).
 				currMasterLockInfo, err := l.readLockInfo(0)
 				if err != nil && !os.IsNotExist(err) {
-					l.unlock(index)
+					l.unlock(index) // nolint: errcheck
 					return false, err
 				}
 				if err != nil || !bytes.Equal(currMasterLockInfo, masterLockInfo) {
 					// The master lock has changed.  We are
 					// not the rightful owner.  Retry from
 					// level 0 after some delay.
-					l.unlock(index)
+					l.unlock(index) // nolint: errcheck
 					l.sleep()
 					continue retry
 				}
@@ -263,7 +263,7 @@ retry:
 			// We grabbed the lock and are the rightful owner.
 			// Steal the master lock and remove higher level locks.
 			if err := l.poachLock(0); err != nil {
-				l.unlock(index)
+				l.unlock(index) // nolint: errcheck
 				return false, err
 			}
 			// It's now safe to clear higher level locks since any
@@ -271,7 +271,7 @@ retry:
 			// will have to resume from level 0 once they notice
 			// that the master lock info has changed.
 			for i := index; i > 0; i-- {
-				l.unlock(i)
+				l.unlock(i) // nolint: errcheck
 			}
 			return true, nil
 		}

--- a/x/ref/services/agent/internal/lock/lock_test.go
+++ b/x/ref/services/agent/internal/lock/lock_test.go
@@ -367,7 +367,7 @@ func TestLockLevelStateChanges(t *testing.T) {
 	// TryLock finds lock 1 held, so it sleeps and retries.
 	sleepDuration := <-tk.Requests()
 	// Unlock level 1, letting TryLock grab it.
-	l.unlock(1)
+	l.unlock(1) // nolint: errcheck
 	tk.AdvanceTime(sleepDuration)
 	// TryLock managed to grab level 1 and it then reclaims level 0.
 	verifyTryLock(true)
@@ -411,7 +411,7 @@ func TestLockLevelStateChanges(t *testing.T) {
 	sleepDuration = <-tk.Requests()
 	// Remove lock 2.  TryLock should then grab it, and then reclaim level
 	// 0.
-	l.unlock(2)
+	l.unlock(2) // nolint: errcheck
 	tk.AdvanceTime(sleepDuration)
 	verifyTryLock(true)
 	assertNumLockFiles(t, d, 1)
@@ -431,7 +431,7 @@ func TestLockLevelStateChanges(t *testing.T) {
 	verifyTryLock = goTryLock()
 	// TryLock finds lock 2 held, so it sleeps and retries.
 	sleepDuration = <-tk.Requests()
-	l.unlock(2)
+	l.unlock(2) // nolint: errcheck
 	// We use the hook to control the execution of TryLock and allow
 	// ourselves to manipulate the lock files 'asynchronously'.
 	tryLockCalled := make(chan struct{})
@@ -474,13 +474,13 @@ func TestLockLevelStateChanges(t *testing.T) {
 	// TryLock finds level 2 lock held, so it sleeps and retries.
 	sleepDuration = <-tk.Requests()
 	// Unlock level 2.
-	l.unlock(2)
+	l.unlock(2) // nolint: errcheck
 	tryLockCalled = make(chan struct{})
 	l.tryLockHook = func() { tryLockCalled <- struct{}{} }
 	tk.AdvanceTime(sleepDuration)
 	<-tryLockCalled // Back to level 0, TryLock finds it stale.
 	// Unlock level 0.
-	l.unlock(0)
+	l.unlock(0)     // nolint: errcheck
 	<-tryLockCalled // For lock 1.
 	<-tryLockCalled // For lock 2.
 	// TryLock grabs level 2, but finds level 0 has changed (unlocked).  It
@@ -656,10 +656,10 @@ func TestLockLevelConfigurations(t *testing.T) {
 				verifyFreeLock(t, l, level)
 			case ac:
 				verifyHeldLock(t, l, level)
-				l.unlock(level)
+				l.unlock(level) // nolint: errcheck
 			case st:
 				verifyStaleLock(t, l, level)
-				l.unlock(level)
+				l.unlock(level) // nolint: errcheck
 			}
 		}
 		assertNumLockFiles(t, d, 0)

--- a/x/ref/services/agent/internal/lockutil/version1.go
+++ b/x/ref/services/agent/internal/lockutil/version1.go
@@ -95,7 +95,7 @@ func createV1(w io.Writer) error {
 	cmd := makePsCommandV1(os.Getpid())
 	cmd.Stdout = w
 	cmd.Stderr = nil
-	cmd.Run()
+	cmd.Run() // nolint: errcheck
 	// If the 'ps' command fails for any reason (e.g. wrong invocation for
 	// the particular ps version on the system), treat that as no 'ps'
 	// available instead of failing.

--- a/x/ref/services/agent/internal/server/server.go
+++ b/x/ref/services/agent/internal/server/server.go
@@ -49,7 +49,7 @@ func (a *agentd) MintDischarge(forCaveat, caveatOnDischarge security.Caveat, add
 func (a *agentd) unlock() {
 	a.mu.Unlock()
 	for _, conn := range a.ipc.Connections() {
-		go conn.Call("FlushAllCaches", nil)
+		go conn.Call("FlushAllCaches", nil) // nolint: errcheck
 	}
 }
 

--- a/x/ref/services/application/applicationd/service.go
+++ b/x/ref/services/application/applicationd/service.go
@@ -300,6 +300,7 @@ func (i *appRepoService) GlobChildren__(ctx *context.T, call rpc.GlobChildrenSer
 
 	for _, r := range results {
 		if m.Match(r) {
+			// nolint: errcheck
 			call.SendStream().Send(naming.GlobChildrenReplyName{Value: r})
 		}
 	}

--- a/x/ref/services/ben/benarchd/internal/http.go
+++ b/x/ref/services/ben/benarchd/internal/http.go
@@ -38,7 +38,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else if strings.HasSuffix(file, ".js") {
 			w.Header().Set("Content-Type", "application/javascript")
 		}
-		w.Write(data)
+		w.Write(data) // nolint: errcheck
 		return
 	}
 	if id := strings.TrimSpace(r.FormValue("id")); len(id) > 0 {

--- a/x/ref/services/ben/benarchd/internal/sql_store.go
+++ b/x/ref/services/ben/benarchd/internal/sql_store.go
@@ -70,7 +70,7 @@ func (s *sqlStore) Save(ctx *context.T, scenario ben.Scenario, code ben.SourceCo
 		return err
 	}
 	// If tx.Commit is called, then this tx.Rollback is a no-op
-	defer tx.Rollback()
+	defer tx.Rollback() // nolint: errcheck
 	cpu, err := s.insertAndGetID(tx, s.insertCPU, s.selectCPU, scenario.Cpu.Architecture, scenario.Cpu.Description, scenario.Cpu.ClockSpeedMhz)
 	if err != nil {
 		return tagerr("cpu", err)

--- a/x/ref/services/ben/benarchd/main.go
+++ b/x/ref/services/ben/benarchd/main.go
@@ -84,7 +84,7 @@ func run(ctx *context.T, env *cmdline.Env, args []string) error {
 		return err
 	}
 	ctx.Infof("HTTP server at http://%v", ln.Addr())
-	go http.Serve(ln, internal.NewHTTPHandler(assets, store))
+	go http.Serve(ln, internal.NewHTTPHandler(assets, store)) // nolint: errcheck
 
 	// Start the v23 RPC service
 	pubAddr := fmt.Sprintf("http://%v", ln.Addr())

--- a/x/ref/services/ben/benarchd/main_test.go
+++ b/x/ref/services/ben/benarchd/main_test.go
@@ -126,7 +126,7 @@ func testHTTP(url string, expect ...string) error {
 		return nil
 	}
 	buf := bytes.NewBuffer(nil)
-	io.Copy(buf, resp.Body)
+	io.Copy(buf, resp.Body) // nolint: errcheck
 	body := buf.String()
 	for _, e := range expect {
 		if !strings.Contains(body, e) {

--- a/x/ref/services/binary/binary/impl_test.go
+++ b/x/ref/services/binary/binary/impl_test.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/rpc"
@@ -49,8 +49,8 @@ func (s *server) Delete(ctx *context.T, _ rpc.ServerCall) error {
 func (s *server) Download(ctx *context.T, call repository.BinaryDownloadServerCall, _ int32) error {
 	ctx.Infof("Download() was called. suffix=%v", s.suffix)
 	sender := call.SendStream()
-	sender.Send([]byte("Hello"))
-	sender.Send([]byte("World"))
+	sender.Send([]byte("Hello")) // nolint: errcheck
+	sender.Send([]byte("World")) // nolint: errcheck
 	return nil
 }
 
@@ -66,7 +66,7 @@ func (s *server) Stat(ctx *context.T, _ rpc.ServerCall) ([]binary.PartInfo, repo
 	ctx.Infof("Stat() was called. suffix=%v", s.suffix)
 	h := md5.New()
 	text := "HelloWorld"
-	h.Write([]byte(text))
+	h.Write([]byte(text)) // nolint: errcheck
 	part := binary.PartInfo{Checksum: hex.EncodeToString(h.Sum(nil)), Size: int64(len(text))}
 	return []binary.PartInfo{part}, repository.MediaInfo{Type: "text/plain"}, nil
 }

--- a/x/ref/services/binary/tidy/binaryd/mock.go
+++ b/x/ref/services/binary/tidy/binaryd/mock.go
@@ -74,6 +74,7 @@ func (mdi *MockBinarydInvoker) Glob__(p *context.T, call rpc.GlobServerCall, g *
 	gs := GlobStimulus{g.String()}
 	gr := mdi.Tape.Record(gs).(GlobResponse)
 	for _, r := range gr.Results {
+		// nolint: errcheck
 		call.SendStream().Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: r}})
 	}
 	return gr.Err

--- a/x/ref/services/debug/debug/browseserver/browseserver.go
+++ b/x/ref/services/debug/debug/browseserver/browseserver.go
@@ -76,9 +76,9 @@ func Serve(ctx *context.T, httpAddr, name string, timeout time.Duration, log boo
 		// Open the browser if we can
 		switch runtime.GOOS {
 		case "linux":
-			exec.Command("xdg-open", url).Start()
+			exec.Command("xdg-open", url).Start() // nolint: errcheck
 		case "darwin":
-			exec.Command("open", url).Start()
+			exec.Command("open", url).Start() // nolint: errcheck
 		}
 
 		<-ctx.Done()
@@ -269,7 +269,9 @@ func (h *blessingsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		args.CertificateChains = security.MarshalBlessings(args.Blessings).CertificateChains
 		// Don't actually care about the RPC, so don't bother waiting on the Finish.
 		cancel()
-		defer func() { go call.Finish() }()
+		defer func() {
+			go call.Finish() // nolint: errcheck
+		}()
 	} else {
 		cancel()
 	}
@@ -485,7 +487,7 @@ func (h *logsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		// writes to: entries, errch
 		// reads from: abortRPC
-		defer stream.Finish()
+		defer stream.Finish() // nolint: errcheck
 		defer close(entries)
 		iterator := stream.RecvStream()
 		for iterator.Advance() {

--- a/x/ref/services/debug/debug/impl.go
+++ b/x/ref/services/debug/debug/impl.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/glob"
 	"v.io/v23/naming"
@@ -644,7 +644,7 @@ func startPprofProxyHTTPServer(ctx *context.T, name string) (string, error) {
 		return "", err
 	}
 	http.Handle("/", pproflib.PprofProxy(ctx, "", name))
-	go http.Serve(ln, nil)
+	go http.Serve(ln, nil) // nolint: errcheck
 	go func() {
 		<-ctx.Done()
 		ln.Close()

--- a/x/ref/services/debug/debuglib/dispatcher_test.go
+++ b/x/ref/services/debug/debuglib/dispatcher_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/services/logreader"
@@ -54,7 +54,7 @@ func TestDebugServer(t *testing.T) {
 
 	// Use logger configured with the directory that we want to use for this test.
 	testLogger := vlog.NewLogger("TestDebugServer")
-	testLogger.Configure(vlog.LogDir(workdir))
+	testLogger.Configure(vlog.LogDir(workdir)) // nolint: errcheck
 	ctx = context.WithLogger(ctx, testLogger)
 
 	disp := debuglib.NewDispatcher(nil)
@@ -157,7 +157,9 @@ func TestDebugServer(t *testing.T) {
 		defer cancel()
 
 		ns := v23.GetNamespace(ctx)
-		ns.SetRoots(naming.JoinAddressName(endpoint, "debug"))
+		if err := ns.SetRoots(naming.JoinAddressName(endpoint, "debug")); err != nil {
+			t.Fatal(err)
+		}
 
 		c, err := ns.Glob(ctx, "logs/...")
 		if err != nil {

--- a/x/ref/services/device/device/devicemanager_mock_test.go
+++ b/x/ref/services/device/device/devicemanager_mock_test.go
@@ -296,6 +296,7 @@ func (mdi *mockDeviceInvoker) Glob__(_ *context.T, call rpc.GlobServerCall, g *g
 	gs := GlobStimulus{g.String()}
 	gr := mdi.tape.Record(gs).(GlobResponse)
 	for _, r := range gr.results {
+		// nolint: errcheck
 		call.SendStream().Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: r}})
 	}
 	return gr.err

--- a/x/ref/services/device/device/glob.go
+++ b/x/ref/services/device/device/glob.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -201,8 +202,14 @@ func Run(ctx *context.T, env *cmdline.Env, args []string, handler GlobHandler, s
 		}
 	}
 	for i := range results {
-		io.Copy(env.Stdout, &stdouts[i])
-		io.Copy(env.Stderr, &stderrs[i])
+		if _, err := io.Copy(env.Stdout, &stdouts[i]); err != nil {
+			fmt.Fprintf(os.Stderr, "io.Copy: %v\n", err)
+			atomic.AddUint32(&errorCounter, 1)
+		}
+		if _, err := io.Copy(env.Stderr, &stderrs[i]); err != nil {
+			fmt.Fprintf(os.Stderr, "io.Copy: %v\n", err)
+			atomic.AddUint32(&errorCounter, 1)
+		}
 	}
 	if errorCounter > 0 {
 		return fmt.Errorf("encountered a total of %d error(s)", errorCounter)

--- a/x/ref/services/device/device/glob_test.go
+++ b/x/ref/services/device/device/glob_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/services/device"
@@ -50,7 +50,7 @@ func newEnforceFullParallelismHandler(t *testing.T, n int) cmd_device.GlobHandle
 	wg.Add(n)
 	return func(entry cmd_device.GlobResult, ctx *context.T, stdout, stderr io.Writer) error {
 		wg.Done()
-		simplePrintHandler(entry, ctx, stdout, stderr)
+		simplePrintHandler(entry, ctx, stdout, stderr) // nolint: errcheck
 		waitDoneCh := make(chan struct{})
 		go func() {
 			wg.Wait()
@@ -137,7 +137,7 @@ func newEnforceNoParallelismHandler(t *testing.T, n int, expected []string) cmd_
 		if suffix != expect {
 			t.Errorf("Expected %s, got %s", expect, suffix)
 		}
-		simplePrintHandler(entry, ctx, stdout, stderr)
+		simplePrintHandler(entry, ctx, stdout, stderr) // nolint: errcheck
 		return nil
 	}
 }

--- a/x/ref/services/device/device/instantiate.go
+++ b/x/ref/services/device/device/instantiate.go
@@ -7,7 +7,7 @@ package main
 import (
 	"fmt"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/rpc"
@@ -69,7 +69,7 @@ func runInstantiate(ctx *context.T, env *cmdline.Env, args []string) error {
 			if err != nil {
 				return fmt.Errorf("Instantiate failed: %v", err)
 			}
-			call.SendStream().Send(device.BlessClientMessageAppBlessings{Value: blessings})
+			call.SendStream().Send(device.BlessClientMessageAppBlessings{Value: blessings}) // nolint: errcheck
 		default:
 			fmt.Fprintf(env.Stderr, "Received unexpected message: %#v\n", msg)
 		}

--- a/x/ref/services/device/device/local_install.go
+++ b/x/ref/services/device/device/local_install.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/rpc"
@@ -151,7 +151,7 @@ func (i binaryInvoker) Stat(*context.T, rpc.ServerCall) ([]binary.PartInfo, repo
 	if err != nil {
 		return []binary.PartInfo{}, repository.MediaInfo{}, err
 	}
-	h.Write(bytes)
+	h.Write(bytes) // nolint: errcheck
 	part := binary.PartInfo{Checksum: hex.EncodeToString(h.Sum(nil)), Size: int64(len(bytes))}
 	return []binary.PartInfo{part}, packages.MediaInfoForFileName(fileName), nil
 }

--- a/x/ref/services/device/deviced/internal/impl/app_service.go
+++ b/x/ref/services/device/deviced/internal/impl/app_service.go
@@ -337,7 +337,7 @@ const (
 // given title.
 func applicationDirName(title string) string {
 	h := md5.New()
-	h.Write([]byte(title))
+	h.Write([]byte(title)) // nolint: errcheck
 	hash := strings.TrimRight(base64.URLEncoding.EncodeToString(h.Sum(nil)), "=")
 	return appDirPrefix + hash
 }
@@ -521,7 +521,7 @@ func setupPrincipal(ctx *context.T, instanceDir string, call device.ApplicationI
 	if err := principalMgr.Serve(instanceDir, nil); err != nil {
 		return verror.New(errors.ErrOperationFailed, ctx, fmt.Sprintf("Serve(%v) failed: %v", instanceDir, err))
 	}
-	defer principalMgr.StopServing(instanceDir)
+	defer principalMgr.StopServing(instanceDir) // nolint: errcheck
 	p, err := principalMgr.Load(instanceDir)
 	if err != nil {
 		return verror.New(errors.ErrOperationFailed, ctx, fmt.Sprintf("Load(%v) failed: %v", instanceDir, err))
@@ -749,7 +749,7 @@ func genCmd(ctx *context.T, instanceDir, nsRoot string) (*exec.Cmd, error) {
 	saArgs.workspace = rootDir
 
 	logDir := filepath.Join(instanceDir, "logs")
-	suidHelper.chownTree(ctx, suidHelper.getCurrentUser(), instanceDir, os.Stdout, os.Stdin)
+	suidHelper.chownTree(ctx, suidHelper.getCurrentUser(), instanceDir, os.Stdout, os.Stdin) // nolint: errcheck
 	if err := mkdirPerm(ctx, logDir, 0755); err != nil {
 		return nil, err
 	}
@@ -896,7 +896,7 @@ func (i *appRunner) run(ctx *context.T, instanceDir string) error {
 	// We should allow the app to be considered for restart if startCmd
 	// fails after having successfully started the app process.
 	if err != nil {
-		transitionInstance(instanceDir, device.InstanceStateLaunching, device.InstanceStateNotRunning)
+		transitionInstance(instanceDir, device.InstanceStateLaunching, device.InstanceStateNotRunning) // nolint: errcheck
 		return err
 	}
 	if err := transitionInstance(instanceDir, device.InstanceStateLaunching, device.InstanceStateRunning); err != nil {
@@ -1434,6 +1434,7 @@ func (i *appService) GlobChildren__(ctx *context.T, call rpc.GlobChildrenServerC
 	}
 	for child := range n.children {
 		if m.Match(child) {
+			// nolint: errcheck
 			call.SendStream().Send(naming.GlobChildrenReplyName{Value: child})
 		}
 	}

--- a/x/ref/services/device/deviced/internal/impl/app_starting_util.go
+++ b/x/ref/services/device/deviced/internal/impl/app_starting_util.go
@@ -135,7 +135,7 @@ func (a *appHandshaker) doHandshake(ctx *context.T, cmd *exec.Cmd, listener call
 	// The appWatcher will stop the listener if the pid dies while waiting below
 	childName, err := listener.waitForValue(childReadyTimeout)
 	if err != nil {
-		suidHelper.terminatePid(ctx, pidFromHelper, nil, nil)
+		suidHelper.terminatePid(ctx, pidFromHelper, nil, nil) // nolint: errcheck
 		return 0, "", verror.New(errors.ErrOperationFailed, ctx,
 			fmt.Sprintf("Waiting for child name: %v", err))
 	}

--- a/x/ref/services/device/deviced/internal/impl/applife/app_life_test.go
+++ b/x/ref/services/device/deviced/internal/impl/applife/app_life_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/security"
@@ -37,7 +37,7 @@ import (
 func instanceDirForApp(root, appID, instanceID string) string {
 	applicationDirName := func(title string) string {
 		h := md5.New()
-		h.Write([]byte(title))
+		h.Write([]byte(title)) // nolint: errcheck
 		hash := strings.TrimRight(base64.URLEncoding.EncodeToString(h.Sum(nil)), "=")
 		return "app-" + hash
 	}

--- a/x/ref/services/device/deviced/internal/impl/applife/instance_reaping_test.go
+++ b/x/ref/services/device/deviced/internal/impl/applife/instance_reaping_test.go
@@ -66,7 +66,7 @@ func TestReaperNoticesAppDeath(t *testing.T) {
 	}
 
 	utiltest.VerifyState(t, ctx, device.InstanceStateRunning, appID, instance1ID)
-	syscall.Kill(int(pid), 9)
+	syscall.Kill(int(pid), 9) // nolint: errcheck
 
 	// Start a second instance of the app which will force polling to happen.
 	instance2ID := utiltest.LaunchApp(t, ctx, appID)

--- a/x/ref/services/device/deviced/internal/impl/daemonreap/daemon_reaping_test.go
+++ b/x/ref/services/device/deviced/internal/impl/daemonreap/daemon_reaping_test.go
@@ -48,7 +48,7 @@ func TestDaemonRestart(t *testing.T) {
 	utiltest.VerifyState(t, ctx, device.InstanceStateRunning, appID, instanceID)
 
 	for i := 0; i < nRestarts; i++ {
-		syscall.Kill(int(pid), 9)
+		syscall.Kill(int(pid), 9) // nolint: errcheck
 		utiltest.PollingWait(t, int(pid))
 
 		// instanceID should be restarted automatically.
@@ -67,7 +67,7 @@ func TestDaemonRestart(t *testing.T) {
 	}
 
 	// Kill the application again.
-	syscall.Kill(int(pid), 9)
+	syscall.Kill(int(pid), 9) // nolint: errcheck
 	utiltest.PollingWait(t, int(pid))
 
 	// The reaper should no longer restart the application:

--- a/x/ref/services/device/deviced/internal/impl/daemonreap/instance_reaping_kill_test.go
+++ b/x/ref/services/device/deviced/internal/impl/daemonreap/instance_reaping_kill_test.go
@@ -61,7 +61,7 @@ func TestReapReconciliationViaKill(t *testing.T) {
 	utiltest.ResolveExpectNotFound(t, ctx, "dm", false) // Ensure a clean slate.
 
 	// Kill instance[0] and wait until it exits before proceeding.
-	syscall.Kill(pid, 9)
+	syscall.Kill(pid, 9) // nolint: errcheck
 	utiltest.PollingWait(t, pid)
 
 	// Run another device manager to replace the dead one.
@@ -85,7 +85,7 @@ func TestReapReconciliationViaKill(t *testing.T) {
 
 	// Kill instance[1]
 	pid = utiltest.GetPid(t, ctx, appID, instances[1])
-	syscall.Kill(pid, 9)
+	syscall.Kill(pid, 9) // nolint: errcheck
 
 	// Make a fourth instance. This forces a polling of processes so that
 	// the state is updated.

--- a/x/ref/services/device/deviced/internal/impl/daemonreap/persistent_daemon_kill_test.go
+++ b/x/ref/services/device/deviced/internal/impl/daemonreap/persistent_daemon_kill_test.go
@@ -52,7 +52,7 @@ func TestReapRestartsDaemonMode(t *testing.T) {
 	utiltest.ResolveExpectNotFound(t, ctx, "dm", false) // Ensure a clean slate.
 
 	// Kill instance[0] and wait until it exits before proceeding.
-	syscall.Kill(pid, 9)
+	syscall.Kill(pid, 9) // nolint: errcheck
 	utiltest.PollingWait(t, int(pid))
 
 	// Run another device manager to replace the dead one.

--- a/x/ref/services/device/deviced/internal/impl/device_service.go
+++ b/x/ref/services/device/deviced/internal/impl/device_service.go
@@ -278,11 +278,11 @@ func (s *deviceService) testDeviceManager(ctx *context.T, workspace string, enve
 	if err := principalMgr.Create(workspace); err != nil {
 		return verror.New(errors.ErrOperationFailed, ctx, fmt.Sprintf("Create(%v) failed: %v", workspace, err))
 	}
-	defer principalMgr.Delete(workspace)
+	defer principalMgr.Delete(workspace) // nolint: errcheck
 	if err := principalMgr.Serve(workspace, cfg); err != nil {
 		return verror.New(errors.ErrOperationFailed, ctx, fmt.Sprintf("Serve(%v) failed: %v", workspace, err))
 	}
-	defer principalMgr.StopServing(workspace)
+	defer principalMgr.StopServing(workspace) // nolint: errcheck
 	p, err := principalMgr.Load(workspace)
 	if err != nil {
 		return verror.New(errors.ErrOperationFailed, ctx, fmt.Sprintf("Load(%v) failed: %v", workspace, err))

--- a/x/ref/services/device/deviced/internal/impl/impl_test.go
+++ b/x/ref/services/device/deviced/internal/impl/impl_test.go
@@ -261,7 +261,7 @@ func TestDeviceManagerUpdateAndRevert(t *testing.T) {
 	utiltest.RevertDevice(t, ctx, "v2DM")
 	dm.S.Expect("restart handler")
 	dm.S.Expect("v2DM terminated")
-	dm.S.ExpectEOF()
+	dm.S.ExpectEOF() // nolint: errcheck
 	if evalLink() != scriptPathFactory {
 		t.Fatalf("current link was not reverted correctly")
 	}
@@ -276,7 +276,7 @@ func TestDeviceManagerUpdateAndRevert(t *testing.T) {
 	utiltest.Resolve(t, ctx, "factoryDM", 1, true) // Current link should have been launching factory version.
 	utiltest.ShutdownDevice(t, ctx, "factoryDM")
 	dm.S.Expect("factoryDM terminated")
-	dm.S.ExpectEOF()
+	dm.S.ExpectEOF() // nolint: errcheck
 
 	// Re-launch the device manager, to exercise the behavior of Stop.
 	utiltest.ResolveExpectNotFound(t, ctx, "factoryDM", false) // Ensure a clean slate.
@@ -289,7 +289,7 @@ func TestDeviceManagerUpdateAndRevert(t *testing.T) {
 	utiltest.KillDevice(t, ctx, "factoryDM")
 	dm.S.Expect("restart handler")
 	dm.S.Expect("factoryDM terminated")
-	dm.S.ExpectEOF()
+	dm.S.ExpectEOF() // nolint: errcheck
 }
 
 type simpleRW chan []byte

--- a/x/ref/services/device/deviced/internal/impl/proxy_invoker.go
+++ b/x/ref/services/device/deviced/internal/impl/proxy_invoker.go
@@ -229,7 +229,7 @@ func (c *call) Send(v interface{}) error {
 
 func (p *proxyInvoker) Glob__(ctx *context.T, serverCall rpc.GlobServerCall, g *glob.Glob) error {
 	pattern := g.String()
-	p.Invoke(ctx, &call{serverCall}, rpc.GlobMethod, []interface{}{&pattern})
+	p.Invoke(ctx, &call{serverCall}, rpc.GlobMethod, []interface{}{&pattern}) // nolint: errcheck
 	return nil
 }
 

--- a/x/ref/services/device/deviced/internal/impl/utiltest/helpers.go
+++ b/x/ref/services/device/deviced/internal/impl/utiltest/helpers.go
@@ -331,7 +331,7 @@ func NewInstanceImpl(t *testing.T, ctx *context.T, appID, grant string) (string,
 		return "", err
 	}
 	// We should finish the rpc call, even if we exit early due to an error.
-	defer call.Finish()
+	defer call.Finish() // nolint: errcheck
 
 	for call.RecvStream().Advance() {
 		switch msg := call.RecvStream().Value().(type) {
@@ -346,7 +346,7 @@ func NewInstanceImpl(t *testing.T, ctx *context.T, appID, grant string) (string,
 			if err != nil {
 				return "", errors.New("bless failed")
 			}
-			call.SendStream().Send(device.BlessClientMessageAppBlessings{Value: blessings})
+			call.SendStream().Send(device.BlessClientMessageAppBlessings{Value: blessings}) // nolint: errcheck
 		default:
 			return "", fmt.Errorf("newInstanceImpl: received unexpected message: %#v", msg)
 		}
@@ -859,7 +859,7 @@ func PollingWait(t *testing.T, pid int) {
 	for syscall.Kill(pid, 0) == nil {
 		select {
 		case <-timeOut:
-			syscall.Kill(pid, 9)
+			syscall.Kill(pid, 9) // nolint: errcheck
 			t.Fatal(testutil.FormatLogLine(2, "Timed out waiting for PID %v to terminate", pid))
 		case <-time.After(time.Millisecond):
 			// Try again.

--- a/x/ref/services/device/deviced/internal/impl/utiltest/mock_repo.go
+++ b/x/ref/services/device/deviced/internal/impl/utiltest/mock_repo.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/v23/security"
@@ -172,7 +172,7 @@ func (*brInvoker) Stat(ctx *context.T, call rpc.ServerCall) ([]binary.PartInfo, 
 	if err != nil {
 		return []binary.PartInfo{}, repository.MediaInfo{}, verror.New(ErrOperationFailed, ctx)
 	}
-	h.Write(bytes)
+	h.Write(bytes) // nolint: errcheck
 	part := binary.PartInfo{Checksum: hex.EncodeToString(h.Sum(nil)), Size: int64(len(bytes))}
 	return []binary.PartInfo{part}, repository.MediaInfo{Type: "application/octet-stream"}, nil
 }

--- a/x/ref/services/device/deviced/internal/impl/utiltest/modules.go
+++ b/x/ref/services/device/deviced/internal/impl/utiltest/modules.go
@@ -55,7 +55,7 @@ var ExecScript = gosh.RegisterFunc("ExecScript", func(script string) error {
 var DeviceManager = gosh.RegisterFunc("DeviceManager", deviceManagerFunc)
 
 func waitForEOF(r io.Reader) {
-	io.Copy(ioutil.Discard, r)
+	io.Copy(ioutil.Discard, r) // nolint: errcheck
 }
 
 func deviceManagerFunc(publishName string, args ...string) error {
@@ -124,7 +124,7 @@ func deviceManagerFunc(publishName string, args ...string) error {
 	}
 	// Manually mount the claimable service in the 'global' mounttable.
 	for _, ep := range claimableEps {
-		v23.GetNamespace(ctx).Mount(ctx, "claimable", ep.Name(), 0)
+		v23.GetNamespace(ctx).Mount(ctx, "claimable", ep.Name(), 0) // nolint: errcheck
 	}
 	fmt.Println("READY")
 

--- a/x/ref/services/device/deviced/internal/installer/device_installer.go
+++ b/x/ref/services/device/deviced/internal/installer/device_installer.go
@@ -352,14 +352,14 @@ func Stop(ctx *context.T, installDir string, stderr, stdout io.Writer) error {
 	if restarterPid != 0 {
 		go func() {
 			if p, err := os.FindProcess(restarterPid); err == nil {
-				p.Wait()
+				p.Wait() // nolint: errcheck
 			}
 		}()
 	}
 	if devmgrPid != 0 {
 		go func() {
 			if p, err := os.FindProcess(devmgrPid); err == nil {
-				p.Wait()
+				p.Wait() // nolint: errcheck
 			}
 		}()
 	}

--- a/x/ref/services/device/internal/suid/args.go
+++ b/x/ref/services/device/internal/suid/args.go
@@ -212,6 +212,7 @@ func (wp *WorkParameters) ProcessArguments(fs *flag.FlagSet, env []string) error
 		env = cleanEnv(env)
 		b := new(bytes.Buffer)
 		enc := json.NewEncoder(b)
+		// nolint: errcheck
 		enc.Encode(ArgsSavedForTest{
 			Uname:    *flagUsername,
 			Workpace: *flagWorkspace,

--- a/x/ref/services/device/internal/suid/args_test.go
+++ b/x/ref/services/device/internal/suid/args_test.go
@@ -196,7 +196,7 @@ func TestParseArguments(t *testing.T) {
 		var wp WorkParameters
 		fs := flag.NewFlagSet(c.cmdline[0], flag.ExitOnError)
 		setupFlags(fs)
-		fs.Parse(c.cmdline[1:])
+		fs.Parse(c.cmdline[1:]) // nolint: errcheck
 		if err := wp.ProcessArguments(fs, c.env); (err != nil || c.errID != "") && verror.ErrorID(err) != c.errID {
 			t.Fatalf("got %s (%v), expected %q error", verror.ErrorID(err), err, c.errID)
 		}

--- a/x/ref/services/device/mgmt_v23_test.go
+++ b/x/ref/services/device/mgmt_v23_test.go
@@ -377,7 +377,7 @@ func testCore(t *testing.T, sh *v23test.Shell, appUser, deviceUser string, withS
 	appPubName := "testbinaryd"
 	appEnvelopeFilename := filepath.Join(workDir, "app.envelope")
 	appEnvelope := fmt.Sprintf("{\"Title\":\"BINARYD\", \"Args\":[\"--name=%s\", \"--root-dir=./binstore\", \"--v23.tcp.address=127.0.0.1:0\", \"--http=127.0.0.1:0\"], \"Binary\":{\"File\":%q}, \"Env\":[ \"%s=1\", \"PATH=%s\"]}", appPubName, sampleAppBinName, ref.EnvCredentialsNoAgent, os.Getenv("PATH"))
-	ioutil.WriteFile(appEnvelopeFilename, []byte(appEnvelope), 0666)
+	ioutil.WriteFile(appEnvelopeFilename, []byte(appEnvelope), 0666) // nolint: errcheck
 	defer os.Remove(appEnvelopeFilename)
 
 	output := withArgs(applicationBin, "put", sampleAppName+"/0", deviceProfile, appEnvelopeFilename).Stdout()
@@ -480,7 +480,7 @@ func testCore(t *testing.T, sh *v23test.Shell, appUser, deviceUser string, withS
 	// Upload a device manager envelope.
 	devicedEnvelopeFilename := filepath.Join(workDir, "deviced.envelope")
 	devicedEnvelope := fmt.Sprintf("{\"Title\":\"device manager\", \"Binary\":{\"File\":%q}, \"Env\":[ \"%s=1\", \"PATH=%s\"]}", devicedAppBinName, ref.EnvCredentialsNoAgent, os.Getenv("PATH"))
-	ioutil.WriteFile(devicedEnvelopeFilename, []byte(devicedEnvelope), 0666)
+	ioutil.WriteFile(devicedEnvelopeFilename, []byte(devicedEnvelope), 0666) // nolint: errcheck
 	defer os.Remove(devicedEnvelopeFilename)
 	withArgs(applicationBin, "put", devicedAppName, deviceProfile, devicedEnvelopeFilename).Run()
 	// Allow root:r:admin and its devices to read the envelope

--- a/x/ref/services/device/restarter/main.go
+++ b/x/ref/services/device/restarter/main.go
@@ -89,11 +89,11 @@ func runRestarter(env *cmdline.Env, args []string) error {
 				if sig == vsignals.STOP {
 					sig = syscall.SIGTERM
 				}
-				cmd.Process.Signal(sig)
+				cmd.Process.Signal(sig) // nolint: errcheck
 			case <-shutdown:
 			}
 		}()
-		cmd.Wait()
+		cmd.Wait() // nolint: errcheck
 		close(shutdown)
 		exitCode = cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 		if !restartOpts.restart(exitCode) {

--- a/x/ref/services/http/http/http.go
+++ b/x/ref/services/http/http/http.go
@@ -13,7 +13,7 @@ import (
 	"net"
 	"net/http"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	_ "v.io/x/ref/runtime/factories/roaming"
 )
@@ -33,9 +33,9 @@ func traceDataHandler(w http.ResponseWriter, req *http.Request) {
 
 	if err != nil {
 		log.Println(err)
-		w.Write([]byte(fmt.Sprintf("%T", err)))
+		w.Write([]byte(fmt.Sprintf("%T", err))) // nolint: errcheck
 	} else {
-		w.Write(data)
+		w.Write(data) // nolint: errcheck
 	}
 }
 
@@ -48,7 +48,7 @@ func findPortAndListen(mux *http.ServeMux) {
 		if err == nil {
 			log.Println("Monitoring on " + fmt_port(curr_port) + "/debug/requests...")
 			defer ln.Close()
-			http.Serve(ln, mux)
+			http.Serve(ln, mux) // nolint: errcheck
 			break
 		}
 		curr_port += 1

--- a/x/ref/services/http/httplib/httplib.go
+++ b/x/ref/services/http/httplib/httplib.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	go_http "net/http"
+
 	v23_http "v.io/v23/services/http"
 )
 
@@ -25,7 +26,7 @@ func VDLRequestFromHTTPRequest(req *go_http.Request) v23_http.Request {
 	}
 
 	body_buf := new(bytes.Buffer)
-	body_buf.ReadFrom(req.Body)
+	body_buf.ReadFrom(req.Body) // nolint: errcheck
 
 	ifc_req := v23_http.Request{
 		Method:           req.Method,

--- a/x/ref/services/identity/internal/blesser/macaroon_test.go
+++ b/x/ref/services/identity/internal/blesser/macaroon_test.go
@@ -15,7 +15,7 @@ import (
 	"v.io/x/ref/test"
 	"v.io/x/ref/test/testutil"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/security"
 	"v.io/v23/vom"
 )
@@ -64,7 +64,9 @@ func TestMacaroonBlesser(t *testing.T) {
 	}
 	// But once it recognizes the provider, it should see exactly the name
 	// "provider:bugsbunny" for the caveat cOnlyMethodFoo.
-	security.AddToRoots(user, b)
+	if err := security.AddToRoots(user, b); err != nil {
+		t.Fatal(err)
+	}
 	if got, want := security.BlessingNames(user, b), []string{"provider:bugsbunny"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("Got %v, want %v", got, want)
 	}

--- a/x/ref/services/identity/internal/handlers/bless.go
+++ b/x/ref/services/identity/internal/handlers/bless.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/security"
 	"v.io/v23/vom"
@@ -237,7 +237,7 @@ func (a *accessTokenBlesser) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(encodedBlessings)
+		w.Write(encodedBlessings) // nolint: errcheck
 	case base64VomFormat:
 		encodedBlessings, err := a.encodeBlessingsVom(blessings)
 		if err != nil {
@@ -246,7 +246,7 @@ func (a *accessTokenBlesser) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/text")
-		w.Write([]byte(encodedBlessings))
+		w.Write([]byte(encodedBlessings)) // nolint: errcheck
 	default:
 		a.ctx.Infof("Unrecognized output format [%v] in request %#v", outputFormat, r)
 		util.HTTPServerError(w, fmt.Errorf("unrecognized output format [%v] in request. Allowed formats are [%v, %v]", outputFormat, base64VomFormat, jsonFormat))

--- a/x/ref/services/identity/internal/handlers/blessing_root.go
+++ b/x/ref/services/identity/internal/handlers/blessing_root.go
@@ -112,5 +112,5 @@ func (b BlessingRoot) jsonResponse(w http.ResponseWriter, r *http.Request) {
 
 func respondString(w http.ResponseWriter, contentType string, res []byte) {
 	w.Header().Set("Content-Type", contentType)
-	w.Write(res)
+	w.Write(res) // nolint: errcheck
 }

--- a/x/ref/services/identity/internal/handlers/handlers_test.go
+++ b/x/ref/services/identity/internal/handlers/handlers_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/security"
 	"v.io/v23/vom"
 
@@ -163,8 +163,14 @@ func TestBless(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	blesserPrin.BlessingStore().Set(trustedBlessing, "trusted")
-	blesserPrin.BlessingStore().Set(security.Blessings{}, "...")
+	_, err = blesserPrin.BlessingStore().Set(trustedBlessing, "trusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = blesserPrin.BlessingStore().Set(security.Blessings{}, "...")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ctx, shutdown := test.V23Init()
 	defer shutdown()

--- a/x/ref/services/identity/internal/oauth/handler.go
+++ b/x/ref/services/identity/internal/oauth/handler.go
@@ -263,14 +263,14 @@ func (h *handler) revoke(ctx *context.T, w http.ResponseWriter, r *http.Request)
 	)
 	if h.args.RevocationManager == nil {
 		ctx.Infof("no provided revocation manager")
-		w.Write([]byte(failure))
+		w.Write([]byte(failure)) // nolint: errcheck
 		return
 	}
 
 	content, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		ctx.Infof("Failed to parse request: %s", err)
-		w.Write([]byte(failure))
+		w.Write([]byte(failure)) // nolint: errcheck
 		return
 	}
 	var requestParams struct {
@@ -278,23 +278,23 @@ func (h *handler) revoke(ctx *context.T, w http.ResponseWriter, r *http.Request)
 	}
 	if err := json.Unmarshal(content, &requestParams); err != nil {
 		ctx.Infof("json.Unmarshal failed : %s", err)
-		w.Write([]byte(failure))
+		w.Write([]byte(failure)) // nolint: errcheck
 		return
 	}
 
 	var caveatID string
 	if caveatID, err = h.validateRevocationToken(ctx, requestParams.Token, r); err != nil {
 		ctx.Infof("failed to validate token for caveat: %s", err)
-		w.Write([]byte(failure))
+		w.Write([]byte(failure)) // nolint: errcheck
 		return
 	}
 	if err := h.args.RevocationManager.Revoke(caveatID); err != nil {
 		ctx.Infof("Revocation failed: %s", err)
-		w.Write([]byte(failure))
+		w.Write([]byte(failure)) // nolint: errcheck
 		return
 	}
 
-	w.Write([]byte(success))
+	w.Write([]byte(success)) // nolint: errcheck
 }
 
 func (h *handler) validateRevocationToken(ctx *context.T, Token string, r *http.Request) (string, error) {

--- a/x/ref/services/identity/internal/util/write.go
+++ b/x/ref/services/identity/internal/util/write.go
@@ -65,7 +65,7 @@ Ask the server administrator to check the server logs
 
 func requestString(r *http.Request) string {
 	var buf bytes.Buffer
-	r.Write(&buf)
+	r.Write(&buf) // nolint: errcheck
 	return buf.String()
 }
 

--- a/x/ref/services/internal/binarylib/client.go
+++ b/x/ref/services/internal/binarylib/client.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/security"
 	"v.io/v23/services/binary"
@@ -72,7 +72,7 @@ func downloadPartAttempt(ctx *context.T, w io.WriteSeeker, client repository.Bin
 			ctx.Errorf("Write() failed: %v", err)
 			return false
 		}
-		h.Write(bytes)
+		h.Write(bytes) // nolint: errcheck
 		nreceived += len(bytes)
 	}
 
@@ -277,7 +277,7 @@ func uploadPartAttempt(ctx *context.T, h hash.Hash, r io.ReadSeeker, client repo
 			return false, nil
 		}
 	}
-	h.Write(buffer)
+	h.Write(buffer) // nolint: errcheck
 	return true, nil
 }
 

--- a/x/ref/services/internal/binarylib/http_test.go
+++ b/x/ref/services/internal/binarylib/http_test.go
@@ -70,7 +70,9 @@ func TestHTTP(t *testing.T) {
 			if !bytes.Equal(output, data[i]) {
 				t.Fatalf("Unexpected output: expected %v, got %v", data[i], output)
 			}
-			hpart.Write(data[i])
+			if _, err := hpart.Write(data[i]); err != nil {
+				t.Fatal(err)
+			}
 			checksum := hex.EncodeToString(hpart.Sum(nil))
 			if expected, got := checksum, parts[i].Checksum; expected != got {
 				t.Fatalf("Unexpected checksum: expected %v, got %v", expected, got)

--- a/x/ref/services/internal/binarylib/impl_test.go
+++ b/x/ref/services/internal/binarylib/impl_test.go
@@ -94,7 +94,7 @@ func TestHierarchy(t *testing.T) {
 			t.Fatalf("Stat() failed: %v", err)
 		}
 		h := md5.New()
-		h.Write(data)
+		h.Write(data) // nolint: errcheck
 		checksum := hex.EncodeToString(h.Sum(nil))
 		if expected, got := checksum, parts[0].Checksum; expected != got {
 			t.Fatalf("Unexpected checksum: expected %v, got %v", expected, got)
@@ -160,7 +160,7 @@ func TestMultiPart(t *testing.T) {
 			if !bytes.Equal(output, data[i]) {
 				t.Fatalf("Unexpected output: expected %v, got %v", data[i], output)
 			}
-			hpart.Write(data[i])
+			hpart.Write(data[i]) // nolint: errcheck
 			checksum := hex.EncodeToString(hpart.Sum(nil))
 			if expected, got := checksum, parts[i].Checksum; expected != got {
 				t.Fatalf("Unexpected checksum: expected %v, got %v", expected, got)

--- a/x/ref/services/internal/binarylib/perms_test.go
+++ b/x/ref/services/internal/binarylib/perms_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/security"
 	"v.io/v23/security/access"
@@ -79,7 +79,9 @@ func TestBinaryCreateAccessList(t *testing.T) {
 	defer deferFn()
 	// make selfCtx and childCtx have the same Namespace Roots as set by
 	// CreateShellAndMountTable
-	v23.GetNamespace(selfCtx).SetRoots(v23.GetNamespace(childCtx).Roots()...)
+	if err := v23.GetNamespace(selfCtx).SetRoots(v23.GetNamespace(childCtx).Roots()...); err != nil {
+		t.Fatal(err)
+	}
 
 	// setup mock up directory to put state in
 	storedir, cleanup := servicetest.SetupRootDir(t, "bindir")

--- a/x/ref/services/internal/binarylib/service.go
+++ b/x/ref/services/internal/binarylib/service.go
@@ -374,7 +374,7 @@ func (i *binaryService) Upload(ctx *context.T, call repository.BinaryUploadServe
 			}
 			return verror.New(ErrOperationFailed, ctx)
 		}
-		h.Write(bytes)
+		h.Write(bytes) // nolint: errcheck
 	}
 
 	if err := rStream.Err(); err != nil {
@@ -416,7 +416,7 @@ func (i *binaryService) GlobChildren__(ctx *context.T, call rpc.GlobChildrenServ
 	}
 	for k := range n.children {
 		if m.Match(k) {
-			call.SendStream().Send(naming.GlobChildrenReplyName{Value: k})
+			call.SendStream().Send(naming.GlobChildrenReplyName{Value: k}) // nolint: errcheck
 		}
 	}
 	return nil

--- a/x/ref/services/internal/binarylib/state.go
+++ b/x/ref/services/internal/binarylib/state.go
@@ -76,7 +76,7 @@ func NewState(rootDir, rootURL string, depth int) (*state, error) {
 // dir generates the local filesystem path for the binary identified by suffix.
 func (s *state) dir(suffix string) string {
 	h := md5.New()
-	h.Write([]byte(suffix))
+	h.Write([]byte(suffix)) // nolint: errcheck
 	hash := hex.EncodeToString(h.Sum(nil))
 	dir := ""
 	for j := 0; j < s.depth; j++ {

--- a/x/ref/services/internal/dirprinter/printer.go
+++ b/x/ref/services/internal/dirprinter/printer.go
@@ -176,7 +176,7 @@ func dumpRegular(w io.Writer, path string) error {
 		if _, err := w.Write(data); err != nil {
 			return err
 		}
-		io.Copy(w, f)
+		io.Copy(w, f) // nolint: errcheck
 		fmt.Fprintln(w)
 	}
 	return nil

--- a/x/ref/services/internal/fs/simplestore_test.go
+++ b/x/ref/services/internal/fs/simplestore_test.go
@@ -272,7 +272,7 @@ func TestSerializeDeserialize(t *testing.T) {
 	}
 
 	// Abort the transaction without committing it.
-	memstoreOriginal.Abort(nil)
+	memstoreOriginal.Abort(nil) // nolint: errcheck
 	memstoreOriginal.Unlock()
 	// TRANSACTION END (ABORTED)
 

--- a/x/ref/services/internal/logreaderlib/logfile.go
+++ b/x/ref/services/internal/logreaderlib/logfile.go
@@ -148,6 +148,7 @@ func (i *logfileService) GlobChildren__(ctx *context.T, call rpc.GlobChildrenSer
 		for _, file := range fi {
 			name := file.Name()
 			if m.Match(name) {
+				// nolint: errcheck
 				call.SendStream().Send(naming.GlobChildrenReplyName{Value: name})
 			}
 		}

--- a/x/ref/services/internal/pathperms/permsaccess.go
+++ b/x/ref/services/internal/pathperms/permsaccess.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/security"
 	"v.io/v23/security/access"
@@ -192,7 +192,10 @@ func write(ctx *context.T, permsFile, sigFile, dir string, perms access.Permissi
 	}
 
 	// Create dir directory if it does not exist
-	os.MkdirAll(dir, dirmode)
+	if err := os.MkdirAll(dir, dirmode); err != nil {
+		ctx.Errorf("Failed to create directory tree %v data:%v", dir, err)
+		return verror.New(ErrOperationFailed, nil)
+	}
 	// Save the object to temporary data and signature files, and then move
 	// those files to the actual data and signature file.
 	data, err := ioutil.TempFile(dir, permsName)

--- a/x/ref/services/internal/pproflib/proxy_test.go
+++ b/x/ref/services/internal/pproflib/proxy_test.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/security"
 	_ "v.io/x/ref/runtime/factories/generic"
@@ -41,6 +41,7 @@ func TestPProfProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
+	// nolint: errcheck
 	go http.Serve(ln, pproflib.PprofProxy(ctx, "/myprefix", endpoints[0].Name()))
 	testcases := []string{
 		"/myprefix/pprof/",

--- a/x/ref/services/internal/statslib/stats.go
+++ b/x/ref/services/internal/statslib/stats.go
@@ -43,10 +43,8 @@ func (i *statsService) Glob__(ctx *context.T, call rpc.GlobServerCall, g *glob.G
 	sender := call.SendStream()
 	it := libstats.Glob(i.suffix, g.String(), time.Time{}, false)
 	for it.Advance() {
-		err := sender.Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: it.Value().Key}})
-		if err != nil {
-			ctx.VI(1).Infof("libstats.Glob(%q, %q) failed to send results: %v", i.suffix, g.String(), err)
-		}
+		// nolint: errcheck
+		sender.Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: it.Value().Key}})
 	}
 	if err := it.Err(); err != nil {
 		ctx.VI(1).Infof("libstats.Glob(%q, %q) failed: %v", i.suffix, g.String(), err)

--- a/x/ref/services/internal/statslib/stats.go
+++ b/x/ref/services/internal/statslib/stats.go
@@ -43,7 +43,10 @@ func (i *statsService) Glob__(ctx *context.T, call rpc.GlobServerCall, g *glob.G
 	sender := call.SendStream()
 	it := libstats.Glob(i.suffix, g.String(), time.Time{}, false)
 	for it.Advance() {
-		sender.Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: it.Value().Key}})
+		err := sender.Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: it.Value().Key}})
+		if err != nil {
+			ctx.VI(1).Infof("libstats.Glob(%q, %q) failed to send results: %v", i.suffix, g.String(), err)
+		}
 	}
 	if err := it.Err(); err != nil {
 		ctx.VI(1).Infof("libstats.Glob(%q, %q) failed: %v", i.suffix, g.String(), err)

--- a/x/ref/services/internal/statslib/stats_test.go
+++ b/x/ref/services/internal/statslib/stats_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/security"
@@ -55,7 +55,7 @@ func TestStatsImpl(t *testing.T) {
 		MinValue:           0,
 	})
 	for i := 0; i < 10; i++ {
-		histogram.Add(int64(i))
+		histogram.Add(int64(i)) // nolint: errcheck
 	}
 
 	name := naming.JoinAddressName(endpoint, "")

--- a/x/ref/services/mounttable/mounttablelib/mounttable.go
+++ b/x/ref/services/mounttable/mounttablelib/mounttable.go
@@ -647,7 +647,7 @@ func (ms *mountContext) Delete(ctx *context.T, call rpc.ServerCall, deleteSubTre
 	}
 	mt.deleteNode(n.parent, ms.elems[len(ms.elems)-1])
 	if mt.persisting {
-		mt.persist.persistDelete(ms.name)
+		mt.persist.persistDelete(ms.name) // nolint: errcheck
 	}
 	return nil
 }
@@ -687,7 +687,7 @@ func (mt *mountTable) globStep(cc *callContext, n *node, name string, pattern *g
 		}
 		// Hold no locks while we are sending on the channel to avoid livelock.
 		n.Unlock()
-		gCall.SendStream().Send(naming.GlobReplyEntry{Value: me})
+		gCall.SendStream().Send(naming.GlobReplyEntry{Value: me}) // nolint: errcheck
 		return
 	}
 
@@ -757,7 +757,7 @@ out:
 	// Hold no locks while we are sending on the channel to avoid livelock.
 	n.Unlock()
 	// Intermediate nodes are marked as serving a mounttable since they answer the mounttable methods.
-	gCall.SendStream().Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: name, ServesMountTable: true}})
+	gCall.SendStream().Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: name, ServesMountTable: true}}) // nolint: errcheck
 }
 
 // Glob finds matches in the namespace.  If we reach a mount point before matching the
@@ -801,7 +801,7 @@ func (ms *mountContext) linkToLeaf(cc *callContext, gCall rpc.GlobServerCall) {
 		servers[i].Server = naming.Join(s.Server, strings.Join(elems, "/"))
 	}
 	n.Unlock()
-	gCall.SendStream().Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: "", Servers: servers}})
+	gCall.SendStream().Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: "", Servers: servers}}) // nolint: errcheck
 }
 
 func (ms *mountContext) SetPermissions(ctx *context.T, call rpc.ServerCall, perms access.Permissions, version string) error {
@@ -845,7 +845,7 @@ func (ms *mountContext) SetPermissions(ctx *context.T, call rpc.ServerCall, perm
 	n.vPerms, err = n.vPerms.Set(ctx, version, perms)
 	if err == nil {
 		if mt.persisting {
-			mt.persist.persistPerms(ms.name, n.creator, n.vPerms)
+			mt.persist.persistPerms(ms.name, n.creator, n.vPerms) // nolint: errcheck
 		}
 		n.explicitPermissions = true
 	}

--- a/x/ref/services/mounttable/mounttablelib/mounttable_test.go
+++ b/x/ref/services/mounttable/mounttablelib/mounttable_test.go
@@ -498,6 +498,7 @@ func TestGlobAborts(t *testing.T) {
 		root, _, _ := mt.Lookup(ctx, "")
 		g, _ := glob.Parse("...")
 		fCall := &fakeServerCall{}
+		// nolint: errcheck
 		root.(rpc.Globber).Globber().AllGlobber.Glob__(ctx, fCall, g)
 		return fCall.sendCount, nil
 	}
@@ -891,7 +892,9 @@ func initTest() (rootCtx *context.T, aliceCtx *context.T, bobCtx *context.T, shu
 	}
 	for _, r := range []*context.T{rootCtx, aliceCtx, bobCtx} {
 		// A hack to set the namespace roots to a value that won't work.
-		v23.GetNamespace(r).SetRoots()
+		if err := v23.GetNamespace(r).SetRoots(); err != nil {
+			panic(err)
+		}
 		// And have all principals recognize each others blessings.
 		p1 := v23.GetPrincipal(r)
 		for _, other := range []*context.T{rootCtx, aliceCtx, bobCtx} {

--- a/x/ref/services/mounttable/mounttablelib/neighborhood.go
+++ b/x/ref/services/mounttable/mounttablelib/neighborhood.go
@@ -118,7 +118,7 @@ func newNeighborhood(host string, addresses []string, loopback bool) (*neighborh
 	logger.Global().VI(2).Infof("listening for service vanadium on port %d", port)
 	m.SubscribeToService("vanadium")
 	if len(host) > 0 {
-		m.AddService("vanadium", "", port, txt...)
+		m.AddService("vanadium", "", port, txt...) // nolint: errcheck
 	}
 
 	// A small sleep to allow the world to learn about us and vice versa.  Not
@@ -287,7 +287,9 @@ func (ns *neighborhoodService) Glob__(ctx *context.T, call rpc.GlobServerCall, g
 		matcher := g.Head()
 		for k, n := range nh.neighbors() {
 			if matcher.Match(k) {
+				// nolint: errcheck
 				sender.Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: k, Servers: n, ServesMountTable: true}})
+
 			}
 		}
 		return nil
@@ -296,6 +298,7 @@ func (ns *neighborhoodService) Glob__(ctx *context.T, call rpc.GlobServerCall, g
 		if neighbor == nil {
 			return verror.New(naming.ErrNoSuchName, ctx, ns.elems[0])
 		}
+		// nolint: errcheck
 		sender.Send(naming.GlobReplyEntry{Value: naming.MountEntry{Name: "", Servers: neighbor, ServesMountTable: true}})
 		return nil
 	default:

--- a/x/ref/services/role/roled/internal/glob.go
+++ b/x/ref/services/role/roled/internal/glob.go
@@ -29,6 +29,7 @@ func globChildren(ctx *context.T, call rpc.GlobChildrenServerCall, serverConfig 
 	}
 	for c := range n.children {
 		if m.Match(c) {
+			// nolint: errcheck
 			call.SendStream().Send(naming.GlobChildrenReplyName{Value: c})
 		}
 	}
@@ -39,6 +40,7 @@ func globChildren(ctx *context.T, call rpc.GlobChildrenServerCall, serverConfig 
 func findRoles(ctx *context.T, call security.Call, root string) *node {
 	blessingNames, _ := security.RemoteBlessingNames(ctx, call)
 	tree := newNode()
+	// nolint: errcheck
 	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() || !strings.HasSuffix(path, ".conf") {
 			return nil

--- a/x/ref/services/role/roled/internal/role.go
+++ b/x/ref/services/role/roled/internal/role.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/glob"
 	"v.io/v23/rpc"
@@ -159,7 +159,7 @@ func createBlessings(ctx *context.T, call security.Call, config *Config, princip
 			return security.Blessings{}, verror.Convert(verror.ErrInternal, ctx, err)
 		}
 		if ret, err = security.UnionOfBlessings(ret, b); err != nil {
-			verror.Convert(verror.ErrInternal, ctx, err)
+			verror.Convert(verror.ErrInternal, ctx, err) // nolint: errcheck
 		}
 	}
 	return ret, nil

--- a/x/ref/services/role/roled/internal/role_internal_test.go
+++ b/x/ref/services/role/roled/internal/role_internal_test.go
@@ -22,7 +22,7 @@ func TestImportMembers(t *testing.T) {
 		t.Fatalf("ioutil.TempDir failed: %v", err)
 	}
 	defer os.RemoveAll(workdir)
-	os.Mkdir(filepath.Join(workdir, "sub"), 0700)
+	os.Mkdir(filepath.Join(workdir, "sub"), 0700) // nolint: errcheck
 
 	configs := map[string]Config{
 		"role1":     {Members: []security.BlessingPattern{"A", "B", "C"}},

--- a/x/ref/services/role/roled/internal/role_test.go
+++ b/x/ref/services/role/roled/internal/role_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/rpc"
@@ -132,7 +132,9 @@ func TestSeekBlessings(t *testing.T) {
 		if len(rejected) != 0 {
 			t.Errorf("unexpected rejected blessings for (%q, %q): %q", user, tc.role, rejected)
 		}
-		v23.GetPrincipal(tc.ctx).BlessingStore().Set(previousBlessings, security.AllPrincipals)
+		if _, err := v23.GetPrincipal(tc.ctx).BlessingStore().Set(previousBlessings, security.AllPrincipals); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
@@ -184,7 +186,9 @@ func TestPeerBlessingCaveats(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	v23.GetPrincipal(user).BlessingStore().Set(blessings, security.AllPrincipals)
+	if _, err := v23.GetPrincipal(user).BlessingStore().Set(blessings, security.AllPrincipals); err != nil {
+		t.Fatal(err)
+	}
 
 	testcases := []struct {
 		peer          string
@@ -219,9 +223,9 @@ func TestGlob(t *testing.T) {
 		t.Fatalf("ioutil.TempDir failed: %v", err)
 	}
 	defer os.RemoveAll(workdir)
-	os.Mkdir(filepath.Join(workdir, "sub1"), 0700)
-	os.Mkdir(filepath.Join(workdir, "sub1", "sub2"), 0700)
-	os.Mkdir(filepath.Join(workdir, "sub3"), 0700)
+	os.Mkdir(filepath.Join(workdir, "sub1"), 0700)         // nolint: errcheck
+	os.Mkdir(filepath.Join(workdir, "sub1", "sub2"), 0700) // nolint: errcheck
+	os.Mkdir(filepath.Join(workdir, "sub3"), 0700)         // nolint: errcheck
 
 	// Role that user1 has access to.
 	roleAConf := irole.Config{Members: []security.BlessingPattern{"test-blessing:user1"}}
@@ -277,7 +281,9 @@ func newPrincipalContext(t *testing.T, ctx *context.T, root *testutil.IDProvider
 	if err != nil {
 		t.Fatalf("security.UnionOfBlessings failed: %v", err)
 	}
-	vsecurity.SetDefaultBlessings(principal, bUnion)
+	if err := vsecurity.SetDefaultBlessings(principal, bUnion); err != nil {
+		t.Fatal(err)
+	}
 	ctx, err = v23.WithPrincipal(ctx, principal)
 	if err != nil {
 		t.Fatalf("v23.WithPrincipal failed: %v", err)

--- a/x/ref/services/xproxy/xproxy/proxy.go
+++ b/x/ref/services/xproxy/xproxy/proxy.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/flow"
 	"v.io/v23/flow/message"
@@ -342,6 +342,7 @@ func (p *proxy) dialNextHop(ctx *context.T, f flow.Flow, m *message.Setup) (flow
 func (p *proxy) replyToServerLocked(ctx *context.T, f flow.Flow) error {
 	if err := p.authorizeFlow(ctx, f); err != nil {
 		if f.Conn().CommonVersion() >= version.RPCVersion13 {
+			// nolint: errcheck
 			writeMessage(ctx, &message.ProxyErrorResponse{Error: err.Error()}, f)
 		}
 		return err
@@ -350,6 +351,7 @@ func (p *proxy) replyToServerLocked(ctx *context.T, f flow.Flow) error {
 	eps, err := p.returnEndpointsLocked(ctx, rid, "")
 	if err != nil {
 		if f.Conn().CommonVersion() >= version.RPCVersion13 {
+			// nolint: errcheck
 			writeMessage(ctx, &message.ProxyErrorResponse{Error: err.Error()}, f)
 		}
 		return err
@@ -378,6 +380,7 @@ func (p *proxy) replyToProxyLocked(ctx *context.T, f flow.Flow) error {
 	eps, err := p.returnEndpointsLocked(ctx, naming.NullRoutingID, rid.String())
 	if err != nil {
 		if f.Conn().CommonVersion() >= version.RPCVersion13 {
+			// nolint: errcheck
 			writeMessage(ctx, &message.ProxyErrorResponse{Error: err.Error()}, f)
 		}
 		return err

--- a/x/ref/services/xproxy/xproxy/proxy_test.go
+++ b/x/ref/services/xproxy/xproxy/proxy_test.go
@@ -631,7 +631,9 @@ func TestProxyBlessings(t *testing.T) {
 	if err := pblesser.Bless(serverP, "server"); err != nil {
 		t.Fatal(err)
 	}
-	serverP.BlessingStore().Set(def, "...")
+	if _, err := serverP.BlessingStore().Set(def, "..."); err != nil {
+		t.Fatal(err)
+	}
 
 	// Start the proxy.
 	pname, stop := startProxy(t, pctx, "proxy", nil, "", address{"tcp", "127.0.0.1:0"})

--- a/x/ref/services/xproxy/xproxyd/main.go
+++ b/x/ref/services/xproxy/xproxyd/main.go
@@ -14,7 +14,7 @@ import (
 	"net/http"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/v23/security"
@@ -99,7 +99,7 @@ func (nilDispatcher) Lookup(*context.T, string) (interface{}, security.Authorize
 type healthzHandler struct{}
 
 func (healthzHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	w.Write([]byte("ok"))
+	w.Write([]byte("ok")) // nolint: errcheck
 }
 
 // startHealthzServer starts a HTTP server that simply returns "ok" to every

--- a/x/ref/test/basics/basics_test.go
+++ b/x/ref/test/basics/basics_test.go
@@ -292,5 +292,7 @@ func BenchmarkRoundtripUnix(b *testing.B) {
 }
 
 func BenchmarkRoundtripTCP_C(b *testing.B) {
-	cRoundTrip(b)
+	if err := cRoundTrip(b); err != nil {
+		b.Fatal(err)
+	}
 }

--- a/x/ref/test/basics/tls_test.go
+++ b/x/ref/test/basics/tls_test.go
@@ -89,7 +89,7 @@ func BenchmarkTLSHandshake(b *testing.B) {
 	ch := make(chan *tls.Conn)
 	go func() {
 		for c := range ch {
-			c.Handshake()
+			c.Handshake() // nolint: errcheck
 		}
 	}()
 	defer close(ch)

--- a/x/ref/test/benchmark/stats.go
+++ b/x/ref/test/benchmark/stats.go
@@ -98,7 +98,7 @@ func (stats *Stats) maybeUpdate() {
 		MinValue:           stats.min})
 
 	for _, d := range stats.durations {
-		stats.histogram.Add(int64(d / stats.unit))
+		stats.histogram.Add(int64(d / stats.unit)) // nolint: errcheck
 	}
 
 	stats.dirty = false

--- a/x/ref/test/benchmark/util.go
+++ b/x/ref/test/benchmark/util.go
@@ -131,12 +131,12 @@ func splitLines(data []byte, eof bool) (advance int, token []byte, err error) {
 	}
 
 	if i := bytes.IndexByte(data, '\n'); i >= 0 {
-		orgStdout.Write(data[nextOutPos : i+1])
+		orgStdout.Write(data[nextOutPos : i+1]) // nolint: errcheck
 		nextOutPos = 0
 		return i + 1, data[0:i], nil
 	}
 
-	orgStdout.Write(data[nextOutPos:])
+	orgStdout.Write(data[nextOutPos:]) // nolint: errcheck
 	nextOutPos = len(data)
 
 	if eof {

--- a/x/ref/test/benchmark/util_test.go
+++ b/x/ref/test/benchmark/util_test.go
@@ -50,7 +50,7 @@ func TestStatsInjection(t *testing.T) {
 	outC := make(chan string)
 	go func() {
 		b := new(bytes.Buffer)
-		io.Copy(b, r)
+		io.Copy(b, r) // nolint: errcheck
 		r.Close()
 		outC <- b.String()
 	}()

--- a/x/ref/test/expect/expect.go
+++ b/x/ref/test/expect/expect.go
@@ -138,7 +138,7 @@ func (s *Session) logWithDepth(err error, depth int, format string, args ...inte
 // error reports the error. It must be called directly from every public
 // function that can produce an error; otherwise, the file:line info will be
 // incorrect.
-func (s *Session) error(err error) error {
+func (s *Session) error(err error) {
 	_, file, line, _ := runtime.Caller(2)
 	s.oerr = err
 	s.err = fmt.Errorf("%s:%d: %s", filepath.Base(file), line, err)
@@ -148,7 +148,6 @@ func (s *Session) error(err error) error {
 			s.t.FailNow()
 		}
 	}
-	return s.err
 }
 
 type reader func(r *bufio.Reader) (string, error)

--- a/x/ref/test/expect/expect_test.go
+++ b/x/ref/test/expect/expect_test.go
@@ -43,7 +43,7 @@ func TestExpectf(t *testing.T) {
 	buffer.WriteString("bar 22\n")
 	s := expect.NewSession(nil, bufio.NewReader(buffer), time.Minute)
 	s.Expectf("bar %d", 22)
-	s.ExpectEOF()
+	s.ExpectEOF() // nolint: errcheck
 	if err := s.Error(); err != nil {
 		t.Error(err)
 	}
@@ -56,7 +56,7 @@ func TestEOF(t *testing.T) {
 	buffer.WriteString("baz 22\n")
 	s := expect.NewSession(nil, bufio.NewReader(buffer), time.Minute)
 	s.Expectf("bar %d", 22)
-	s.ExpectEOF()
+	s.ExpectEOF() // nolint: errcheck
 	if err := s.Error(); err == nil {
 		t.Error("unexpected success")
 	} else {

--- a/x/ref/test/hello/hello_v23_test.go
+++ b/x/ref/test/hello/hello_v23_test.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	// Allow v23.Init to be called multiple times.
 	library.AllowMultipleInitializations = true
-	ref.EnvClearCredentials()
+	ref.EnvClearCredentials() // nolint: errcheck
 }
 
 func withCreds(dir string, c *v23test.Cmd) *v23test.Cmd {

--- a/x/ref/test/init_common.go
+++ b/x/ref/test/init_common.go
@@ -64,7 +64,7 @@ func editNamespace(ctx *context.T, v23testProcess, createMounttable bool) {
 	}
 
 	if !createMounttable {
-		ns.SetRoots()
+		ns.SetRoots() // nolint: errcheck
 		return
 	}
 
@@ -77,7 +77,7 @@ func editNamespace(ctx *context.T, v23testProcess, createMounttable bool) {
 	if err != nil {
 		panic(err)
 	}
-	ns.SetRoots(s.Status().Endpoints[0].Name())
+	ns.SetRoots(s.Status().Endpoints[0].Name()) // nolint: errcheck
 }
 
 func editEnvironment(v23testProcess bool) func() {


### PR DESCRIPTION
This PR 'fixes' errcheck errors either by checking the errors or disabling the lint check for the offending statements.