### PR TITLE
lint: fix lint staticcheck, ineffassign errors.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@ jobs:
     executor:
       name: go/default
       tag: "1.14"
-    environment:
-      VDLPATH:
     steps:
       - checkout
       - go/load-cache
@@ -47,6 +45,30 @@ jobs:
             golangci-lint run ./...
             validjson ./...
 
+  integration-tests:
+    executor:
+      name: go/default
+      tag: "1.14"
+    steps:
+      - checkout
+      - go/load-cache
+      - go/mod-download
+      - run:
+          name: goimports
+          command: |
+            go get golang.org/x/tools/cmd/goimports
+            go install -x golang.org/x/tools/cmd/goimports
+      - go/save-cache
+      - run:
+          name: vdlpath
+          command: |
+            echo "export VDLPATH=$CIRCLE_WORKING_DIRECTORY" >> $BASH_ENV
+            source $BASH_ENV
+      - run:
+          name: integration-tests
+          command: |
+            make test-integration
+
 version: 2.1
 orbs:
   go: circleci/go@1.1.2
@@ -55,3 +77,4 @@ workflows:
     jobs:
       - test
       - lint
+      - integration-tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+run:
+  timeout: 5m
+  issues-exit-code: 1
+  tests: true
+  build-tags:
+
+linters-settings:
+  gocyclo:
+    min-complexity: 15
+
+linters:
+  enable:
+    - deadcode
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - scopelint
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - varcheck
+  disable-all: true

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shirou/gopsutil v2.19.9+incompatible h1:IrPVlK4nfwW10DF7pW+7YJKws9NkgNzWozwwWv9FsgY=
 github.com/shirou/gopsutil v2.19.9+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
-github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
@@ -63,8 +61,6 @@ github.com/vanadium/go-mdns-sd v0.0.0-20181006014439-f1a1ccd1252e/go.mod h1:35fX
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 h1:Gv7RPwsi3eZ2Fgewe3CBsuOebPwO27PoXzRpJPsvSSM=
-golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -132,7 +128,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-v.io/x/lib v0.1.4 h1:PCDfluqBeRbA7OgDIs9tIpT+z6ZNZ5VMeR+t7h/K2ig=
-v.io/x/lib v0.1.4/go.mod h1:maU79RWqiiC9ARbvS+2Q8tqZUnQiHxeJDriXcW7cYg8=
 v.io/x/lib v0.1.5 h1:Nv82WPqT0W9vHdc2CnLEOQepmSCsvEKUQHFwf/kXc6s=
 v.io/x/lib v0.1.5/go.mod h1:aLm+mPXyXf4Vd/n+1f4LcSQFFgqNhNzwQvHYfXoOLlE=

--- a/v23/context/gcontext_test.go
+++ b/v23/context/gcontext_test.go
@@ -4,6 +4,7 @@ import (
 	gocontext "context"
 	"testing"
 	"time"
+
 	vcontext "v.io/v23/context"
 )
 
