### PR TITLE
lint: final round of fixes

### DIFF
--- a/v23/context/context.go
+++ b/v23/context/context.go
@@ -106,6 +106,7 @@ const (
 
 // ContextLogger is a logger that uses a passed in T to configure
 // the logging behavior.
+//nolint:golint // API change required.
 type ContextLogger interface {
 	// InfoDepth logs to the INFO log. depth is used to determine which call frame to log.
 	InfoDepth(ctx *T, depth int, args ...interface{})
@@ -129,10 +130,12 @@ type ContextLogger interface {
 type CancelFunc func()
 
 // Cancelled is returned by contexts which have been cancelled.
+//nolint:golint // API change required.
 var Canceled = errors.New("context canceled")
 
 // DeadlineExceeded is returned by contexts that have exceeded their
 // deadlines and therefore been canceled automatically.
+//nolint:golint // API change required.
 var DeadlineExceeded = errors.New("context deadline exceeded")
 
 // T carries deadlines, cancellation and data across API boundaries.

--- a/v23/conventions/uid.go
+++ b/v23/conventions/uid.go
@@ -49,6 +49,7 @@ func GetClientUserIds(ctx *context.T, call security.Call) []string {
 }
 
 // Parse the userId components from a blessing name or a userId string.  Returns nil on failure.
+//nolint:golint // API change required.
 func ParseUserId(s string) []string {
 	c := strings.Split(s, security.ChainSeparator)
 	if len(c) >= 3 && len(c[1]) == 1 {

--- a/v23/discovery/adid.go
+++ b/v23/discovery/adid.go
@@ -28,6 +28,7 @@ func (id AdId) String() string {
 }
 
 // NewId returns a new random id.
+//nolint:golint // API change required.
 func NewAdId() (AdId, error) {
 	var id AdId
 	if _, err := rand.Read(id[:]); err != nil {
@@ -37,6 +38,7 @@ func NewAdId() (AdId, error) {
 }
 
 // Parse decodes the hexadecimal string into id.
+//nolint:golint // API change required.
 func ParseAdId(s string) (AdId, error) {
 	decoded, err := hex.DecodeString(s)
 	if err != nil {

--- a/v23/discovery/update.go
+++ b/v23/discovery/update.go
@@ -17,7 +17,7 @@ type Update interface {
 	IsLost() bool
 
 	// Id returns the universal unique identifier of the advertisement.
-	Id() AdId
+	Id() AdId //nolint:golint // API change required.
 
 	// InterfaceName returns the interface name that the service implements.
 	InterfaceName() string

--- a/v23/rpc/reflect_invoker_internal_test.go
+++ b/v23/rpc/reflect_invoker_internal_test.go
@@ -47,6 +47,7 @@ func (o *tags) Delta(*context.T, ServerCall, int) (int, error)                  
 func (o *tags) Epsilon(*context.T, ServerCall, int, string) (int, string, error) { return 0, "", nil }
 func (o *tags) Error(*context.T, ServerCall) error                               { return errApp }
 
+//nolint:golint // API change required.
 func (o *tags) Describe__() []InterfaceDesc {
 	return []InterfaceDesc{{
 		Methods: []MethodDesc{
@@ -145,25 +146,53 @@ func (*badRecv3Call) RecvStream() interface {
 	return nil
 }
 
-func (badoutargs) NoFinalError1(*context.T, ServerCall)                 {}
-func (badoutargs) NoFinalError2(*context.T, ServerCall) string          { return "" }
-func (badoutargs) NoFinalError3(*context.T, ServerCall) (bool, string)  { return false, "" }
+func (badoutargs) NoFinalError1(*context.T, ServerCall)                {}
+func (badoutargs) NoFinalError2(*context.T, ServerCall) string         { return "" }
+func (badoutargs) NoFinalError3(*context.T, ServerCall) (bool, string) { return false, "" }
+
+//nolint:golint // API change required.
 func (badoutargs) NoFinalError4(*context.T, ServerCall) (error, string) { return nil, "" }
 
-func (badGlobber) Globber()                                                    {}
-func (badGlob1) Glob__()                                                       {}
-func (badGlob2) Glob__(*context.T)                                             {}
-func (badGlob3) Glob__(*context.T, ServerCall)                                 {}
-func (badGlob4) Glob__(*context.T, ServerCall, string)                         {}
+func (badGlobber) Globber() {}
+
+//nolint:golint // API change required.
+func (badGlob1) Glob__() {}
+
+//nolint:golint // API change required.
+func (badGlob2) Glob__(*context.T) {}
+
+//nolint:golint // API change required.
+func (badGlob3) Glob__(*context.T, ServerCall) {}
+
+//nolint:golint // API change required.
+func (badGlob4) Glob__(*context.T, ServerCall, string) {}
+
+//nolint:golint // API change required.
 func (badGlob5) Glob__(*context.T, ServerCall, string) <-chan naming.GlobReply { return nil }
-func (badGlob6) Glob__(*context.T, ServerCall, string) error                   { return nil }
-func (badGlob7) Glob__() (<-chan naming.GlobReply, error)                      { return nil, nil }
-func (badGlobChildren1) GlobChildren__()                                       {}
-func (badGlobChildren2) GlobChildren__(*context.T)                             {}
-func (badGlobChildren3) GlobChildren__(*context.T, ServerCall)                 {}
-func (badGlobChildren4) GlobChildren__(*context.T, ServerCall) <-chan string   { return nil }
-func (badGlobChildren5) GlobChildren__(*context.T, ServerCall) error           { return nil }
-func (badGlobChildren6) GlobChildren__() (<-chan string, error)                { return nil, nil }
+
+//nolint:golint // API change required.
+func (badGlob6) Glob__(*context.T, ServerCall, string) error { return nil }
+
+//nolint:golint // API change required.
+func (badGlob7) Glob__() (<-chan naming.GlobReply, error) { return nil, nil }
+
+//nolint:golint // API change required.
+func (badGlobChildren1) GlobChildren__() {}
+
+//nolint:golint // API change required.
+func (badGlobChildren2) GlobChildren__(*context.T) {}
+
+//nolint:golint // API change required.
+func (badGlobChildren3) GlobChildren__(*context.T, ServerCall) {}
+
+//nolint:golint // API change required.
+func (badGlobChildren4) GlobChildren__(*context.T, ServerCall) <-chan string { return nil }
+
+//nolint:golint // API change required.
+func (badGlobChildren5) GlobChildren__(*context.T, ServerCall) error { return nil }
+
+//nolint:golint // API change required.
+func (badGlobChildren6) GlobChildren__() (<-chan string, error) { return nil, nil }
 
 const (
 	badInit = `Init must have signature`

--- a/v23/rpc/reflect_invoker_test.go
+++ b/v23/rpc/reflect_invoker_test.go
@@ -162,6 +162,7 @@ func (o *tags) Error(ctx *context.T, call rpc.ServerCall) error {
 	return errApp
 }
 
+//nolint:golint // API change required.
 func (o *tags) Describe__() []rpc.InterfaceDesc {
 	return []rpc.InterfaceDesc{{
 		Methods: []rpc.MethodDesc{
@@ -312,6 +313,8 @@ func (sigTest) Sig3(*context.T, *stringBoolCall, float64) ([]uint32, error) { re
 func (sigTest) Sig4(*context.T, rpc.StreamServerCall, int32, string) (int32, string, error) {
 	return 0, "", nil
 }
+
+//nolint:golint // API change required.
 func (sigTest) Describe__() []rpc.InterfaceDesc {
 	return []rpc.InterfaceDesc{
 		{
@@ -579,23 +582,47 @@ func (*badRecv3Call) RecvStream() interface {
 	return nil
 }
 
-func (badoutargs) NoFinalError1(*context.T, rpc.ServerCall)                 {}
-func (badoutargs) NoFinalError2(*context.T, rpc.ServerCall) string          { return "" }
-func (badoutargs) NoFinalError3(*context.T, rpc.ServerCall) (bool, string)  { return false, "" }
+func (badoutargs) NoFinalError1(*context.T, rpc.ServerCall)                {}
+func (badoutargs) NoFinalError2(*context.T, rpc.ServerCall) string         { return "" }
+func (badoutargs) NoFinalError3(*context.T, rpc.ServerCall) (bool, string) { return false, "" }
+
+//nolint:golint // API change required.
 func (badoutargs) NoFinalError4(*context.T, rpc.ServerCall) (error, string) { return nil, "" }
 
-func (badGlobber) Globber()                                                                   {}
-func (badGlob1) Glob__()                                                                      {}
-func (badGlob2) Glob__(*context.T)                                                            {}
-func (badGlob3) Glob__(*context.T, rpc.GlobServerCall)                                        {}
-func (badGlob4) Glob__(*context.T, rpc.GlobServerCall, *glob.Glob)                            {}
-func (badGlob5) Glob__(*context.T, rpc.ServerCall, *glob.Glob) error                          { return nil }
-func (badGlob6) Glob__() error                                                                { return nil }
-func (badGlobChildren1) GlobChildren__()                                                      {}
-func (badGlobChildren2) GlobChildren__(*context.T)                                            {}
-func (badGlobChildren3) GlobChildren__(*context.T, rpc.GlobChildrenServerCall)                {}
+func (badGlobber) Globber() {}
+
+//nolint:golint // API change required.
+func (badGlob1) Glob__() {}
+
+//nolint:golint // API change required.
+func (badGlob2) Glob__(*context.T) {}
+
+//nolint:golint // API change required.
+func (badGlob3) Glob__(*context.T, rpc.GlobServerCall) {}
+
+//nolint:golint // API change required.
+func (badGlob4) Glob__(*context.T, rpc.GlobServerCall, *glob.Glob) {}
+
+//nolint:golint // API change required.
+func (badGlob5) Glob__(*context.T, rpc.ServerCall, *glob.Glob) error { return nil }
+
+//nolint:golint // API change required.
+func (badGlob6) Glob__() error { return nil }
+
+//nolint:golint // API change required.
+func (badGlobChildren1) GlobChildren__() {}
+
+//nolint:golint // API change required.
+func (badGlobChildren2) GlobChildren__(*context.T) {}
+
+//nolint:golint // API change required.
+func (badGlobChildren3) GlobChildren__(*context.T, rpc.GlobChildrenServerCall) {}
+
+//nolint:golint // API change required.
 func (badGlobChildren4) GlobChildren__(*context.T, rpc.GlobChildrenServerCall, *glob.Element) {}
-func (badGlobChildren5) GlobChildren__(*context.T, rpc.GlobChildrenServerCall) error          { return nil }
+
+//nolint:golint // API change required.
+func (badGlobChildren5) GlobChildren__(*context.T, rpc.GlobChildrenServerCall) error { return nil }
 
 func TestReflectInvokerPanic(t *testing.T) {
 	type testcase struct {
@@ -688,12 +715,14 @@ func (o *vGlobberObject) Globber() *rpc.GlobState {
 
 type allGlobberObject struct{}
 
+//nolint:golint // API change required.
 func (allGlobberObject) Glob__(*context.T, rpc.GlobServerCall, *glob.Glob) error {
 	return nil
 }
 
 type childrenGlobberObject struct{}
 
+//nolint:golint // API change required.
 func (childrenGlobberObject) GlobChildren__(*context.T, rpc.GlobChildrenServerCall, *glob.Element) error {
 	return nil
 }

--- a/v23/rpc/util.go
+++ b/v23/rpc/util.go
@@ -34,6 +34,7 @@ type obj struct {
 	children []string
 }
 
+//nolint:golint // API change required.
 func (o obj) GlobChildren__(_ *context.T, call GlobChildrenServerCall, matcher *glob.Element) error {
 	sender := call.SendStream()
 	for _, v := range o.children {

--- a/v23/vdl/register_native.go
+++ b/v23/vdl/register_native.go
@@ -185,7 +185,7 @@ func nativeInfoForError() (*nativeInfo, error) {
 	return ni, nil
 }
 
-var errNoRegisterNativeError = errors.New(`vdl: RegisterNative must be called to register error<->WireError conversions.  Import the "v.io/v23/verror" package in your program.`)
+var errNoRegisterNativeError = errors.New(`vdl: RegisterNative must be called to register error<->WireError conversions.  Import the "v.io/v23/verror" package in your program`)
 
 // Generated code in the vdl package can use fromWireError to convert from wireError to verror.E.
 //nolint:deadcode,unused

--- a/v23/vdl/register_test.go
+++ b/v23/vdl/register_test.go
@@ -315,9 +315,9 @@ type (
 		Index() int
 		Interface() interface{}
 		Name() string
-		VDLReflect(__NameConflictReflect)
+		VDLReflect(privateNameConflictReflect)
 	}
-	__NameConflictReflect struct {
+	privateNameConflictReflect struct {
 		Name  string `vdl:"v.io/v23/vdl.OtherNameConflictType"`
 		Type  NameConflictType
 		Union struct{ A NameConflictUnionField }
@@ -326,10 +326,10 @@ type (
 	OtherNameConflictType  struct{}
 )
 
-func (x NameConflictUnionField) Index() int                       { return 0 }
-func (x NameConflictUnionField) Interface() interface{}           { return x.Value }
-func (x NameConflictUnionField) Name() string                     { return "A" }
-func (x NameConflictUnionField) VDLReflect(__NameConflictReflect) {}
+func (x NameConflictUnionField) Index() int                            { return 0 }
+func (x NameConflictUnionField) Interface() interface{}                { return x.Value }
+func (x NameConflictUnionField) Name() string                          { return "A" }
+func (x NameConflictUnionField) VDLReflect(privateNameConflictReflect) {}
 
 func TestReflectNameConflicts(t *testing.T) {
 	Register(NameConflictUnionField{})

--- a/v23/vdlroot/time/time.go
+++ b/v23/vdlroot/time/time.go
@@ -26,12 +26,14 @@ const (
 )
 
 // TimeToNative is called by VDL for conversions from wire to native times.
+//nolint:golint // API change required.
 func TimeToNative(wire Time, native *time.Time) error {
 	*native = time.Unix(wire.Seconds-unixEpoch, int64(wire.Nanos)).UTC()
 	return nil
 }
 
 // TimeFromNative is called by VDL for conversions from native to wire times.
+//nolint:golint // API change required.
 func TimeFromNative(wire *Time, native time.Time) error {
 	wire.Seconds = native.Unix() + unixEpoch
 	wire.Nanos = int32(native.Nanosecond())

--- a/v23/vom/dump.go
+++ b/v23/vom/dump.go
@@ -286,6 +286,7 @@ func (d *dumpWorker) lastFlushDone(err error) {
 // DumpStatus represents the state of the dumper.  It is written to the
 // DumpWriter at the end of decoding each value, and may also be triggered
 // explicitly via Dumper.Status calls to get information for partial dumps.
+//nolint:golint // API change required.
 type DumpStatus struct {
 	MsgId      int64
 	MsgLen     int

--- a/v23/vom/raw_bytes.go
+++ b/v23/vom/raw_bytes.go
@@ -157,7 +157,7 @@ func (rb *RawBytes) VDLRead(dec vdl.Decoder) error {
 	if enc.tids == nil || len(enc.tids.tids) == 0 {
 		rb.RefTypes = nil
 	} else {
-		tids, idToType := enc.tids.tids, enc.typeEnc.makeIdToTypeUnlocked()
+		tids, idToType := enc.tids.tids, enc.typeEnc.makeIDToTypeUnlocked()
 		rb.RefTypes = make([]*vdl.Type, len(tids))
 		for i, tid := range tids {
 			tt := bootstrapIDToType[tid]

--- a/v23/vom/type_encoder.go
+++ b/v23/vom/type_encoder.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	errEncodeTypeIdOverflow = verror.Register(pkgPath+".errEncodeTypeIdOverflow", verror.NoRetry, "{1:}{2:} vom: encoder type id overflow{:_}")
+	errEncodeTypeIDOverflow = verror.Register(pkgPath+".errEncodeTypeIDOverflow", verror.NoRetry, "{1:}{2:} vom: encoder type id overflow{:_}")
 	errUnhandledType        = verror.Register(pkgPath+".errUnhandledType", verror.NoRetry, "{1:}{2:} vom: encode unhandled type {3}{:_}")
 )
 
@@ -61,7 +61,7 @@ func newTypeEncoderInternal(version Version, enc *encoder81) *TypeEncoder {
 // the order that we recurse and consequentially may be sent out of sequential
 // order if type information for children is sent (before the parent type).
 func (e *TypeEncoder) encode(tt *vdl.Type) (TypeId, error) {
-	if tid := e.lookupTypeId(tt); tid != 0 {
+	if tid := e.lookupTypeID(tt); tid != 0 {
 		return tid, nil
 	}
 
@@ -94,7 +94,7 @@ func (e *TypeEncoder) encode(tt *vdl.Type) (TypeId, error) {
 // encodeType encodes the type
 func (e *TypeEncoder) encodeType(tt *vdl.Type, pending map[*vdl.Type]bool) (TypeId, error) { //nolint:gocyclo
 	// Lookup a type Id for tt or assign a new one.
-	tid, isNew, err := e.lookupOrAssignTypeId(tt)
+	tid, isNew, err := e.lookupOrAssignTypeID(tt)
 	if err != nil {
 		return 0, err
 	}
@@ -187,9 +187,9 @@ func (e *TypeEncoder) encodeType(tt *vdl.Type, pending map[*vdl.Type]bool) (Type
 	return tid, nil
 }
 
-// lookupTypeId returns the id for the type tt if it is already encoded;
+// lookupTypeID returns the id for the type tt if it is already encoded;
 // otherwise zero id is returned.
-func (e *TypeEncoder) lookupTypeId(tt *vdl.Type) TypeId {
+func (e *TypeEncoder) lookupTypeID(tt *vdl.Type) TypeId {
 	if tid := bootstrapTypeToID[tt]; tid != 0 {
 		return tid
 	}
@@ -199,7 +199,7 @@ func (e *TypeEncoder) lookupTypeId(tt *vdl.Type) TypeId {
 	return tid
 }
 
-func (e *TypeEncoder) lookupOrAssignTypeId(tt *vdl.Type) (TypeId, bool, error) {
+func (e *TypeEncoder) lookupOrAssignTypeID(tt *vdl.Type) (TypeId, bool, error) {
 	if tid := bootstrapTypeToID[tt]; tid != 0 {
 		return tid, false, nil
 	}
@@ -214,7 +214,7 @@ func (e *TypeEncoder) lookupOrAssignTypeId(tt *vdl.Type) (TypeId, bool, error) {
 	newID := e.nextID
 	if newID > math.MaxInt64 {
 		e.typeMu.Unlock()
-		return 0, false, verror.New(errEncodeTypeIdOverflow, nil)
+		return 0, false, verror.New(errEncodeTypeIDOverflow, nil)
 	}
 	e.nextID++
 	e.typeToID[tt] = newID
@@ -222,7 +222,7 @@ func (e *TypeEncoder) lookupOrAssignTypeId(tt *vdl.Type) (TypeId, bool, error) {
 	return newID, true, nil
 }
 
-func (e *TypeEncoder) makeIdToTypeUnlocked() map[TypeId]*vdl.Type {
+func (e *TypeEncoder) makeIDToTypeUnlocked() map[TypeId]*vdl.Type {
 	if len(e.typeToID) == 0 {
 		return nil
 	}

--- a/x/ref/cmd/mounttable/impl_test.go
+++ b/x/ref/cmd/mounttable/impl_test.go
@@ -38,6 +38,7 @@ type server struct {
 	suffix string
 }
 
+//nolint:golint // API change required.
 func (s *server) Glob__(ctx *context.T, call rpc.GlobServerCall, g *glob.Glob) error {
 	ctx.VI(2).Infof("Glob() was called. suffix=%v pattern=%q", s.suffix, g.String())
 	sender := call.SendStream()

--- a/x/ref/lib/discovery/update.go
+++ b/x/ref/lib/discovery/update.go
@@ -22,7 +22,9 @@ type update struct {
 	timestamp time.Time
 }
 
-func (u *update) IsLost() bool          { return u.lost }
+func (u *update) IsLost() bool { return u.lost }
+
+//nolint:golint // API change required.
 func (u *update) Id() discovery.AdId    { return u.ad.Id }
 func (u *update) InterfaceName() string { return u.ad.InterfaceName }
 

--- a/x/ref/lib/dispatcher/wrapped.go
+++ b/x/ref/lib/dispatcher/wrapped.go
@@ -16,6 +16,7 @@ import (
 // it is sometimes helpful to know the server's endpoints.
 // In such cases you can construct a DispatcherWrapper which will simply block
 // all lookups until the real dispatcher is set with SetDispatcher.
+//nolint:golint // API change required.
 type DispatcherWrapper struct {
 	wrapped      rpc.Dispatcher
 	wrappedIsSet chan struct{}

--- a/x/ref/lib/raft/model.go
+++ b/x/ref/lib/raft/model.go
@@ -15,6 +15,7 @@ import (
 // Raft provides a consistent log across multiple instances of a client.
 
 // RaftClient defines the call backs from the Raft library to the application.
+//nolint:golint // API change required.
 type RaftClient interface {
 	// Apply appies a logged command, 'cmd', to the client. The commands will
 	// be delivered in the same order and with the same 'index' to all clients.
@@ -81,6 +82,7 @@ type Raft interface {
 }
 
 // RaftConfig is passed to NewRaft to avoid lots of parameters.
+//nolint:golint // API change required.
 type RaftConfig struct {
 	LogDir            string            // Directory in which to put log and snapshot files.
 	HostPort          string            // For RPCs from other members.

--- a/x/ref/lib/stats/stats.go
+++ b/x/ref/lib/stats/stats.go
@@ -25,6 +25,7 @@ import (
 )
 
 // StatsObject is the interface for objects stored in the stats repository.
+//nolint:golint // API change required.
 type StatsObject interface {
 	// LastUpdate is used by WatchGlob to decide which updates to send.
 	LastUpdate() time.Time

--- a/x/ref/lib/vdl/build/build.go
+++ b/x/ref/lib/vdl/build/build.go
@@ -1023,6 +1023,7 @@ func (b byBaseName) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 //
 // All imports that pkg depend on must have already been compiled and populated
 // into env.
+//nolint:golint // API change required.
 func BuildPackage(pkg *Package, env *compile.Env) *compile.Package {
 	pfiles := ParsePackage(pkg, parse.Opts{}, env.Errors)
 	return compile.CompilePackage(pkg.Path, pkg.GenPath, pfiles, pkg.Config, env)
@@ -1039,6 +1040,7 @@ func BuildPackage(pkg *Package, env *compile.Env) *compile.Package {
 // All packages that the config src depends on must have already been compiled
 // and populated into env.  The imports are injected into the parsed src,
 // behaving as if the src had listed the imports explicitly.
+//nolint:golint // API change required.
 func BuildConfig(fileName string, src io.Reader, implicit *vdl.Type, imports []string, env *compile.Env) *vdl.Value {
 	pconfig := parse.ParseConfig(fileName, src, parse.Opts{}, env.Errors)
 	if pconfig != nil {
@@ -1050,6 +1052,7 @@ func BuildConfig(fileName string, src io.Reader, implicit *vdl.Type, imports []s
 // BuildConfigValue is a convenience function that runs BuildConfig, and then
 // converts the result into value.  The implicit type used by BuildConfig is
 // inferred from the value.
+//nolint:golint // API change required.
 func BuildConfigValue(fileName string, src io.Reader, imports []string, env *compile.Env, value interface{}) {
 	rv := reflect.ValueOf(value)
 	tt, err := vdl.TypeFromReflect(rv.Type())
@@ -1085,6 +1088,7 @@ func BuildConfigValue(fileName string, src io.Reader, imports []string, env *com
 //
 // All imports that the input data depends on must have already been compiled
 // and populated into env.
+//nolint:golint // API change required.
 func BuildExprs(data string, types []*vdl.Type, env *compile.Env) []*vdl.Value {
 	var values []*vdl.Value
 	var t *vdl.Type

--- a/x/ref/lib/vdl/codegen/java/generate.go
+++ b/x/ref/lib/vdl/codegen/java/generate.go
@@ -31,6 +31,7 @@ func javaGenPkgPath(vdlPkgPath string) string {
 }
 
 // JavaFileInfo stores the name and contents of the generated Java file.
+//nolint:golint // API change required.
 type JavaFileInfo struct {
 	Dir  string
 	Name string

--- a/x/ref/lib/vdl/codegen/swift/generate.go
+++ b/x/ref/lib/vdl/codegen/swift/generate.go
@@ -54,6 +54,7 @@ func swiftGenPkgPath(vdlPkgPath string) string {
 }
 
 // SwiftFileInfo stores the name and contents of the generated Swift file.
+//nolint:golint // API change required.
 type SwiftFileInfo struct {
 	Data   []byte
 	Dir    string

--- a/x/ref/lib/vdl/compile/compile.go
+++ b/x/ref/lib/vdl/compile/compile.go
@@ -34,6 +34,7 @@ import (
 // with the compiled package and returns it on success, or returns nil and
 // guarantees !env.Errors.IsEmpty().  All imports that the parsed package depend
 // on must already have been compiled and populated into env.
+//nolint:golint // API change required.
 func CompilePackage(pkgpath, genpath string, pfiles []*parse.File, config vdltool.Config, env *Env) *Package {
 	if pkgpath == "" {
 		env.Errors.Errorf("Compile called with empty pkgpath")
@@ -59,6 +60,7 @@ func CompilePackage(pkgpath, genpath string, pfiles []*parse.File, config vdltoo
 // imports that the parsed config depend on must already have been compiled and
 // populated into env.  If t is non-nil, the returned value will be of that
 // type.
+//nolint:golint // API change required.
 func CompileConfig(t *vdl.Type, pconfig *parse.Config, env *Env) *vdl.Value {
 	if pconfig == nil || env == nil {
 		env.Errors.Errorf("CompileConfig called with nil config or env")
@@ -91,6 +93,7 @@ func CompileConfig(t *vdl.Type, pconfig *parse.Config, env *Env) *vdl.Value {
 // success, or returns nil and guarantees !env.Errors.IsEmpty().  All imports
 // that expr depends on must already have been compiled and populated into env.
 // If t is non-nil, the returned value will be of that type.
+//nolint:golint // API change required.
 func CompileExpr(t *vdl.Type, expr parse.ConstExpr, env *Env) *vdl.Value {
 	file := &File{
 		BaseName: "_expr.vdl",

--- a/x/ref/lib/vdl/parse/parse.go
+++ b/x/ref/lib/vdl/parse/parse.go
@@ -36,6 +36,7 @@ type Opts struct {
 // accumulated errors, and parses the vdl into a parse.File containing the parse
 // tree.  Returns nil if any errors are encountered, with errs containing more
 // information.  Otherwise returns the parsed File.
+//nolint:golint // API change required.
 func ParseFile(fileName string, src io.Reader, opts Opts, errs *vdlutil.Errors) *File {
 	start := startFile
 	if opts.ImportsOnly {
@@ -48,6 +49,7 @@ func ParseFile(fileName string, src io.Reader, opts Opts, errs *vdlutil.Errors) 
 // accumulated errors, and parses the config into a parse.Config containing the
 // parse tree.  Returns nil if any errors are encountered, with errs containing
 // more information.  Otherwise returns the parsed Config.
+//nolint:golint // API change required.
 func ParseConfig(fileName string, src io.Reader, opts Opts, errs *vdlutil.Errors) *Config {
 	start := startConfig
 	if opts.ImportsOnly {
@@ -105,6 +107,7 @@ func parse(fileName string, src io.Reader, startTok int, errs *vdlutil.Errors) *
 // data is specified in VDL syntax, with commas separating multiple expressions.
 // There must be at least one expression specified in data.  Errors are returned
 // in errs.
+//nolint:golint // API change required.
 func ParseExprs(data string, errs *vdlutil.Errors) []ConstExpr {
 	const name = "exprs"
 	lex := newLexer(name, strings.NewReader(data), startExprs, errs)

--- a/x/ref/runtime/internal/cloudvm/cloud_linux.go
+++ b/x/ref/runtime/internal/cloudvm/cloud_linux.go
@@ -26,10 +26,10 @@ import (
 // header, it is also not a GCE instance. The body of the document contains the
 // external IP address, if present. Otherwise, the body is empty.
 // See https://developers.google.com/compute/docs/metadata for details.
-const gceExternalUrl = "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip"
-const gceInternalUrl = "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip"
-const awsExternalUrl = "http://169.254.169.254/latest/meta-data/public-ipv4"
-const awsInternalUrl = "http://169.254.169.254/latest/meta-data/local-ipv4"
+const gceExternalURL = "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip"
+const gceInternalURL = "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip"
+const awsExternalURL = "http://169.254.169.254/latest/meta-data/public-ipv4"
+const awsInternalURL = "http://169.254.169.254/latest/meta-data/local-ipv4"
 
 var (
 	onceGCE    sync.Once
@@ -39,6 +39,8 @@ var (
 	internalIP net.IP
 	externalIP net.IP
 )
+
+// TODO(cnicolaou): change InitGCE and initAWS to take a context.
 
 func InitGCE(timeout time.Duration, cancel <-chan struct{}) {
 	onceGCE.Do(func() {
@@ -82,8 +84,8 @@ func ExternalIPAddress() net.IP {
 
 func gceTest(timeout time.Duration, cancel <-chan struct{}) {
 	var err error
-	internalIP, _ = gceGetIP(gceInternalUrl, timeout, cancel)
-	if externalIP, err = gceGetIP(gceExternalUrl, timeout, cancel); err != nil {
+	internalIP, _ = gceGetIP(gceInternalURL, timeout, cancel)
+	if externalIP, err = gceGetIP(gceExternalURL, timeout, cancel); err != nil {
 		return
 	}
 
@@ -117,7 +119,7 @@ func gceGetMeta(url string, timeout time.Duration, cancel <-chan struct{}) (stri
 	if err != nil {
 		return "", err
 	}
-	req.Cancel = cancel
+	req.Cancel = cancel //nolint:staticcheck //ignore:SA1019
 	req.Header.Add("Metadata-Flavor", "Google")
 	resp, err := client.Do(req)
 	if err != nil {
@@ -138,8 +140,8 @@ func gceGetMeta(url string, timeout time.Duration, cancel <-chan struct{}) (stri
 }
 
 func awsTest(timeout time.Duration, cancel <-chan struct{}) {
-	externalIP = awsGetIP(awsExternalUrl, timeout, cancel)
-	internalIP = awsGetIP(awsInternalUrl, timeout, cancel)
+	externalIP = awsGetIP(awsExternalURL, timeout, cancel)
+	internalIP = awsGetIP(awsInternalURL, timeout, cancel)
 	onAWS = true
 }
 
@@ -149,7 +151,7 @@ func awsGetIP(url string, timeout time.Duration, cancel <-chan struct{}) net.IP 
 	if err != nil {
 		return nil
 	}
-	req.Cancel = cancel
+	req.Cancel = cancel //nolint:staticcheck //ignore:SA1019
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil

--- a/x/ref/runtime/internal/naming/namespace/all_test.go
+++ b/x/ref/runtime/internal/naming/namespace/all_test.go
@@ -138,6 +138,7 @@ func (testServer) KnockKnock(*context.T, rpc.ServerCall) (string, error) {
 
 // testServer has the following namespace:
 // "" -> {level1} -> {level2}
+//nolint:golint // API change required.
 func (t *testServer) GlobChildren__(_ *context.T, call rpc.GlobChildrenServerCall, m *glob.Element) error {
 	switch t.suffix {
 	case "":
@@ -514,6 +515,7 @@ type GlobbableServer struct {
 	mu        sync.Mutex
 }
 
+//nolint:golint // API change required.
 func (g *GlobbableServer) Glob__(*context.T, rpc.GlobServerCall, *glob.Glob) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/x/ref/runtime/internal/naming/namespace/namespace.go
+++ b/x/ref/runtime/internal/naming/namespace/namespace.go
@@ -63,6 +63,7 @@ func badRoots(roots []string) error {
 }
 
 // Create a new namespace.
+//nolint:golint // API change required.
 func New(roots ...string) (*namespace, error) {
 	if !rooted(roots) {
 		return nil, badRoots(roots)

--- a/x/ref/runtime/internal/rpc/reserved.go
+++ b/x/ref/runtime/internal/rpc/reserved.go
@@ -42,6 +42,7 @@ type reservedMethods struct {
 	selfInvoker  rpc.Invoker
 }
 
+//nolint:golint // API change required.
 func (r *reservedMethods) Describe__() []rpc.InterfaceDesc {
 	return []rpc.InterfaceDesc{{
 		Name: "__Reserved",

--- a/x/ref/runtime/internal/rpc/test/cancel_test.go
+++ b/x/ref/runtime/internal/rpc/test/cancel_test.go
@@ -363,7 +363,7 @@ func TestChannelTimeout_Proxy(t *testing.T) {
 	testChannelTimeout(t, v23.WithListenSpec(ctx, ls))
 }
 
-func testChannelTimeOut_Server(t *testing.T, ctx *context.T) {
+func testChannelTimeOutServer(t *testing.T, ctx *context.T) {
 	conns := make(chan disconnect, 1)
 	sctx := v23.WithListenSpec(ctx, rpc.ListenSpec{
 		Addrs: rpc.ListenAddrs{{Protocol: "debug", Address: "tcp/127.0.0.1:0"}},
@@ -408,13 +408,13 @@ func testChannelTimeOut_Server(t *testing.T, ctx *context.T) {
 	<-done
 }
 
-func TestChannelTimeout_Server(t *testing.T) {
+func TestChannelTimeoutServer(t *testing.T) {
 	ctx, shutdown := test.V23InitWithMounttable()
 	defer shutdown()
-	testChannelTimeOut_Server(t, ctx)
+	testChannelTimeOutServer(t, ctx)
 }
 
-func TestChannelTimeout_ServerProxy(t *testing.T) {
+func TestChannelTimeoutServerProxy(t *testing.T) {
 	ctx, shutdown := test.V23InitWithMounttable()
 	defer shutdown()
 	ls := v23.GetListenSpec(ctx)
@@ -429,5 +429,5 @@ func TestChannelTimeout_ServerProxy(t *testing.T) {
 		cancel()
 		<-p.Closed()
 	}()
-	testChannelTimeOut_Server(t, v23.WithListenSpec(ctx, ls))
+	testChannelTimeOutServer(t, v23.WithListenSpec(ctx, ls))
 }

--- a/x/ref/runtime/internal/rpc/test/glob_test.go
+++ b/x/ref/runtime/internal/rpc/test/glob_test.go
@@ -290,6 +290,7 @@ type globObject struct {
 	n *node
 }
 
+//nolint:golint // API change required.
 func (o *globObject) Glob__(ctx *context.T, call rpc.GlobServerCall, g *glob.Glob) error {
 	o.globLoop(call, "", g, o.n)
 	return nil
@@ -314,6 +315,7 @@ type vChildrenObject struct {
 	n *node
 }
 
+//nolint:golint // API change required.
 func (o *vChildrenObject) GlobChildren__(ctx *context.T, call rpc.GlobChildrenServerCall, m *glob.Element) error {
 	sender := call.SendStream()
 	for child := range o.n.children {

--- a/x/ref/runtime/internal/vtrace/logger.go
+++ b/x/ref/runtime/internal/vtrace/logger.go
@@ -16,6 +16,7 @@ const (
 	initialMaxStackBufSize = 128 * 1024
 )
 
+//nolint:golint // API change required.
 type VTraceLogger struct{}
 
 func (*VTraceLogger) InfoDepth(ctx *context.T, depth int, args ...interface{}) {

--- a/x/ref/runtime/protocols/lib/websocket/conn.go
+++ b/x/ref/runtime/protocols/lib/websocket/conn.go
@@ -18,6 +18,7 @@ import (
 )
 
 // WebsocketConn provides a flow.Conn interface for a websocket connection.
+//nolint:golint // API change required.
 func WebsocketConn(ws *websocket.Conn) flow.Conn {
 	return &wrappedConn{ws: ws}
 }

--- a/x/ref/runtime/protocols/wsh_nacl/doc.go
+++ b/x/ref/runtime/protocols/wsh_nacl/doc.go
@@ -4,4 +4,5 @@
 
 // Package wsh_nacl registers the websocket 'hybrid' protocol for nacl
 // architectures. It will only be built if on the nacl architecture.
+//nolint:golint // API change required.
 package wsh_nacl

--- a/x/ref/services/agent/internal/ipc/ipc.go
+++ b/x/ref/services/agent/internal/ipc/ipc.go
@@ -52,6 +52,7 @@ type IPC struct {
 // It can be used to make rpcs to the other process.  It also
 // dispatches rpcs from that process to handlers registered with the
 // parent IPC object.
+//nolint:golint // API change required.
 type IPCConn struct {
 	enc    *vom.Encoder
 	dec    *vom.Decoder

--- a/x/ref/services/application/applicationd/service.go
+++ b/x/ref/services/application/applicationd/service.go
@@ -260,6 +260,7 @@ func (i *appRepoService) allAppVersions(appName string) ([]string, error) {
 	return i.allAppVersionsForProfiles(appName, profiles)
 }
 
+//nolint:golint // API change required.
 func (i *appRepoService) GlobChildren__(ctx *context.T, call rpc.GlobChildrenServerCall, m *glob.Element) error {
 	ctx.VI(0).Infof("%v.GlobChildren__()", i.suffix)
 	i.store.Lock()

--- a/x/ref/services/binary/binary/impl_test.go
+++ b/x/ref/services/binary/binary/impl_test.go
@@ -54,6 +54,7 @@ func (s *server) Download(ctx *context.T, call repository.BinaryDownloadServerCa
 	return nil
 }
 
+//nolint:golint // API change required.
 func (s *server) DownloadUrl(ctx *context.T, _ rpc.ServerCall) (string, int64, error) {
 	ctx.Infof("DownloadUrl() was called. suffix=%v", s.suffix)
 	if s.suffix != "" {

--- a/x/ref/services/binary/tidy/binaryd/mock.go
+++ b/x/ref/services/binary/tidy/binaryd/mock.go
@@ -70,6 +70,7 @@ type GlobResponse struct {
 	Err     error
 }
 
+//nolint:golint // API change required.
 func (mdi *MockBinarydInvoker) Glob__(p *context.T, call rpc.GlobServerCall, g *glob.Glob) error {
 	gs := GlobStimulus{g.String()}
 	gr := mdi.Tape.Record(gs).(GlobResponse)

--- a/x/ref/services/binary/tidy/impl.go
+++ b/x/ref/services/binary/tidy/impl.go
@@ -43,7 +43,7 @@ sourcing the envelopes.
 }
 
 // simpleGlob globs the provided endpoint as the namespace cmd does.
-func mapGlob(ctx *context.T, pattern string, mapFunc func(string)) (error, []error) {
+func mapGlob(ctx *context.T, pattern string, mapFunc func(string)) ([]error, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
@@ -51,7 +51,7 @@ func mapGlob(ctx *context.T, pattern string, mapFunc func(string)) (error, []err
 	c, err := ns.Glob(ctx, pattern)
 	if err != nil {
 		vlog.Infof("ns.Glob(%q) failed: %v", pattern, err)
-		return err, nil
+		return nil, err
 	}
 
 	errors := []*naming.GlobError{}
@@ -70,7 +70,7 @@ func mapGlob(ctx *context.T, pattern string, mapFunc func(string)) (error, []err
 	for _, err := range errors {
 		globErrors = append(globErrors, fmt.Errorf("glob error: %s: %v", err.Name, err.Error))
 	}
-	return nil, globErrors
+	return globErrors, nil
 }
 
 func logGlobErrors(env *cmdline.Env, errors []error) {
@@ -96,7 +96,7 @@ func getProfileNames(ctx *context.T, env *cmdline.Env, endpoint string) ([]strin
 
 func getNames(ctx *context.T, env *cmdline.Env, endpoint string) ([]string, error) {
 	resultSet := make(map[string]struct{})
-	err, errors := mapGlob(ctx, endpoint, func(s string) {
+	errors, err := mapGlob(ctx, endpoint, func(s string) {
 		resultSet[s] = struct{}{}
 	})
 

--- a/x/ref/services/device/device/devicemanager_mock_test.go
+++ b/x/ref/services/device/device/devicemanager_mock_test.go
@@ -291,6 +291,7 @@ type GlobResponse struct {
 	err     error
 }
 
+//nolint:golint // API change required.
 func (mdi *mockDeviceInvoker) Glob__(_ *context.T, call rpc.GlobServerCall, g *glob.Glob) error {
 	gs := GlobStimulus{g.String()}
 	gr := mdi.tape.Record(gs).(GlobResponse)

--- a/x/ref/services/device/device/glob.go
+++ b/x/ref/services/device/device/glob.go
@@ -385,6 +385,7 @@ func (f *instanceStateFlag) Set(s string) error {
 	})
 }
 
+//nolint:golint // API change required.
 func InstanceStates(states ...device.InstanceState) (f instanceStateFlag) {
 	for _, s := range states {
 		f.add(s)
@@ -392,6 +393,7 @@ func InstanceStates(states ...device.InstanceState) (f instanceStateFlag) {
 	return
 }
 
+//nolint:golint // API change required.
 func ExcludeInstanceStates(states ...device.InstanceState) instanceStateFlag {
 	f := InstanceStates(states...)
 	f.exclude = true
@@ -408,6 +410,7 @@ func (f *installationStateFlag) Set(s string) error {
 	})
 }
 
+//nolint:golint // API change required.
 func InstallationStates(states ...device.InstallationState) (f installationStateFlag) {
 	for _, s := range states {
 		f.add(s)
@@ -415,6 +418,7 @@ func InstallationStates(states ...device.InstallationState) (f installationState
 	return
 }
 
+//nolint:golint // API change required.
 func ExcludeInstallationStates(states ...device.InstallationState) installationStateFlag {
 	f := InstallationStates(states...)
 	f.exclude = true

--- a/x/ref/services/device/device/local_install.go
+++ b/x/ref/services/device/device/local_install.go
@@ -140,6 +140,7 @@ func (i binaryInvoker) Download(ctx *context.T, call repository.BinaryDownloadSe
 	}
 }
 
+//nolint:golint // API change required.
 func (binaryInvoker) DownloadUrl(*context.T, rpc.ServerCall) (string, int64, error) {
 	return "", 0, errNotImplemented
 }

--- a/x/ref/services/device/deviced/internal/impl/app_service.go
+++ b/x/ref/services/device/deviced/internal/impl/app_service.go
@@ -1411,6 +1411,7 @@ func (i *appService) scanInstance(ctx *context.T, tree *treeNode, title, instanc
 	}
 }
 
+//nolint:golint // API change required.
 func (i *appService) GlobChildren__(ctx *context.T, call rpc.GlobChildrenServerCall, m *glob.Element) error {
 	tree := newTreeNode()
 	switch len(i.suffix) {

--- a/x/ref/services/device/deviced/internal/impl/proxy_invoker.go
+++ b/x/ref/services/device/deviced/internal/impl/proxy_invoker.go
@@ -227,6 +227,7 @@ func (c *call) Send(v interface{}) error {
 	return c.SendStream().Send(v.(naming.GlobReply))
 }
 
+//nolint:golint // API change required.
 func (p *proxyInvoker) Glob__(ctx *context.T, serverCall rpc.GlobServerCall, g *glob.Glob) error {
 	pattern := g.String()
 	p.Invoke(ctx, &call{serverCall}, rpc.GlobMethod, []interface{}{&pattern}) //nolint:errcheck

--- a/x/ref/services/device/deviced/internal/impl/utiltest/helpers.go
+++ b/x/ref/services/device/deviced/internal/impl/utiltest/helpers.go
@@ -662,6 +662,7 @@ type globTestRegexHelper struct {
 	statsTrimRE                      *regexp.Regexp
 }
 
+//nolint:golint // API change required.
 func NewGlobTestRegexHelper(appName string) *globTestRegexHelper {
 	return &globTestRegexHelper{
 		logFileTimeStampRE:               regexp.MustCompile("(STDOUT|STDERR)-[0-9]+$"),

--- a/x/ref/services/device/deviced/internal/impl/utiltest/mock_repo.go
+++ b/x/ref/services/device/deviced/internal/impl/utiltest/mock_repo.go
@@ -160,6 +160,7 @@ func (i *brInvoker) Download(ctx *context.T, call repository.BinaryDownloadServe
 	}
 }
 
+//nolint:golint // API change required.
 func (*brInvoker) DownloadUrl(ctx *context.T, _ rpc.ServerCall) (string, int64, error) {
 	ctx.VI(1).Infof("DownloadUrl()")
 	return "", 0, nil

--- a/x/ref/services/device/util_darwin_test.go
+++ b/x/ref/services/device/util_darwin_test.go
@@ -35,7 +35,7 @@ func (uids uidMap) findAvailable() (int, error) {
 }
 
 //nolint:deadcode,unused
-func newUidMap(sh *v23test.Shell) uidMap {
+func newUIDMap(sh *v23test.Shell) uidMap {
 	// `dscl . -list /Users UniqueID` into a datastructure.
 	userstring := sh.Cmd("dscl", ".", "-list", "/Users", "UniqueID").Stdout()
 	users := strings.Split(userstring, "\n")
@@ -77,7 +77,7 @@ func makeTestAccounts(t *testing.T, sh *v23test.Shell) {
 		return
 	}
 
-	uids := newUidMap(sh)
+	uids := newUIDMap(sh)
 	if needVanaErr != nil {
 		vanauid, err := uids.findAvailable()
 		if err != nil {

--- a/x/ref/services/identity/internal/oauth/oauth_provider.go
+++ b/x/ref/services/identity/internal/oauth/oauth_provider.go
@@ -13,6 +13,7 @@ const (
 )
 
 // OAuthProvider authenticates users to the identity server via the OAuth2 Web Server flow.
+//nolint:golint // API change required.
 type OAuthProvider interface {
 	// AuthURL is the URL the user must visit in order to authenticate with the OAuthProvider.
 	// After authentication, the user will be re-directed to redirectURL with the provided state.

--- a/x/ref/services/identity/internal/revocation/revocation_manager.go
+++ b/x/ref/services/identity/internal/revocation/revocation_manager.go
@@ -17,6 +17,7 @@ import (
 )
 
 // RevocationManager persists information for revocation caveats to provided discharges and allow for future revocations.
+//nolint:golint // API change required.
 type RevocationManager interface {
 	NewCaveat(discharger security.PublicKey, dischargerLocation string) (security.Caveat, error)
 	Revoke(caveatID string) error

--- a/x/ref/services/internal/binarylib/client.go
+++ b/x/ref/services/internal/binarylib/client.go
@@ -198,6 +198,7 @@ func DownloadToFile(ctx *context.T, von, path string) error {
 	return nil
 }
 
+//nolint:golint // API change required.
 func DownloadUrl(ctx *context.T, von string) (string, int64, error) {
 	url, ttl, err := repository.BinaryClient(von).DownloadUrl(ctx)
 	if err != nil {

--- a/x/ref/services/internal/binarylib/service.go
+++ b/x/ref/services/internal/binarylib/service.go
@@ -288,6 +288,7 @@ func (i *binaryService) Download(ctx *context.T, call repository.BinaryDownloadS
 
 // TODO(jsimsa): Design and implement an access control mechanism for
 // the URL-based downloads.
+//nolint:golint // API change required.
 func (i *binaryService) DownloadUrl(ctx *context.T, _ rpc.ServerCall) (string, int64, error) {
 	ctx.Infof("%v.DownloadUrl()", i.suffix)
 	return i.state.rootURL + "/" + i.suffix, 0, nil
@@ -406,6 +407,7 @@ func (i *binaryService) Upload(ctx *context.T, call repository.BinaryUploadServe
 	return nil
 }
 
+//nolint:golint // API change required.
 func (i *binaryService) GlobChildren__(ctx *context.T, call rpc.GlobChildrenServerCall, m *glob.Element) error {
 	elems := strings.Split(i.suffix, "/")
 	if len(elems) == 1 && elems[0] == "" {

--- a/x/ref/services/internal/binarylib/state.go
+++ b/x/ref/services/internal/binarylib/state.go
@@ -51,6 +51,7 @@ type state struct {
 
 // NewState creates a new state object for the binary service.  This
 // should be passed into both NewDispatcher and NewHTTPRoot.
+//nolint:golint // API change required.
 func NewState(rootDir, rootURL string, depth int) (*state, error) {
 	if min, max := 0, md5.Size-1; min > depth || depth > max {
 		return nil, verror.New(errUnexpectedDepth, nil, min, max, depth)

--- a/x/ref/services/internal/fs/simplestore.go
+++ b/x/ref/services/internal/fs/simplestore.go
@@ -280,6 +280,7 @@ type boundObject struct {
 }
 
 // BindObject sets the path string for subsequent operations.
+//nolint:golint // API change required.
 func (ms *Memstore) BindObject(path string) *boundObject {
 	pathParts := strings.SplitN(path, "/", 2)
 	if pathParts[0] == transactionNamePrefix {
@@ -441,7 +442,8 @@ func (o *boundObject) Exists(_ interface{}) (bool, error) {
 	if o.ms.haveTransactionNameBinding {
 		return o.transactionExists(), nil
 	}
-	if _, inBase := o.ms.data[o.path]; inBase {
+	_, inBase := o.ms.data[o.path]
+	if inBase {
 		return true, nil
 	}
 	for k := range o.ms.data {

--- a/x/ref/services/internal/httplib/http.go
+++ b/x/ref/services/internal/httplib/http.go
@@ -28,6 +28,7 @@ func (f *httpService) RawDo(_ *context.T, _ rpc.ServerCall, req v23_http.Request
 	return buf.Bytes(), nil
 }
 
+//nolint:golint // API change required.
 func NewHttpService() interface{} {
 	return v23_http.HttpServer(&httpService{})
 }

--- a/x/ref/services/internal/logreaderlib/logfile.go
+++ b/x/ref/services/internal/logreaderlib/logfile.go
@@ -115,6 +115,7 @@ func (i *logfileService) ReadLog(ctx *context.T, call logreader.LogFileReadLogSe
 
 // GlobChildren__ returns the list of files in a directory on a stream.
 // The list is empty if the object is a file.
+//nolint:golint // API change required.
 func (i *logfileService) GlobChildren__(ctx *context.T, call rpc.GlobChildrenServerCall, m *glob.Element) error {
 	ctx.VI(1).Infof("%v.GlobChildren__()", i.suffix)
 	dirName, err := translateNameToFilename(i.root, i.suffix)

--- a/x/ref/services/internal/pproflib/server.go
+++ b/x/ref/services/internal/pproflib/server.go
@@ -65,6 +65,7 @@ func (pprofService) Profile(ctx *context.T, call s_pprof.PProfProfileServerCall,
 
 // CPUProfile enables CPU profiling for the requested duration and
 // streams the profile data.
+//nolint:golint // API change required.
 func (pprofService) CpuProfile(ctx *context.T, call s_pprof.PProfCpuProfileServerCall, seconds int32) error {
 	if seconds <= 0 || seconds > 3600 {
 		return verror.New(errInvalidSeconds, ctx, seconds)

--- a/x/ref/services/internal/statslib/stats.go
+++ b/x/ref/services/internal/statslib/stats.go
@@ -38,6 +38,7 @@ func NewStatsService(suffix string, watchFreq time.Duration) interface{} {
 }
 
 // Glob__ returns the name of all objects that match pattern.
+//nolint:golint // API change required.
 func (i *statsService) Glob__(ctx *context.T, call rpc.GlobServerCall, g *glob.Glob) error {
 	ctx.VI(1).Infof("%v.Glob__(%q)", i.suffix, g.String())
 	sender := call.SendStream()

--- a/x/ref/services/mounttable/mounttablelib/mounttable.go
+++ b/x/ref/services/mounttable/mounttablelib/mounttable.go
@@ -771,6 +771,7 @@ out:
 // a state that never existed in the mounttable.  For example, if someone removes c/d and later
 // adds a/b while a Glob is in progress, the Glob may return a set of nodes that includes both
 // c/d and a/b.
+//nolint:golint // API change required.
 func (ms *mountContext) Glob__(ctx *context.T, call rpc.GlobServerCall, g *glob.Glob) error {
 	ctx.VI(2).Infof("mt.Glob %v", ms.elems)
 	mt, cc := ms.newCallContext(ctx, call.Security(), !createMissingNodes)

--- a/x/ref/services/mounttable/mounttablelib/neighborhood.go
+++ b/x/ref/services/mounttable/mounttablelib/neighborhood.go
@@ -277,6 +277,7 @@ func (*neighborhoodService) Delete(ctx *context.T, _ rpc.ServerCall, _ bool) err
 }
 
 // Glob__ implements rpc.AllGlobber
+//nolint:golint // API change required.
 func (ns *neighborhoodService) Glob__(ctx *context.T, call rpc.GlobServerCall, g *glob.Glob) error {
 	// return all neighbors that match the first element of the pattern.
 	nh := ns.nh

--- a/x/ref/services/mounttable/mounttablelib/opts.go
+++ b/x/ref/services/mounttable/mounttablelib/opts.go
@@ -10,7 +10,7 @@ import (
 
 type Opts struct {
 	MountName  string
-	AclFile    string
+	AclFile    string //nolint:golint // API change required.
 	NhName     string
 	PersistDir string
 }

--- a/x/ref/services/role/roled/internal/discharger.go
+++ b/x/ref/services/role/roled/internal/discharger.go
@@ -60,6 +60,7 @@ func (dischargerImpl) Discharge(ctx *context.T, call rpc.ServerCall, caveat secu
 	return discharge, nil
 }
 
+//nolint:golint // API change required.
 func (d *dischargerImpl) GlobChildren__(ctx *context.T, call rpc.GlobChildrenServerCall, m *glob.Element) error {
 	return globChildren(ctx, call, d.serverConfig, m)
 }

--- a/x/ref/services/role/roled/internal/role.go
+++ b/x/ref/services/role/roled/internal/role.go
@@ -47,6 +47,7 @@ func (i *roleService) SeekBlessings(ctx *context.T, call rpc.ServerCall) (securi
 	return createBlessings(ctx, call.Security(), i.roleConfig, v23.GetPrincipal(ctx), extensions, caveats, i.serverConfig.dischargerLocation)
 }
 
+//nolint:golint // API change required.
 func (i *roleService) GlobChildren__(ctx *context.T, call rpc.GlobChildrenServerCall, m *glob.Element) error {
 	return globChildren(ctx, call, i.serverConfig, m)
 }

--- a/x/ref/services/xproxy/xproxy/proxy.go
+++ b/x/ref/services/xproxy/xproxy/proxy.go
@@ -45,6 +45,7 @@ type proxy struct {
 	closing            bool
 }
 
+//nolint:golint // API change required.
 func New(ctx *context.T, name string, auth security.Authorizer) (*proxy, error) {
 	mgr, err := v23.NewFlowManager(ctx, 0)
 	if err != nil {

--- a/x/ref/test/expect/expect.go
+++ b/x/ref/test/expect/expect.go
@@ -56,6 +56,7 @@ import (
 )
 
 var (
+	//nolint:golint // API change required.
 	Timeout = errors.New("timeout")
 )
 


### PR DESCRIPTION
This final round of lint fixes use nolint comments of the form:
 //nolint:golint // API change required.

for fixes that would force an API change. These are mostly use of _, stuttering etc.
