### PR TITLE
x/ref/lib/vdl/codegen/java: fix for handling certain float values

### DIFF
--- a/x/ref/lib/vdl/codegen/java/util_val.go
+++ b/x/ref/lib/vdl/codegen/java/util_val.go
@@ -78,7 +78,7 @@ func javaVal(v *vdl.Value, env *compile.Env) string {
 		return strconv.FormatInt(v.Int(), 10) + longSuffix
 	case vdl.Float32, vdl.Float64:
 		c := strconv.FormatFloat(v.Float(), 'g', -1, bitlen(v.Kind()))
-		if !strings.Contains(c, ".") {
+		if !strings.Contains(c, ".") && !strings.Contains(c, "e") {
 			c += ".0"
 		}
 		if v.Kind() == vdl.Float32 {


### PR DESCRIPTION
For float values that don't have '.' the code is appending a '.0'. The bug is
that we only need to do this if there are no exponents. When we have an
exponents appending the '.0' is generating invalid numbers (like '5e-203.0'
instead of '5e-203').