@@ -41,14 +42,15 @@ func TestDeadline(t *testing.T) {
 
 func TestValue(t *testing.T) {
 	c0, cancel0 := vcontext.RootContext()
-	c1 := vcontext.WithValue(c0, "foo1", "bar1")
-	c2 := gocontext.WithValue(c1, "foo2", "bar2")
+	type ts string // define a new type to avoid collisions with string
+	c1 := vcontext.WithValue(c0, ts("foo1"), ts("bar1"))
+	c2 := gocontext.WithValue(c1, ts("foo2"), ts("bar2"))
 	c3 := vcontext.FromGoContext(c2)
 
-	if v := c3.Value("foo1"); v.(string) != "bar1" {
+	if v := c3.Value(ts("foo1")); v.(ts) != "bar1" {
 		t.Error(v)
 	}
-	if v := c3.Value("foo2"); v.(string) != "bar2" {
+	if v := c3.Value(ts("foo2")); v.(ts) != "bar2" {
 		t.Error(v)
 	}
 	select {

--- a/v23/flow/message/message.go
+++ b/v23/flow/message/message.go
@@ -321,7 +321,7 @@ func (m *Auth) read(ctx *context.T, orig []byte) error {
 	if m.ChannelBinding.R, data, valid = readLenBytes(ctx, data); !valid {
 		return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 4, nil)
 	}
-	if m.ChannelBinding.S, data, valid = readLenBytes(ctx, data); !valid {
+	if m.ChannelBinding.S, _, valid = readLenBytes(ctx, data); !valid {
 		return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 5, nil)
 	}
 	return nil

--- a/v23/i18n/i18n.go
+++ b/v23/i18n/i18n.go
@@ -35,14 +35,17 @@
 // parameter may depend on LangID.
 package i18n
 
-import "bufio"
-import "fmt"
-import "io"
-import "os"
-import "strconv"
-import "strings"
-import "sync"
-import "v.io/v23/context"
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"v.io/v23/context"
+)
 
 // MsgID identifies a message, without specifying its language.
 type MsgID string
@@ -286,7 +289,7 @@ func (cat *Catalogue) Merge(r io.Reader) error {
 		var formatStr string
 		var fields int
 		fields, err = fmt.Sscanf(lineStr, "%s %s %q", &langID, &msgID, &formatStr)
-		if fields == 3 && !strings.HasPrefix(string(langID), "#") {
+		if err == nil && fields == 3 && !strings.HasPrefix(string(langID), "#") {
 			cat.SetWithBase(langID, msgID, formatStr)
 		}
 		lineStr, err = bufReader.ReadString('\n')

--- a/v23/query/engine/internal/query_parser/query_parser.go
+++ b/v23/query/engine/internal/query_parser/query_parser.go
@@ -329,12 +329,12 @@ func Parse(db ds.Database, src string) (*Statement, error) {
 	case "select":
 		var st Statement
 		var err error
-		st, token, err = selectStatement(db, &s, token)
+		st, _, err = selectStatement(db, &s, token)
 		return &st, err
 	case "delete":
 		var st Statement
 		var err error
-		st, token, err = deleteStatement(db, &s, token)
+		st, _, err = deleteStatement(db, &s, token)
 		return &st, err
 	default:
 		return nil, syncql.NewErrUnknownIdentifier(db.GetContext(), token.Off, token.Value)
@@ -576,9 +576,9 @@ func parseWhereClause(db ds.Database, s *scanner.Scanner, token *Token) (*WhereC
 }
 
 // Parse a parenthesized expression.  Return expression and next token (or error)
-func parseParenthesizedExpression(db ds.Database, s *scanner.Scanner, token *Token) (*Expression, *Token, error) {
+func parseParenthesizedExpression(db ds.Database, s *scanner.Scanner, _ *Token) (*Expression, *Token, error) {
 	// Only called when token == TokLEFTPAREN
-	token = scanToken(s) // eat '('
+	token := scanToken(s) // eat '('
 	var expr *Expression
 	var err error
 	expr, token, err = parseExpression(db, s, token)
@@ -690,11 +690,11 @@ func parseLikeEqualExpression(db ds.Database, s *scanner.Scanner, token *Token) 
 	return &expression, token, nil
 }
 
-func parseFunction(db ds.Database, s *scanner.Scanner, funcName string, funcOffset int64, token *Token) (*Function, *Token, error) {
+func parseFunction(db ds.Database, s *scanner.Scanner, funcName string, funcOffset int64, _ *Token) (*Function, *Token, error) {
 	var function Function
 	function.Name = funcName
 	function.Off = funcOffset
-	token = scanToken(s) // eat left paren
+	token := scanToken(s) // eat left paren
 	for token.Tok != TokRIGHTPAREN {
 		if token.Tok == TokEOF {
 			return nil, nil, syncql.NewErrExpected(db.GetContext(), token.Off, ")")

--- a/v23/query/engine/query_test.go
+++ b/v23/query/engine/query_test.go
@@ -2400,6 +2400,9 @@ func TestSelect(t *testing.T) {
 		}
 		h := p.Handle()
 		p2, err := qe.GetPreparedStatement(h)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		headers, rs, err := p2.Exec()
 		if err != nil {

--- a/v23/security/caveat.go
+++ b/v23/security/caveat.go
@@ -195,6 +195,7 @@ func (c *Caveat) Validate(ctx *context.T, call Call) error {
 func (c *Caveat) ThirdPartyDetails() ThirdPartyCaveat {
 	if c.Id == PublicKeyThirdPartyCaveat.Id {
 		var param publicKeyThirdPartyCaveatParam
+		// nolint: staticcheck //lint:ignore SA9003
 		if err := vom.Decode(c.ParamVom, &param); err != nil {
 			// TODO(jsimsa): Decide what (if any) logging mechanism to use.
 			// vlog.Errorf("Error decoding PublicKeyThirdPartyCaveat: %v", err)

--- a/v23/vom/dump.go
+++ b/v23/vom/dump.go
@@ -354,6 +354,9 @@ func (d *dumpWorker) writeStatus(err error, doneDecoding bool) {
 		d.status.Buf = nil
 	}
 	err = NewDecoder(bytes.NewReader(d.recReader.bytes)).Decode(&d.status.Value)
+	if err != nil {
+		d.status.Err = err
+	}
 	d.w.WriteStatus(d.status)
 	if doneDecoding {
 		d.status = DumpStatus{}
@@ -499,6 +502,9 @@ func (d *dumpWorker) decodeValueMsg(tt *vdl.Type) error {
 				return err
 			}
 			d.status.RefTypes[i], err = d.typeDec.lookupType(TypeId(tid))
+			if err != nil {
+				return err
+			}
 			d.writeAtom(DumpKindTypeId, PrimitivePUint{tid}, "")
 		}
 		if containsAny(tt) {

--- a/x/jni/impl/google/services/vango/funcs.go
+++ b/x/jni/impl/google/services/vango/funcs.go
@@ -104,11 +104,7 @@ func btAndDiscoveryFunc(ctx *context.T, w io.Writer) error {
 		"v.io/x/jni/impl/google/services/vango/Echo3",
 		"v.io/x/jni/impl/google/services/vango/Echo4",
 	}
-	type adstate struct {
-		ad   *discovery.Advertisement
-		stop func()
-	}
-	ads := []adstate{}
+
 	for _, name := range interfaces {
 		ad := &discovery.Advertisement{
 			InterfaceName: name,
@@ -119,18 +115,12 @@ func btAndDiscoveryFunc(ctx *context.T, w io.Writer) error {
 				"four":  "This is insane",
 			},
 		}
-		nctx, ncancel := context.WithCancel(ctx)
-		ch, err := libdiscovery.AdvertiseServer(nctx, dis, server, "", ad, nil)
+		nctx, _ := context.WithCancel(ctx)
+		_, err := libdiscovery.AdvertiseServer(nctx, dis, server, "", ad, nil)
 		if err != nil {
 			bothf(nctx, w, "Can't advertise server %v", err)
 			return err
 		}
-
-		stop := func() {
-			ncancel()
-			<-ch
-		}
-		ads = append(ads, adstate{ad, stop})
 	}
 
 	type updateState struct {

--- a/x/ref/cmd/principal/main.go
+++ b/x/ref/cmd/principal/main.go
@@ -515,7 +515,7 @@ appear on this list. If the principal is operating as a server, clients must
 present blessings derived from this list.
 `,
 		Runner: v23cmd.RunnerFunc(func(ctx *context.T, env *cmdline.Env, args []string) error {
-			fmt.Printf(v23.GetPrincipal(ctx).Roots().DebugString())
+			fmt.Print(v23.GetPrincipal(ctx).Roots().DebugString())
 			return nil
 		}),
 	}
@@ -530,7 +530,7 @@ If the principal operates as a client, it presents the map value associated with
 the peer it contacts.
 `,
 		Runner: v23cmd.RunnerFunc(func(ctx *context.T, env *cmdline.Env, args []string) error {
-			fmt.Printf(v23.GetPrincipal(ctx).BlessingStore().DebugString())
+			fmt.Print(v23.GetPrincipal(ctx).BlessingStore().DebugString())
 			return nil
 		}),
 	}
@@ -1018,7 +1018,7 @@ This file can be supplied to bless:
 				token:                base64.URLEncoding.EncodeToString(token[:]),
 				notify:               make(chan error),
 			}
-			ctx, server, err := v23.WithNewServer(ctx, "", service, security.AllowEveryone())
+			_, server, err := v23.WithNewServer(ctx, "", service, security.AllowEveryone())
 			if err != nil {
 				return fmt.Errorf("failed to create server to listen for blessings: %v", err)
 			}

--- a/x/ref/cmd/vdl/arith_test.go
+++ b/x/ref/cmd/vdl/arith_test.go
@@ -349,6 +349,10 @@ func TestArith(t *testing.T) {
 
 		addStream, err := ar.StreamingAdd(ctx)
 
+		if err != nil {
+			t.Errorf("StreamingAdd failed with %v", err)
+		}
+
 		go func() {
 			sender := addStream.SendStream()
 			for i := int32(0); i < 100; i++ {

--- a/x/ref/lib/raft/client_test.go
+++ b/x/ref/lib/raft/client_test.go
@@ -92,7 +92,6 @@ func buildRafts(t *testing.T, ctx *context.T, n int, config *RaftConfig) ([]*raf
 	// Start each server with its own log directory.
 	var rs []*raft
 	var cs []*client
-	var td []string
 	for i := 0; i < n; i++ {
 		if n > 1 || len(config.LogDir) == 0 {
 			config.LogDir = tempDir(t)
@@ -102,7 +101,6 @@ func buildRafts(t *testing.T, ctx *context.T, n int, config *RaftConfig) ([]*raf
 		if err != nil {
 			t.Fatalf("NewRaft: %s", err)
 		}
-		td = append(td, config.LogDir)
 		c.id = r.Id()
 		rs = append(rs, r)
 		cs = append(cs, c)

--- a/x/ref/lib/raft/fspersistence.go
+++ b/x/ref/lib/raft/fspersistence.go
@@ -533,7 +533,7 @@ func parseFileName(s string) (Term, Index, error) {
 		return 0, 0, err
 	}
 	i, err := strconv.ParseInt(p[1], 10, 64)
-	return Term(t), Index(i), nil
+	return Term(t), Index(i), err
 }
 
 // readState is called on start up.  State is recreated from the last valid snapshot and

--- a/x/ref/lib/security/blessingroots.go
+++ b/x/ref/lib/security/blessingroots.go
@@ -54,9 +54,8 @@ func (br *blessingRoots) Add(root []byte, pattern security.BlessingPattern) erro
 }
 
 func (br *blessingRoots) Recognized(root []byte, blessing string) error {
-	key := string(root)
 	br.mu.RLock()
-	for _, p := range br.state[key] {
+	for _, p := range br.state[string(root)] {
 		if p.MatchedBy(blessing) {
 			br.mu.RUnlock()
 			return nil

--- a/x/ref/lib/security/passphrase/passphrase.go
+++ b/x/ref/lib/security/passphrase/passphrase.go
@@ -24,7 +24,7 @@ func Get(prompt string) ([]byte, error) {
 		// obtained by reading a line from it.
 		return readPassphrase()
 	}
-	fmt.Printf(prompt)
+	fmt.Print(prompt)
 	stop := make(chan bool)
 	defer close(stop)
 	state, err := terminal.GetState(int(os.Stdin.Fd()))
@@ -72,7 +72,7 @@ func secureAppend(s []byte, t byte) []byte {
 		copy(s, make([]byte, len(s)))
 	}
 	// Clear out the byte.
-	t = 0
+	t = 0 // nolint: ineffassign
 	return res
 }
 

--- a/x/ref/lib/security/prepare_discharges_test.go
+++ b/x/ref/lib/security/prepare_discharges_test.go
@@ -116,7 +116,7 @@ func TestPrepareDischarges(t *testing.T) {
 	}
 	tpid := tpcav.ThirdPartyDetails().ID()
 
-	dctx, _, err = v23.WithNewServer(dctx,
+	_, _, err = v23.WithNewServer(dctx,
 		"discharger",
 		&expiryDischarger{map[string]time.Duration{
 			tpcav.ThirdPartyDetails().ID(): 100 * time.Millisecond,

--- a/x/ref/lib/security/util_test.go
+++ b/x/ref/lib/security/util_test.go
@@ -27,6 +27,9 @@ func TestLoadSavePEMKey(t *testing.T) {
 	}
 
 	loadedKey, err := LoadPEMKey(&buf, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(loadedKey, key) {
 		t.Fatalf("Got key %v, but want %v", loadedKey, key)
 	}
@@ -55,6 +58,9 @@ func TestLoadSavePEMKeyWithPassphrase(t *testing.T) {
 		t.Fatalf("Failed to save ECDSA private key: %v", err)
 	}
 	loadedKey, err = LoadPEMKey(&buf, pass)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(loadedKey, key) {
 		t.Fatalf("Got key %v, but want %v", loadedKey, key)
 	}

--- a/x/ref/lib/stats/counter/timeseries_test.go
+++ b/x/ref/lib/stats/counter/timeseries_test.go
@@ -144,7 +144,7 @@ func TestTimeSeriesValues(t *testing.T) {
 	// Add 3 more values.
 	// slots: [6, 7, 8, 3, 4, 5]
 	// values: [3, 4, 5, 6, 7, 8]
-	now = addValue(1, 3, ts, now)
+	addValue(1, 3, ts, now)
 	if expected, got := []int64{3, 4, 5, 6, 7, 8}, ts.values(); !reflect.DeepEqual(got, expected) {
 		t.Errorf("unexpected values. Got %v, want %v", got, expected)
 	}

--- a/x/ref/lib/vdl/build/build.go
+++ b/x/ref/lib/vdl/build/build.go
@@ -317,7 +317,6 @@ func SrcDirs(errs *vdlutil.Errors) []string {
 func GoModuleName(path string) (string, error) {
 	gomod := filepath.Join(path, "go.mod")
 	buf, err := ioutil.ReadFile(gomod)
-	path = filepath.Dir(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			err = nil
@@ -823,7 +822,7 @@ func (ds *depSorter) resolveImportPath(pkgPath string, mode UnknownPathMode, pre
 	}
 	// Look through srcDirs in-order until we find a valid package dir.
 	var dirs []string
-	for _, srcDir := range append(ds.srcDirs) {
+	for _, srcDir := range ds.srcDirs {
 		dir := filepath.Join(srcDir, filepath.FromSlash(pkgPath))
 		if pkg := ds.resolveDirPath(dir, UnknownPathIsIgnored); pkg != nil {
 			vdlutil.Vlog.Printf("%s: resolved import path %q", pkg.Dir, pkgPath)
@@ -838,7 +837,6 @@ func (ds *depSorter) resolveImportPath(pkgPath string, mode UnknownPathMode, pre
 				vdlutil.Vlog.Printf("%s: resolved import path %q using go.mod to %v", pkg.Dir, pkgPath, dir)
 				return pkg
 			}
-			dirs = append(dirs, dir)
 			return nil
 		}
 	}

--- a/x/ref/lib/vdl/codegen/java/file_package_info.go
+++ b/x/ref/lib/vdl/codegen/java/file_package_info.go
@@ -28,7 +28,6 @@ func genJavaPackageFile(pkg *compile.Package, env *compile.Env) *JavaFileInfo {
 				log.Printf("WARNING: Multiple vdl files with package documentation. One will be overwritten.")
 				return nil
 			}
-			generated = true
 
 			data := struct {
 				Doc         string
@@ -51,6 +50,7 @@ func genJavaPackageFile(pkg *compile.Package, env *compile.Env) *JavaFileInfo {
 				Data: buf.Bytes(),
 			}
 		}
+		generated = true
 	}
 	return nil
 }

--- a/x/ref/lib/vdl/compile/error_test.go
+++ b/x/ref/lib/vdl/compile/error_test.go
@@ -82,7 +82,7 @@ type errorTest struct {
 
 const (
 	en i18n.LangID = "en"
-	zh             = "zh"
+	zh i18n.LangID = "zh"
 )
 
 func arg(name string, t *vdl.Type) *compile.Field {

--- a/x/ref/runtime/internal/flow/conn/util_test.go
+++ b/x/ref/runtime/internal/flow/conn/util_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/flow"
 	"v.io/v23/naming"
@@ -95,8 +95,8 @@ func setupFlows(t *testing.T, network, address string, dctx, actx *context.T, di
 	}
 	if !dialFromDialer {
 		d, a = a, d
-		dctx, actx = actx, dctx
-		aflows, dflows = dflows, aflows
+		dctx = actx
+		aflows = dflows
 	}
 	for i := 0; i < n; i++ {
 		var err error

--- a/x/ref/runtime/internal/flow/manager/conncache.go
+++ b/x/ref/runtime/internal/flow/manager/conncache.go
@@ -192,7 +192,7 @@ func (c *ConnCache) Find(
 	auth flow.PeerAuthorizer,
 ) (conn CachedConn, names []string, rejected []security.RejectedBlessing, err error) {
 	var keys []interface{}
-	if keys, conn, names, rejected, err = c.internalFindCached(ctx, remote, auth); conn != nil {
+	if keys, conn, names, rejected, _ = c.internalFindCached(ctx, remote, auth); conn != nil {
 		return conn, names, rejected, nil
 	}
 	// Finally try waiting for any outstanding dials to complete.

--- a/x/ref/runtime/internal/lib/iobuf/slice_test.go
+++ b/x/ref/runtime/internal/lib/iobuf/slice_test.go
@@ -30,7 +30,7 @@ func TestExpandFront(t *testing.T) {
 	if slice.Size() != 7 {
 		t.Errorf("Expected length 9, got %d", slice.Size())
 	}
-	ok = slice.ExpandFront(3)
+	slice.ExpandFront(3)
 	if slice.Size() != 10 {
 		t.Errorf("Expected length 10, got %d", slice.Size())
 	}

--- a/x/ref/runtime/internal/naming/namespace/cache_test.go
+++ b/x/ref/runtime/internal/naming/namespace/cache_test.go
@@ -84,10 +84,6 @@ func TestCache(t *testing.T) {
 	lkup := func(name string, servers ...string) {
 		_, file, line, _ := runtime.Caller(1)
 		loc := fmt.Sprintf("%v:%v", filepath.Base(file), line)
-		srvs := []naming.MountedServer{}
-		for _, s := range servers {
-			srvs = append(srvs, naming.MountedServer{Server: s, Deadline: future(30)})
-		}
 		e, err := c.lookup(ctx, "/h1//t/"+name)
 		if err != nil {
 			t.Fatalf("%v: failed for %v: %v", loc, name, err)

--- a/x/ref/runtime/internal/rpc/client.go
+++ b/x/ref/runtime/internal/rpc/client.go
@@ -261,7 +261,6 @@ func (c *client) reconnectPinnedConn(ctx *context.T, p *pinnedConn, name string,
 				delay = reconnectDelay
 				p.mu.Lock()
 				p.conn = r.flow.Conn()
-				closed = p.conn.Closed()
 				p.mu.Unlock()
 			}
 		case <-p.done:
@@ -644,6 +643,7 @@ func (fc *flowClient) close(err error) error {
 	}
 	subErr := verror.SubErr{Err: err, Options: verror.Print}
 	subErr.Name = "remote=" + fc.flow.RemoteEndpoint().String()
+	// nolint: staticcheck //lint:ignore SA9003
 	if cerr := fc.flow.Close(); cerr != nil && err == nil {
 		// TODO(mattr): The context is often already canceled here, in
 		// which case we'll get an error.  Not clear what to do.
@@ -800,6 +800,7 @@ func (fc *flowClient) closeSend() error {
 	if fc.sendClosed {
 		return nil
 	}
+	// nolint: staticcheck //lint:ignore SA9003
 	if err := fc.enc.Encode(rpc.Request{EndStreamArgs: true}); err != nil {
 		// TODO(caprita): Indiscriminately closing the flow below causes
 		// a race as described in:

--- a/x/ref/runtime/internal/rpc/stress/mtstress/run.go
+++ b/x/ref/runtime/internal/rpc/stress/mtstress/run.go
@@ -57,7 +57,7 @@ func run(f func(*context.T) (time.Duration, error), p params) error {
 		latency   = make(chan time.Duration, 1000)
 		started   = time.Now()
 		stop      = time.After(p.Duration)
-		interrupt = make(chan os.Signal)
+		interrupt = make(chan os.Signal, 1)
 		ret       report
 	)
 	defer ticker.Stop()
@@ -132,7 +132,6 @@ func warmup(ctx *context.T, f func(*context.T) (time.Duration, error)) {
 }
 
 func call(ctx *context.T, f func(*context.T) (time.Duration, error), reauth bool, d chan<- time.Duration) {
-	client := v23.GetClient(ctx)
 	if reauth {
 		// HACK ALERT: At the time the line below was written, it was
 		// known that the implementation would cause 'ctx' to be setup
@@ -145,7 +144,7 @@ func call(ctx *context.T, f func(*context.T) (time.Duration, error), reauth bool
 			ctx.Infof("%v", err)
 			return
 		}
-		client = v23.GetClient(ctx)
+		client := v23.GetClient(ctx)
 		defer client.Close()
 	}
 	sample, err := f(ctx)

--- a/x/ref/runtime/internal/rpc/test/full_test.go
+++ b/x/ref/runtime/internal/rpc/test/full_test.go
@@ -1130,7 +1130,7 @@ func TestPrivateServer(t *testing.T) {
 	client := v23.GetClient(cctx)
 
 	// Test that an RPC to the server fails as the client has no blessing private keys.
-	call, err := client.StartCall(cctx, serverEPName, "Closure", nil)
+	_, err = client.StartCall(cctx, serverEPName, "Closure", nil)
 	if err == nil {
 		t.Error("RPC by client with no blessing private key unexpectedly succeeded")
 	}
@@ -1140,7 +1140,7 @@ func TestPrivateServer(t *testing.T) {
 	if err := bcrypter.GetCrypter(cctx).AddKey(cctx, extractKey(t, ctx, root, "root:otherclient")); err != nil {
 		t.Fatal(err)
 	}
-	call, err = client.StartCall(cctx, serverEPName, "Closure", nil)
+	_, err = client.StartCall(cctx, serverEPName, "Closure", nil)
 	if err == nil {
 		t.Error("RPC by client with no matching blessing private key unexpectedly succeeded")
 	}
@@ -1150,7 +1150,7 @@ func TestPrivateServer(t *testing.T) {
 	if err := bcrypter.GetCrypter(cctx).AddKey(cctx, extractKey(t, ctx, root, "root:client")); err != nil {
 		t.Fatal(err)
 	}
-	call, err = client.StartCall(cctx, serverEPName, "Closure", nil, options.ServerAuthorizer{Authorizer: access.AccessList{In: []security.BlessingPattern{"root:server:$"}}})
+	call, err := client.StartCall(cctx, serverEPName, "Closure", nil, options.ServerAuthorizer{Authorizer: access.AccessList{In: []security.BlessingPattern{"root:server:$"}}})
 	if err != nil {
 		t.Error(verror.DebugString(err))
 	} else {

--- a/x/ref/runtime/internal/rpc/test/server_test.go
+++ b/x/ref/runtime/internal/rpc/test/server_test.go
@@ -46,7 +46,6 @@ func TestBadObject(t *testing.T) {
 	defer shutdown()
 
 	sctx := withPrincipal(t, ctx, "server")
-	cctx := withPrincipal(t, ctx, "client")
 
 	if _, _, err := v23.WithNewServer(sctx, "", nil, nil); err == nil {
 		t.Fatal("should have failed")
@@ -63,7 +62,7 @@ func TestBadObject(t *testing.T) {
 	// TODO(mattr): It doesn't necessarily make sense to me that a bad object from
 	// the dispatcher results in a retry.
 	var cancel context.CancelFunc
-	cctx, cancel = context.WithTimeout(ctx, time.Second)
+	cctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 	var result string
 	if err := v23.GetClient(cctx).Call(cctx, "servername", "SomeMethod", nil, []interface{}{&result}); err == nil {
@@ -283,7 +282,8 @@ func mountedBlessings(ctx *context.T, name string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, ms := range me.Servers {
+	if len(me.Servers) > 0 {
+		ms := me.Servers[0]
 		ep, err := naming.ParseEndpoint(ms.Server)
 		if err != nil {
 			return nil, err

--- a/x/ref/runtime/internal/rpc/test/simple_test.go
+++ b/x/ref/runtime/internal/rpc/test/simple_test.go
@@ -81,7 +81,7 @@ func (s *simple) Inc(_ *context.T, call rpc.StreamServerCall, inc int) (int, err
 
 func startSimpleServer(t *testing.T, ctx *context.T) (string, func()) {
 	done := make(chan struct{})
-	ctx, server, err := v23.WithNewServer(ctx, "", &simple{done}, nil)
+	_, server, err := v23.WithNewServer(ctx, "", &simple{done}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/x/ref/runtime/internal/rt/mgmt.go
+++ b/x/ref/runtime/internal/rt/mgmt.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/v23/security"
@@ -38,6 +38,9 @@ func (rt *Runtime) initMgmt(ctx *context.T) error {
 	}
 
 	parentName, err := config.Get(mgmt.ParentNameConfigKey)
+	if err != nil {
+		return err
+	}
 	if ctx, err = setListenSpec(ctx, rt, config); err != nil {
 		return err
 	}

--- a/x/ref/runtime/internal/rt/rpc_test.go
+++ b/x/ref/runtime/internal/rt/rpc_test.go
@@ -247,7 +247,7 @@ func TestServerDischarges(t *testing.T) {
 		t.Fatal(err)
 	}
 	ds := &dischargeService{}
-	dischargerCtx, server, err := v23.WithNewServer(dischargerCtx, "", ds, security.AllowEveryone())
+	_, server, err := v23.WithNewServer(dischargerCtx, "", ds, security.AllowEveryone())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,7 +326,7 @@ func TestServerDischarges(t *testing.T) {
 	if err := pserver.BlessingStore().SetDefault(rootServerInvalidTPCaveat); err != nil {
 		t.Fatal(err)
 	}
-	serverCtx, server, err = v23.WithNewServer(serverCtx, "", testService{}, security.AllowEveryone())
+	_, server, err = v23.WithNewServer(serverCtx, "", testService{}, security.AllowEveryone())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x/ref/runtime/internal/rt/runtime.go
+++ b/x/ref/runtime/internal/rt/runtime.go
@@ -278,7 +278,7 @@ func (r *Runtime) setPrincipal(ctx *context.T, principal security.Principal, shu
 
 func (r *Runtime) WithPrincipal(ctx *context.T, principal security.Principal) (*context.T, error) {
 	var err error
-	newctx := ctx
+	var newctx *context.T
 
 	// TODO(mattr, suharshs): If there user gives us some principal that has dependencies
 	// we don't know about, we will not honour those dependencies during shutdown.

--- a/x/ref/runtime/internal/vtrace/vtrace_logging_test.go
+++ b/x/ref/runtime/internal/vtrace/vtrace_logging_test.go
@@ -25,9 +25,9 @@ func TestLogging(t *testing.T) {
 	ctx, shutdown, _ := initForTest(t)
 	defer shutdown()
 
-	ctx, span := vtrace.WithNewTrace(ctx)
+	ctx, _ = vtrace.WithNewTrace(ctx)
 	vtrace.ForceCollect(ctx, 0)
-	ctx, span = vtrace.WithNewSpan(ctx, "foo")
+	ctx, span := vtrace.WithNewSpan(ctx, "foo")
 	ctx.Info("logging ", "from ", "info")
 	ctx.Infof("logging from %s", "infof")
 	ctx.InfoDepth(0, "logging from info depth")

--- a/x/ref/runtime/protocols/debug/debug.go
+++ b/x/ref/runtime/protocols/debug/debug.go
@@ -93,8 +93,12 @@ type debug struct{}
 
 func (d *debug) Dial(ctx *context.T, network, address string, timeout time.Duration) (flow.Conn, error) {
 	var base flow.Protocol
-	if network, address, base = baseProtocol(address); base == nil {
+	var baseNetwork string
+	if baseNetwork, address, base = baseProtocol(address); base == nil {
 		return nil, fmt.Errorf("could not find underlying protocol %q", network)
+	}
+	if len(baseNetwork) > 0 {
+		network = baseNetwork
 	}
 	c, err := base.Dial(ctx, network, address, timeout)
 	if err != nil {
@@ -104,8 +108,12 @@ func (d *debug) Dial(ctx *context.T, network, address string, timeout time.Durat
 }
 func (d *debug) Listen(ctx *context.T, network, address string) (flow.Listener, error) {
 	var base flow.Protocol
-	if network, address, base = baseProtocol(address); base == nil {
+	var baseNetwork string
+	if baseNetwork, address, base = baseProtocol(address); base == nil {
 		return nil, fmt.Errorf("could not find underlying protocol %q", network)
+	}
+	if len(baseNetwork) > 0 {
+		network = baseNetwork
 	}
 	l, err := base.Listen(ctx, network, address)
 	if err != nil {

--- a/x/ref/runtime/protocols/lib/websocket/ws.go
+++ b/x/ref/runtime/protocols/lib/websocket/ws.go
@@ -45,6 +45,8 @@ func (WS) Dial(ctx *context.T, protocol, address string, timeout time.Duration) 
 	if err != nil {
 		return nil, err
 	}
+
+	// nolint: staticcheck //lint:ignore SA1019
 	ws, _, err := websocket.NewClient(conn, u, http.Header{}, bufferSize, bufferSize)
 	if err != nil {
 		return nil, err

--- a/x/ref/runtime/protocols/vine/vine.go
+++ b/x/ref/runtime/protocols/vine/vine.go
@@ -45,6 +45,10 @@ func Init(ctx *context.T, name string, auth security.Authorizer, localTag string
 	v := protocol.(*vine)
 	ctx, cancel := context.WithCancel(ctx)
 	_, server, err := v23.WithNewServer(ctx, name, VineServer(v), auth)
+	if err != nil {
+		cancel()
+		return nil, func() {}, err
+	}
 	serverShutdown := func() {
 		cancel()
 		<-server.Closed()

--- a/x/ref/services/agent/agentlib/agent_test.go
+++ b/x/ref/services/agent/agentlib/agent_test.go
@@ -181,6 +181,9 @@ func TestAgentDischargeCache(t *testing.T) {
 		"discharger",
 		security.ThirdPartyRequirements{},
 		expcav)
+	if err != nil {
+		t.Fatal(err)
+	}
 	d, err := agent.MintDischarge(tpcav, expcav)
 	if err != nil {
 		t.Fatal(err)

--- a/x/ref/services/agent/agentlib/principal.go
+++ b/x/ref/services/agent/agentlib/principal.go
@@ -168,9 +168,8 @@ const agentBinName = "v23agentd"
 
 // findAgent tries to locate an agent binary that we can run.
 func findAgent() (string, version.T, error) {
-	// TODO(caprita): Besides checking PATH, we can also look under
-	// JIRI_ROOT.  Also, consider caching a copy of the agent binary under
-	// <creds dir>/agent?
+	// TODO(caprita): Besides checking PATH, we can also consider caching
+	// a copy of the agent binary under <creds dir>/agent?
 	var defaultVersion version.T
 	agentBin, err := exec.LookPath(agentBinName)
 	if err != nil {

--- a/x/ref/services/agent/agentlib/principal_v23_test.go
+++ b/x/ref/services/agent/agentlib/principal_v23_test.go
@@ -191,12 +191,13 @@ func TestV23AgentPrincipal(t *testing.T) {
 		t.Errorf("Agent didn't seem to have exited")
 	}
 
-	p1 = loadPrincipal()
+	loadPrincipal()
 
 	// The agent restarted, so re-establish the commands socket connection.
-	cmds, err = net.Dial("unix", filepath.Join(constants.AgentDir(credsDir), "commands"))
+	socket := filepath.Join(constants.AgentDir(credsDir), "commands")
+	cmds, err = net.Dial("unix", socket)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("faile to dial socket: %v: %v", socket, err)
 	}
 	defer cmds.Close()
 	cmdsRead = bufio.NewScanner(cmds)

--- a/x/ref/services/agent/gcreds/main.go
+++ b/x/ref/services/agent/gcreds/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	gocontext "context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -106,7 +107,9 @@ func runGcreds(ctx *context.T, env *cmdline.Env, args []string) error {
 		return err
 	}
 
-	ref.EnvClearCredentials() // nolint: errcheck
+	if err := ref.EnvClearCredentials(); err != nil {
+		return err
+	}
 	if err := os.Setenv(ref.EnvAgentPath, socketPath); err != nil {
 		return err
 	}
@@ -157,10 +160,10 @@ func getGoogleCloudBlessings(ctx *context.T) error {
 		if err != nil {
 			return err
 		}
-		tokSource = conf.TokenSource(oauth2.NoContext)
+		tokSource = conf.TokenSource(gocontext.TODO())
 	} else {
 		var err error
-		if tokSource, err = google.DefaultTokenSource(oauth2.NoContext, scope); err != nil {
+		if tokSource, err = google.DefaultTokenSource(gocontext.TODO(), scope); err != nil {
 			return err
 		}
 	}

--- a/x/ref/services/agent/internal/cache/cache_test.go
+++ b/x/ref/services/agent/internal/cache/cache_test.go
@@ -19,7 +19,7 @@ import (
 func createRoots() ([]byte, security.BlessingRoots, *cachedRoots) {
 	var mu sync.RWMutex
 	ctx, _ := context.RootContext()
-	ctx = context.WithLogger(ctx, logger.Global())
+	context.WithLogger(ctx, logger.Global())
 	p := testutil.NewPrincipal()
 	impl := p.Roots()
 	roots, err := newCachedRoots(impl, &mu)
@@ -208,7 +208,7 @@ func TestDefaultBlessing(t *testing.T) {
 	if cur, _ := store.Default(); !reflect.DeepEqual(carol, cur) {
 		t.Errorf("Default(): got: %v, want: %v", cur, carol)
 	}
-	if cached, notify = cache.Default(); !reflect.DeepEqual(carol, cached) {
+	if cached, _ = cache.Default(); !reflect.DeepEqual(carol, cached) {
 		t.Errorf("Default(): got: %v, want: %v", cached, carol)
 	}
 
@@ -254,7 +254,7 @@ func TestSet(t *testing.T) {
 		t.Errorf("ForPeer(bob:server) got: %v, want: %v", got, want)
 	}
 
-	blessings, err = cache.Set(john, "john")
+	_, err = cache.Set(john, "john")
 	if err == nil {
 		t.Errorf("No error from set")
 	}
@@ -262,11 +262,11 @@ func TestSet(t *testing.T) {
 		t.Errorf("ForPeer(john:server) got: %v, want: %v", got, nil)
 	}
 
-	blessings, err = cache.Set(bob, "...")
+	_, err = cache.Set(bob, "...")
 	if err != nil {
 		t.Errorf("Set() failed: %v", err)
 	}
-	blessings, err = cache.Set(alice, "bob")
+	_, err = cache.Set(alice, "bob")
 	if err != nil {
 		t.Errorf("Set() failed: %v", err)
 	}

--- a/x/ref/services/agent/internal/test_principal/main.go
+++ b/x/ref/services/agent/internal/test_principal/main.go
@@ -15,7 +15,7 @@ import (
 	"reflect"
 	"runtime"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/security"
 	"v.io/x/lib/cmdline"
@@ -126,7 +126,7 @@ func runTestPrincipal(ctx *context.T, env *cmdline.Env, args []string) error {
 		errorf("BlessingStore().SetDefault: %v", err)
 	}
 	<-defCh
-	if def, defCh = p.BlessingStore().Default(); !reflect.DeepEqual(def, b) {
+	if def, _ = p.BlessingStore().Default(); !reflect.DeepEqual(def, b) {
 		errorf("BlessingStore().Default returned [%v], want [%v]", def, b)
 	}
 	// BlessingStore: Set & ForPeer

--- a/x/ref/services/application/applicationd/perms_test.go
+++ b/x/ref/services/application/applicationd/perms_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/security"
 	"v.io/v23/security/access"
 	"v.io/v23/services/application"
@@ -127,7 +127,7 @@ func TestApplicationUpdatePermissions(t *testing.T) {
 		t.Fatalf("SetPermissions failed: %v", err)
 	}
 
-	perms, version, err = repostub.GetPermissions(ctx)
+	perms, _, err = repostub.GetPermissions(ctx)
 	if err != nil {
 		t.Fatalf("GetPermissions should not have failed: %v", err)
 	}

--- a/x/ref/services/ben/benarchd/internal/store.go
+++ b/x/ref/services/ben/benarchd/internal/store.go
@@ -111,7 +111,9 @@ func ParseQuery(query string) (*Query, error) {
 		set = set || trySetField(&ret.OS, &err, "os:", f)
 		set = set || trySetField(&ret.Uploader, &err, "uploader:", f)
 		set = set || trySetField(&ret.Label, &err, "label:", f)
-		set = set || trySetField(&ret.Name, &err, "", f)
+		if !set {
+			trySetField(&ret.Name, &err, "", f)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/x/ref/services/device/device/publish.go
+++ b/x/ref/services/device/device/publish.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/security"
@@ -90,7 +90,7 @@ func setAccessLists(ctx *context.T, env *cmdline.Env, von string) error {
 }
 
 func publishOne(ctx *context.T, env *cmdline.Env, binPath, binary string) error {
-	binaryName, envelopeName, title := binary, binary, binary
+	var binaryName, envelopeName, title string
 	binaryRE := regexp.MustCompile(`^([^:@]+)(:[^@]+)?(@.+)?$`)
 	if parts := binaryRE.FindStringSubmatch(binary); len(parts) == 4 {
 		binaryName = parts[1]

--- a/x/ref/services/device/deviced/internal/impl/app_service.go
+++ b/x/ref/services/device/deviced/internal/impl/app_service.go
@@ -554,6 +554,9 @@ func setupPrincipal(ctx *context.T, instanceDir string, call device.ApplicationI
 	// If there were any publisher blessings in the envelope, add those to the set of blessings
 	// sent to servers by default
 	appBlessings, err := addPublisherBlessings(ctx, instanceDir, p, appBlessingsFromInstantiator.Value)
+	if err != nil {
+		return verror.New(errors.ErrOperationFailed, ctx, fmt.Sprintf("addPublisherBlessings: failed: %v", err))
+	}
 	if _, err := p.BlessingStore().Set(appBlessings, security.AllPrincipals); err != nil {
 		return verror.New(errors.ErrOperationFailed, ctx, fmt.Sprintf("BlessingStore.Set() failed: %v", err))
 	}

--- a/x/ref/services/device/deviced/internal/impl/association_state_test.go
+++ b/x/ref/services/device/deviced/internal/impl/association_state_test.go
@@ -139,7 +139,7 @@ func TestAssociationPersistenceDetectsBadStartingConditions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}
-	nbsa1, err = impl.NewBlessingSystemAssociationStore(dir)
+	_, err = impl.NewBlessingSystemAssociationStore(dir)
 	defer os.RemoveAll(dir)
 	if err != nil {
 		t.Fatalf("NewBlessingSystemAssociationStore failed: %v", err)

--- a/x/ref/services/device/deviced/internal/impl/device_service.go
+++ b/x/ref/services/device/deviced/internal/impl/device_service.go
@@ -290,7 +290,12 @@ func (s *deviceService) testDeviceManager(ctx *context.T, workspace string, enve
 	defer p.Close()
 	dmPrincipal := v23.GetPrincipal(ctx)
 	dmBlessings, _ := dmPrincipal.BlessingStore().Default()
-	testDmBlessings, err := dmPrincipal.Bless(p.PublicKey(), dmBlessings, "testdm", security.UnconstrainedUse())
+	testDmBlessings, err := dmPrincipal.Bless(p.PublicKey(), dmBlessings, "testdm",
+		security.UnconstrainedUse())
+	if err != nil {
+		return verror.New(errors.ErrOperationFailed, ctx, fmt.Sprintf("Bless failed: %v", err))
+	}
+
 	if err := p.BlessingStore().SetDefault(testDmBlessings); err != nil {
 		return verror.New(errors.ErrOperationFailed, ctx, fmt.Sprintf("BlessingStore.SetDefault() failed: %v", err))
 	}
@@ -345,8 +350,7 @@ func (s *deviceService) testDeviceManager(ctx *context.T, workspace string, enve
 func GenerateScript(workspace string, configSettings []string, envelope *application.Envelope, logs string) error {
 	// TODO(caprita): Remove this snippet of code, it doesn't seem to serve
 	// any purpose.
-	path, err := filepath.EvalSymlinks(os.Args[0])
-	if err != nil {
+	if _, err := filepath.EvalSymlinks(os.Args[0]); err != nil {
 		return verror.New(errors.ErrOperationFailed, nil, fmt.Sprintf("EvalSymlinks(%v) failed: %v", os.Args[0], err))
 	}
 
@@ -374,7 +378,7 @@ func GenerateScript(workspace string, configSettings []string, envelope *applica
 	output += "--logtostderr=${LOG_TO_STDERR} "
 	output += strings.Join(envelope.Args, " ")
 
-	path = filepath.Join(workspace, "deviced.sh")
+	path := filepath.Join(workspace, "deviced.sh")
 	if err := ioutil.WriteFile(path, []byte(output), 0700); err != nil {
 		return verror.New(errors.ErrOperationFailed, nil, fmt.Sprintf("WriteFile(%v) failed: %v", path, err))
 	}

--- a/x/ref/services/device/deviced/internal/impl/instance_reaping.go
+++ b/x/ref/services/device/deviced/internal/impl/instance_reaping.go
@@ -220,6 +220,10 @@ func perInstance(ctx *context.T, instancePath string, c chan<- pidErrorTuple, wg
 	defer wg.Done()
 	ctx.Infof("Instance: %v", instancePath)
 	state, err := getInstanceState(instancePath)
+	if err != nil {
+		ctx.Errorf("getInstanceState failed: %v", err)
+		return
+	}
 	switch state {
 	// Ignore apps already in deleted and not running states.
 	case device.InstanceStateNotRunning:

--- a/x/ref/services/device/deviced/internal/impl/utiltest/helpers.go
+++ b/x/ref/services/device/deviced/internal/impl/utiltest/helpers.go
@@ -114,6 +114,9 @@ func EnvelopeFromShell(sh *v23test.Shell, vars, flags []string, f *gosh.Func, ti
 func SignedEnvelopeFromShell(ctx *context.T, sh *v23test.Shell, vars, flags []string, f *gosh.Func, title string, retries int, window time.Duration, args ...interface{}) (application.Envelope, error) {
 	envelope := EnvelopeFromShell(sh, vars, flags, f, title, retries, window, args...)
 	reader, cleanup, err := mockBinaryBytesReader()
+	if err != nil {
+		return application.Envelope{}, err
+	}
 	defer cleanup()
 	sig, err := binarylib.Sign(ctx, reader)
 	if err != nil {

--- a/x/ref/services/device/inithelper/main.go
+++ b/x/ref/services/device/inithelper/main.go
@@ -52,6 +52,8 @@ func main() {
 	}
 
 	flag.Usage = usage
+
+	// nolint: staticcheck //lint:ignore SA4006 - this is a real false positive.
 	sdFlag := flag.String("service_description", "", "File containing a JSON-encoded sysinit.ServiceDescription object.")
 	systemFlag := flag.String("system", sysinit.InitSystem(), "System label, to select the appropriate sysinit mechanism.")
 	flag.Parse()

--- a/x/ref/services/device/mgmt_v23_test.go
+++ b/x/ref/services/device/mgmt_v23_test.go
@@ -544,7 +544,6 @@ func testCore(t *testing.T, sh *v23test.Shell, appUser, deviceUser string, withS
 	// Kill the device manager (which causes it to be restarted), wait for
 	// the endpoint to change.
 	withArgs(deviceBin, "kill", mtName+"/devmgr/device").Run()
-	mtEP = resolveChange(mtName, mtEP)
 
 	// Shut down the device manager.
 	stopDevMgrOnce.Do(stopDevMgr)
@@ -575,7 +574,7 @@ func testCore(t *testing.T, sh *v23test.Shell, appUser, deviceUser string, withS
 	// owned by the device manager user and unreadable by the user
 	// running this test.
 	if !withSuid {
-		fi, err = ioutil.ReadDir(dmInstallDir)
+		_, err = ioutil.ReadDir(dmInstallDir)
 		if err != nil {
 			t.Fatalf("failed to readdir for %q: %v", dmInstallDir, err)
 		}

--- a/x/ref/services/groups/groups/main_test.go
+++ b/x/ref/services/groups/groups/main_test.go
@@ -14,7 +14,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/rpc"
@@ -84,7 +84,7 @@ func capitalize(s string) string {
 
 func startServer(ctx *context.T, t *testing.T) (rpc.Server, naming.Endpoint) {
 	unpublished := ""
-	ctx, s, err := v23.WithNewServer(ctx, unpublished, groups.GroupServer(&mock{}), nil)
+	_, s, err := v23.WithNewServer(ctx, unpublished, groups.GroupServer(&mock{}), nil)
 	if err != nil {
 		t.Fatalf("NewServer(%v) failed: %v", unpublished, err)
 	}

--- a/x/ref/services/groups/internal/server/server_test.go
+++ b/x/ref/services/groups/internal/server/server_test.go
@@ -340,7 +340,7 @@ func testPermsHelper(t *testing.T, be backend) {
 	}
 
 	// SetPermissions with correct version should succeed.
-	permsBefore, versionBefore = permsAfter, versionAfter
+	_, versionBefore = permsAfter, versionAfter
 	if err := ac.SetPermissions(ctx, myperms, versionBefore); err != nil {
 		t.Fatalf("SetPermissions failed: %v", err)
 	}
@@ -354,7 +354,7 @@ func testPermsHelper(t *testing.T, be backend) {
 	}
 
 	// SetPermissions with empty version should succeed.
-	permsBefore, versionBefore = permsAfter, versionAfter
+	_, versionBefore = permsAfter, versionAfter
 	myperms.Add(security.BlessingPattern("idp:client"), string(access.Read))
 	if err := ac.SetPermissions(ctx, myperms, ""); err != nil {
 		t.Fatalf("SetPermissions failed: %v", err)

--- a/x/ref/services/identity/internal/oauth/googleoauth.go
+++ b/x/ref/services/identity/internal/oauth/googleoauth.go
@@ -5,6 +5,7 @@
 package oauth
 
 import (
+	gocontext "context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -58,7 +59,7 @@ func (g *googleOAuth) AuthURL(redirectUrl, state string, approval AuthURLApprova
 // tokeninfo API to extract the email address from that token.
 func (g *googleOAuth) ExchangeAuthCodeForEmail(authcode string, url string) (string, error) {
 	config := g.oauthConfig(url)
-	t, err := config.Exchange(oauth2.NoContext, authcode)
+	t, err := config.Exchange(gocontext.TODO(), authcode)
 	if err != nil {
 		return "", fmt.Errorf("failed to exchange authorization code for token: %v", err)
 	}

--- a/x/ref/services/identity/internal/oauth/handler.go
+++ b/x/ref/services/identity/internal/oauth/handler.go
@@ -320,7 +320,7 @@ func validLoopbackURL(u string) (*url.URL, error) {
 		return nil, fmt.Errorf("invalid url: %v", err)
 	}
 	// Remove the port from the netURL.Host.
-	host, _, err := net.SplitHostPort(netURL.Host)
+	host, _, _ := net.SplitHostPort(netURL.Host)
 	// Check if its localhost or loopback ip
 	if host == "localhost" {
 		return netURL, nil

--- a/x/ref/services/identity/internal/revocation/revocation_manager.go
+++ b/x/ref/services/identity/internal/revocation/revocation_manager.go
@@ -92,6 +92,7 @@ func isRevoked(ctx *context.T, call security.Call, key []byte) error {
 	revocationLock.RUnlock()
 	revoked, err := revocationDB.IsRevoked(key)
 	if err != nil {
+		return fmt.Errorf("failed to call IsRevoked: %v", err)
 	}
 	if revoked {
 		return fmt.Errorf("revoked")

--- a/x/ref/services/internal/binarylib/client_test.go
+++ b/x/ref/services/internal/binarylib/client_test.go
@@ -53,7 +53,7 @@ func setupRepository(t *testing.T, ctx *context.T) (string, func()) {
 		t.Fatalf("NewDispatcher() failed: %v\n", err)
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	ctx, server, err := v23.WithNewDispatchingServer(ctx, "", dispatcher)
+	_, server, err := v23.WithNewDispatchingServer(ctx, "", dispatcher)
 	if err != nil {
 		t.Fatalf("NewServer() failed: %v", err)
 	}

--- a/x/ref/services/internal/binarylib/perms_test.go
+++ b/x/ref/services/internal/binarylib/perms_test.go
@@ -457,7 +457,7 @@ func TestBinaryRationalStartingValueForGetPermissions(t *testing.T) {
 		t.Fatalf("SetPermissions() failed: %v", err)
 	}
 
-	perms, tag, err = b("bini").GetPermissions(selfCtx)
+	perms, _, err = b("bini").GetPermissions(selfCtx)
 	if err != nil {
 		t.Fatalf("GetPermissions failed: %#v", err)
 	}

--- a/x/ref/services/internal/fs/simplestore_test.go
+++ b/x/ref/services/internal/fs/simplestore_test.go
@@ -157,7 +157,10 @@ func TestSerializeDeserialize(t *testing.T) {
 
 	// TRANSACTION BEGIN Write a value to /test/b as well.
 	memstoreOriginal.Lock()
-	tname, err = memstoreOriginal.BindTransactionRoot("also ignored").CreateTransaction(nil)
+	_, err = memstoreOriginal.BindTransactionRoot("also ignored").CreateTransaction(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	bindingTnameTestB := memstoreOriginal.BindObject(fs.TP("/test/b"))
 	if _, err := bindingTnameTestB.Put(nil, envelope); err != nil {
 		t.Fatalf("Put() failed: %v", err)
@@ -201,7 +204,9 @@ func TestSerializeDeserialize(t *testing.T) {
 	// TRANSACTION BEGIN (to be abandonned)
 	memstoreOriginal.Lock()
 	tname, err = memstoreOriginal.BindTransactionRoot("").CreateTransaction(nil)
-
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Exists is true before doing anything.
 	if err := allPathsExist(memstoreOriginal, []string{fs.TP("/test")}); err != nil {
 		t.Fatalf("%v", err)
@@ -309,8 +314,10 @@ func TestSerializeDeserialize(t *testing.T) {
 
 	// TRANSACTION BEGIN
 	memstoreCopy.Lock()
-	tname, err = memstoreCopy.BindTransactionRoot("also ignored").CreateTransaction(nil)
-
+	_, err = memstoreCopy.BindTransactionRoot("also ignored").CreateTransaction(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Add a pending object c to test that pending objects are deleted.
 	if _, err := memstoreCopy.BindObject(fs.TP("/test/c")).Put(nil, secondEnvelope); err != nil {
 		t.Fatalf("Put() failed: %v", err)
@@ -426,7 +433,7 @@ func TestOperationsNeedValidBinding(t *testing.T) {
 
 	// Attempt inserting a value at /test/b
 	memstoreOriginal.Lock()
-	tname, err = memstoreOriginal.BindTransactionRoot("").CreateTransaction(nil)
+	_, err = memstoreOriginal.BindTransactionRoot("").CreateTransaction(nil)
 	if err != nil {
 		t.Fatalf("CreateTransaction() failed: %v", err)
 	}
@@ -588,6 +595,9 @@ func gobPersist(t *testing.T, ms *fs.Memstore) error {
 
 	enc := gob.NewEncoder(file)
 	err = enc.Encode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := enc.Encode(data); err != nil {
 		t.Fatalf("enc.Encode() failed: %v", err)
 	}

--- a/x/ref/services/internal/pproflib/proxy.go
+++ b/x/ref/services/internal/pproflib/proxy.go
@@ -162,7 +162,7 @@ func (p *proxy) cmdLine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	fmt.Fprintf(w, strings.Join(cmdline, "\x00"))
+	fmt.Fprint(w, strings.Join(cmdline, "\x00"))
 }
 
 // symbol replies with a map of program counters to object name.

--- a/x/ref/services/internal/restsigner/rest_signer.go
+++ b/x/ref/services/internal/restsigner/rest_signer.go
@@ -5,6 +5,7 @@
 package restsigner
 
 import (
+	gocontext "context"
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/base64"
@@ -45,7 +46,7 @@ func DecodeSignature(sig *signer.VSignature) (r, s *big.Int, err error) {
 }
 
 func NewRestSigner() (security.Signer, error) {
-	client, err := signer.New(oauth2.NewClient(oauth2.NoContext, google.ComputeTokenSource("")))
+	client, err := signer.New(oauth2.NewClient(gocontext.TODO(), google.ComputeTokenSource("")))
 	if err != nil {
 		return nil, err
 	}

--- a/x/ref/services/mounttable/mounttablelib/mounttable_test.go
+++ b/x/ref/services/mounttable/mounttablelib/mounttable_test.go
@@ -202,7 +202,7 @@ func newMT(t *testing.T, permsFile, persistDir, statsDir string, rootCtx *contex
 
 	// Start serving on a loopback address.
 	ctx, cancel := context.WithCancel(ctx)
-	ctx, server, err := v23.WithNewDispatchingServer(ctx, "", mt, options.ServesMountTable(true))
+	_, server, err := v23.WithNewDispatchingServer(ctx, "", mt, options.ServesMountTable(true))
 	if err != nil {
 		boom(t, "r.NewServer: %s", err)
 	}

--- a/x/ref/services/mounttable/mounttablelib/servers.go
+++ b/x/ref/services/mounttable/mounttablelib/servers.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/naming"
 	"v.io/v23/options"
@@ -90,6 +90,10 @@ func StartServers(ctx *context.T, listenSpec rpc.ListenSpec, mountName, nhName, 
 			nh, err = NewLoopbackNeighborhoodDispatcher(nhName, names...)
 		} else {
 			nh, err = NewNeighborhoodDispatcher(nhName, names...)
+		}
+		if err != nil {
+			ctx.Errorf("NewLoopback or Neigborhood dispatcher (host %s) failed: %v", host, err)
+			return "", nil, err
 		}
 
 		ctx, nhServer, err := v23.WithNewDispatchingServer(ctx, naming.Join(mtName, "nh"), nh, options.ServesMountTable(true))

--- a/x/ref/services/mounttable/mounttablelib/versionedpermissions.go
+++ b/x/ref/services/mounttable/mounttablelib/versionedpermissions.go
@@ -177,6 +177,9 @@ func (mt *mountTable) parsePermFile(ctx *context.T, path string) error {
 // pickCreator returns a string matching the blessing of the user performing the creation.
 func (mt *mountTable) pickCreator(ctx *context.T, call security.Call) string {
 	ids := conventions.GetClientUserIds(ctx, call)
-	// Replace the slashes with something else or we'll confuse the stats package.
-	return strings.Replace(ids[0], "/", "\\", 0)
+	if len(ids) > 0 {
+		// Replace the slashes with something else or we'll confuse the stats package.
+		return strings.Replace(ids[0], "/", "\\", -1)
+	}
+	return ""
 }

--- a/x/ref/services/role/roled/internal/glob.go
+++ b/x/ref/services/role/roled/internal/glob.go
@@ -42,6 +42,9 @@ func findRoles(ctx *context.T, call security.Call, root string) *node {
 	tree := newNode()
 	// nolint: errcheck
 	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() || !strings.HasSuffix(path, ".conf") {
 			return nil
 		}

--- a/x/ref/services/role/roled/internal/role_test.go
+++ b/x/ref/services/role/roled/internal/role_test.go
@@ -80,7 +80,7 @@ func TestSeekBlessings(t *testing.T) {
 
 	testServerCtx := newPrincipalContext(t, ctx, root, "testserver")
 	tDisp := &testDispatcher{}
-	testServerCtx, _, err = v23.WithNewDispatchingServer(testServerCtx, "test", tDisp)
+	_, _, err = v23.WithNewDispatchingServer(testServerCtx, "test", tDisp)
 	if err != nil {
 		t.Fatalf("NewDispatchingServer failed: %v", err)
 	}
@@ -168,15 +168,15 @@ func TestPeerBlessingCaveats(t *testing.T) {
 	roleAddr := newRoleServer(t, newPrincipalContext(t, ctx, root, "roles"), workdir)
 
 	tDisp := &testDispatcher{}
-	peer1, _, err = v23.WithNewDispatchingServer(peer1, "peer1", tDisp)
+	_, _, err = v23.WithNewDispatchingServer(peer1, "peer1", tDisp)
 	if err != nil {
 		t.Fatalf("NewDispatchingServer failed: %v", err)
 	}
-	peer2, _, err = v23.WithNewDispatchingServer(peer2, "peer2", tDisp)
+	_, _, err = v23.WithNewDispatchingServer(peer2, "peer2", tDisp)
 	if err != nil {
 		t.Fatalf("NewDispatchingServer failed: %v", err)
 	}
-	peer3, _, err = v23.WithNewDispatchingServer(peer3, "peer3", tDisp)
+	_, _, err = v23.WithNewDispatchingServer(peer3, "peer3", tDisp)
 	if err != nil {
 		t.Fatalf("NewDispatchingServer failed: %v", err)
 	}
@@ -292,7 +292,7 @@ func newPrincipalContext(t *testing.T, ctx *context.T, root *testutil.IDProvider
 }
 
 func newRoleServer(t *testing.T, ctx *context.T, dir string) string {
-	ctx, _, err := v23.WithNewDispatchingServer(ctx, "role", irole.NewDispatcher(dir, "role"))
+	_, _, err := v23.WithNewDispatchingServer(ctx, "role", irole.NewDispatcher(dir, "role"))
 	if err != nil {
 		t.Fatalf("ServeDispatcher failed: %v", err)
 	}

--- a/x/ref/test/init.go
+++ b/x/ref/test/init.go
@@ -65,7 +65,7 @@ func debug(ctx *context.T, shutdown func()) {
 	eps := s.Status().Endpoints
 
 	go func() {
-		ch := make(chan os.Signal)
+		ch := make(chan os.Signal, 1)
 		signal.Notify(ch, os.Interrupt)
 		<-ch
 		signal.Stop(ch)

--- a/x/ref/test/v23test/v23test.go
+++ b/x/ref/test/v23test/v23test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"v.io/v23"
+	v23 "v.io/v23"
 	"v.io/v23/context"
 	"v.io/v23/rpc"
 	"v.io/v23/security"


### PR DESCRIPTION
This PR fixes primarily lint staticcheck and ineffassign erroors. It also adds the integration tests to the circleci configs. The golangci-lint config file is also checked in .