### PR TITLE
x/ref/lib/signals: add the ability to react to context cancelation and to cancel a context on a signal reception

### DIFF
--- a/x/ref/examples/tunnel/tunneld/main.go
+++ b/x/ref/examples/tunnel/tunneld/main.go
@@ -46,6 +46,8 @@ func runTunnelD(ctx *context.T, env *cmdline.Env, args []string) error {
 		auth security.Authorizer
 		err  error
 	)
+	ctx, waitForSignals := signals.ShutdownOnSignalsWithCancel(ctx)
+	defer waitForSignals()
 	switch {
 	case aclLiteral != "":
 		var perms access.Permissions
@@ -69,6 +71,5 @@ func runTunnelD(ctx *context.T, env *cmdline.Env, args []string) error {
 	}
 	ctx.Infof("Published as %q", name)
 
-	<-signals.ShutdownOnSignals(ctx)
 	return nil
 }

--- a/x/ref/runtime/internal/rpc/benchmark/benchmarkd/main.go
+++ b/x/ref/runtime/internal/rpc/benchmark/benchmarkd/main.go
@@ -33,6 +33,7 @@ var cmdRoot = &cmdline.Command{
 }
 
 func runBenchmarkD(ctx *context.T, env *cmdline.Env, args []string) error {
+	ctx, waitForSignals := signals.ShutdownOnSignalsWithCancel(ctx)
 	ctx, server, err := v23.WithNewServer(
 		ctx,
 		"",
@@ -43,6 +44,6 @@ func runBenchmarkD(ctx *context.T, env *cmdline.Env, args []string) error {
 		ctx.Fatalf("NewServer failed: %v", err)
 	}
 	ctx.Infof("Listening on %s", server.Status().Endpoints[0].Name())
-	<-signals.ShutdownOnSignals(ctx)
+	waitForSignals()
 	return nil
 }

--- a/x/ref/runtime/internal/rt/shutdown_servers_test.go
+++ b/x/ref/runtime/internal/rt/shutdown_servers_test.go
@@ -176,12 +176,21 @@ var simpleServerProgram = gosh.RegisterFunc("simpleServerProgram", func() {
 	// Initialize the runtime.  This is boilerplate.
 	ctx, shutdown := test.V23Init()
 	// Calling shutdown is optional, but it's a good idea to clean up, especially
-	// since it takes care of flushing the logs before exiting.
+	// for servers to remove their entries from the mounttable and to ensure
+	// flushing the logs before exiting.
 	//
 	// We use defer to ensure this is the last thing in the program (to
 	// avoid shutting down the runtime while it may still be in use), and to
 	// allow it to execute even if a panic occurs down the road.
 	defer shutdown()
+
+	// This is how to wait for a shutdown.  In this example, a shutdown
+	// comes from a signal or context cancelation command.
+	//
+	// Note, if the developer wants to exit immediately upon receiving a
+	// signal or stop command, they can skip this, in which case the default
+	// behavior is for the process to exit.
+	ctx, waitForSignal := signals.ShutdownOnSignalsWithCancel(ctx)
 
 	// This is part of the test setup -- we need a way to accept
 	// commands from the parent process to simulate Stop and
@@ -190,19 +199,10 @@ var simpleServerProgram = gosh.RegisterFunc("simpleServerProgram", func() {
 	defer remoteCmdLoop(ctx, os.Stdin)()
 
 	// Create a server, and start serving.
-	ctx, cancel := context.WithCancel(ctx)
 	ctx, server, err := v23.WithNewServer(ctx, "", &dummy{}, nil)
 	if err != nil {
 		ctx.Fatalf("r.NewServer error: %s", err)
 	}
-
-	// This is how to wait for a shutdown.  In this example, a shutdown
-	// comes from a signal or a stop command.
-	//
-	// Note, if the developer wants to exit immediately upon receiving a
-	// signal or stop command, they can skip this, in which case the default
-	// behavior is for the process to exit.
-	waiter := signals.ShutdownOnSignals(ctx)
 
 	// This communicates to the parent test driver process in our unit test
 	// that this server is ready and waiting on signals or stop commands.
@@ -213,18 +213,17 @@ var simpleServerProgram = gosh.RegisterFunc("simpleServerProgram", func() {
 	// occurs.
 	defer fmt.Println("Deferred cleanup")
 
-	// Wait for shutdown.
-	sig := <-waiter
+	// Wait for shutdown, which will also cancel the context
+	// when a signal is received.
+	sig := waitForSignal()
+
+	// Note: this is not strictly required since the defer'ed shutdown
+	// function will also call <- server.Closed()
+	<-server.Closed()
+
 	// The developer could take different actions depending on the type of
 	// signal.
 	fmt.Println("Received signal", sig)
-
-	// Cleanup code starts here.  Alternatively, these steps could be
-	// invoked through defer, but we list them here to make the order of
-	// operations obvious.
-
-	cancel()
-	<-server.Closed()
 
 	// Note, this will not execute in cases of forced shutdown
 	// (e.g. SIGSTOP), when the process calls os.Exit (e.g. via log.Fatal),

--- a/x/ref/services/groups/groupsd/main.go
+++ b/x/ref/services/groups/groupsd/main.go
@@ -47,6 +47,8 @@ v.io/v23/services/groups.Group interface.
 }
 
 func runGroupsD(ctx *context.T, env *cmdline.Env, args []string) error {
+	ctx, waitForSignal := signals.ShutdownOnSignalsWithCancel(ctx)
+	defer waitForSignal()
 	dispatcher, err := lib.NewGroupsDispatcher(flagRootDir, flagEngine)
 	if err != nil {
 		return err
@@ -56,8 +58,5 @@ func runGroupsD(ctx *context.T, env *cmdline.Env, args []string) error {
 		return fmt.Errorf("NewDispatchingServer(%v) failed: %v", flagName, err)
 	}
 	ctx.Infof("Groups server running at endpoint=%q", server.Status().Endpoints[0].Name())
-
-	// Wait until shutdown.
-	<-signals.ShutdownOnSignals(ctx)
 	return nil
 }

--- a/x/ref/services/xproxy/xproxyd/main.go
+++ b/x/ref/services/xproxy/xproxyd/main.go
@@ -51,6 +51,8 @@ Command proxyd is a daemon that listens for connections from Vanadium services
 }
 
 func runProxyD(ctx *context.T, env *cmdline.Env, args []string) error {
+	ctx, waitForSignal := signals.ShutdownOnSignalsWithCancel(ctx)
+	defer waitForSignal()
 	// TODO(suharshs): Add ability to specify multiple proxies through this tool.
 	auth, err := authorizer(ctx)
 	if err != nil {
@@ -85,7 +87,6 @@ func runProxyD(ctx *context.T, env *cmdline.Env, args []string) error {
 	if _, _, err := v23.WithNewDispatchingServer(ctx, monitoringName, &nilDispatcher{}); err != nil {
 		return fmt.Errorf("NewServer failed: %v", err)
 	}
-	<-signals.ShutdownOnSignals(ctx)
 	return nil
 }
 

--- a/x/ref/test/hello/helloserver/helloserver.go
+++ b/x/ref/test/hello/helloserver/helloserver.go
@@ -45,7 +45,7 @@ func (*helloServer) Hello(ctx *context.T, call rpc.ServerCall) (string, error) {
 
 func runHelloServer(ctx *context.T, env *cmdline.Env, args []string) error {
 	ctx, waitForSignals := signals.ShutdownOnSignalsWithCancel(ctx)
-	ctx, server, err := v23.WithNewServer(ctx, name, &helloServer{}, security.AllowEveryone())
+	_, server, err := v23.WithNewServer(ctx, name, &helloServer{}, security.AllowEveryone())
 	if err != nil {
 		return fmt.Errorf("NewServer: %v", err)
 	}

--- a/x/ref/test/hello/helloserver/helloserver.go
+++ b/x/ref/test/hello/helloserver/helloserver.go
@@ -44,6 +44,7 @@ func (*helloServer) Hello(ctx *context.T, call rpc.ServerCall) (string, error) {
 }
 
 func runHelloServer(ctx *context.T, env *cmdline.Env, args []string) error {
+	ctx, waitForSignals := signals.ShutdownOnSignalsWithCancel(ctx)
 	ctx, server, err := v23.WithNewServer(ctx, name, &helloServer{}, security.AllowEveryone())
 	if err != nil {
 		return fmt.Errorf("NewServer: %v", err)
@@ -51,6 +52,6 @@ func runHelloServer(ctx *context.T, env *cmdline.Env, args []string) error {
 	if eps := server.Status().Endpoints; len(eps) > 0 {
 		fmt.Printf("SERVER_NAME=%s\n", eps[0].Name())
 	}
-	<-signals.ShutdownOnSignals(ctx)
+	waitForSignals()
 	return nil
 }


### PR DESCRIPTION
The shutdown function returned by v23.Init() keeps track of all services and will wait for them to be terminate, it does not explicitly initiate their shutdown however since the idiomatic way to do so is by canceling their context. Many servers wait for an OS signal before terminating using the signals.ShutdownOnSignals but often neglect to cancel the context used to create runtime services. `signals.ShutdownOnSignalsWithCancel(ctx)` is provided to make such cleanup more easily used. The following code will both wait for a signal, cancel the context when a signal is received thus initiating the shutdown of all services created using that context.

```go
  ctx, shutdown := test.V23Init()
  defer shutdown()
  ctx, waitForSignal := signals.ShutdownOnSignalsWithCancel(ctx)
  // use ctx when creating new runtime services
  defer waitForSignal()
```