### PR TITLE
x/ref/runtime/internal/flow/conn: fix flaky test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
 
 version: 2.1
 orbs:
-  go: circleci/go@1.1.2
+  go: circleci/go@1.2.0
 workflows:
   main:
     jobs:

--- a/v23/flow/message/message.go
+++ b/v23/flow/message/message.go
@@ -65,6 +65,19 @@ func Read(ctx *context.T, from []byte) (Message, error) { //nolint:gocyclo
 	return m, m.read(ctx, from)
 }
 
+// FlowID returns the id of the flow this message is associated with for
+// message types that are bound to a flow, zero otherwise.
+func FlowID(m interface{}) uint64 {
+	switch a := m.(type) {
+	case *Data:
+		return a.ID
+	case *OpenFlow:
+		return a.ID
+	default:
+		return 0
+	}
+}
+
 // Message is implemented by all low-level messages defined by this package.
 type Message interface {
 	append(ctx *context.T, data []byte) ([]byte, error)

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -248,6 +248,10 @@ func NewDialed(
 			select {
 			case <-done:
 				canceled = true
+				// There is always the possibility that the handshake fails
+				// (eg. the client doesn't trust the server), so make sure to
+				// record any such error.
+				ferr = err
 				// Handshake done.
 			case <-timer.C:
 				// Report the timeout not the cancelation, hence

--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -453,6 +453,11 @@ func (f *flw) Closed() <-chan struct{} {
 	return f.currentContext().Done()
 }
 
+// ID returns the ID of this flow.
+func (f *flw) ID() uint64 {
+	return f.id
+}
+
 func (f *flw) close(ctx *context.T, closedRemotely bool, err error) {
 	f.conn.mu.Lock()
 	cancel := f.cancel


### PR DESCRIPTION
See issue #132 for a more complete description of the background to this PR. In summary, this PR makes the following changes.
1. ensures that the client RPC dial handshake code acts on errors returned by the handshake process even if that handshake is
interrupted by a context cancelation.
2. the code that reads auth blessings (readRemoteAuth) explicitly handles connection teardown messages and reports a closed connection rather than silently closing the connection and reporting an EOF error on the first read.
3. minor changes to expose the flow id via APIs to help with debugging in future.