### PR TITLE
x/ref/lib/signals: update signals API

### DIFF
--- a/x/ref/examples/tunnel/tunneld/main.go
+++ b/x/ref/examples/tunnel/tunneld/main.go
@@ -46,8 +46,8 @@ func runTunnelD(ctx *context.T, env *cmdline.Env, args []string) error {
 		auth security.Authorizer
 		err  error
 	)
-	ctx, waitForSignals := signals.ShutdownOnSignalsWithCancel(ctx)
-	defer waitForSignals()
+	ctx, handler := signals.ShutdownOnSignalsWithCancel(ctx)
+	defer handler.WaitForSignal()
 	switch {
 	case aclLiteral != "":
 		var perms access.Permissions

--- a/x/ref/lib/signals/signals_test.go
+++ b/x/ref/lib/signals/signals_test.go
@@ -83,9 +83,9 @@ func programWithContext(cancelSelf bool, sig ...os.Signal) {
 		go cancel()
 		ctx = nctx
 	}
-	ctx, waitForInterrupt := signals.ShutdownOnSignalsWithCancel(ctx)
+	ctx, handler := signals.ShutdownOnSignalsWithCancel(ctx)
 	defer func() {
-		sig := waitForInterrupt()
+		sig := handler.WaitForSignal()
 		fmt.Printf("received signal %v\n", sig)
 		<-ctx.Done()
 		fmt.Println(ctx.Err())

--- a/x/ref/runtime/internal/rpc/benchmark/benchmarkd/main.go
+++ b/x/ref/runtime/internal/rpc/benchmark/benchmarkd/main.go
@@ -33,7 +33,7 @@ var cmdRoot = &cmdline.Command{
 }
 
 func runBenchmarkD(ctx *context.T, env *cmdline.Env, args []string) error {
-	ctx, waitForSignals := signals.ShutdownOnSignalsWithCancel(ctx)
+	ctx, handler := signals.ShutdownOnSignalsWithCancel(ctx)
 	ctx, server, err := v23.WithNewServer(
 		ctx,
 		"",
@@ -44,6 +44,6 @@ func runBenchmarkD(ctx *context.T, env *cmdline.Env, args []string) error {
 		ctx.Fatalf("NewServer failed: %v", err)
 	}
 	ctx.Infof("Listening on %s", server.Status().Endpoints[0].Name())
-	waitForSignals()
+	handler.WaitForSignal()
 	return nil
 }

--- a/x/ref/runtime/internal/rt/shutdown_servers_test.go
+++ b/x/ref/runtime/internal/rt/shutdown_servers_test.go
@@ -190,7 +190,7 @@ var simpleServerProgram = gosh.RegisterFunc("simpleServerProgram", func() {
 	// Note, if the developer wants to exit immediately upon receiving a
 	// signal or stop command, they can skip this, in which case the default
 	// behavior is for the process to exit.
-	ctx, waitForSignal := signals.ShutdownOnSignalsWithCancel(ctx)
+	ctx, handler := signals.ShutdownOnSignalsWithCancel(ctx)
 
 	// This is part of the test setup -- we need a way to accept
 	// commands from the parent process to simulate Stop and
@@ -215,7 +215,7 @@ var simpleServerProgram = gosh.RegisterFunc("simpleServerProgram", func() {
 
 	// Wait for shutdown, which will also cancel the context
 	// when a signal is received.
-	sig := waitForSignal()
+	sig := handler.WaitForSignal()
 
 	// Note: this is not strictly required since the defer'ed shutdown
 	// function will also call <- server.Closed()

--- a/x/ref/services/groups/groupsd/main.go
+++ b/x/ref/services/groups/groupsd/main.go
@@ -47,8 +47,8 @@ v.io/v23/services/groups.Group interface.
 }
 
 func runGroupsD(ctx *context.T, env *cmdline.Env, args []string) error {
-	ctx, waitForSignal := signals.ShutdownOnSignalsWithCancel(ctx)
-	defer waitForSignal()
+	ctx, handler := signals.ShutdownOnSignalsWithCancel(ctx)
+	defer handler.WaitForSignal()
 	dispatcher, err := lib.NewGroupsDispatcher(flagRootDir, flagEngine)
 	if err != nil {
 		return err

--- a/x/ref/services/xproxy/xproxyd/main.go
+++ b/x/ref/services/xproxy/xproxyd/main.go
@@ -51,8 +51,8 @@ Command proxyd is a daemon that listens for connections from Vanadium services
 }
 
 func runProxyD(ctx *context.T, env *cmdline.Env, args []string) error {
-	ctx, waitForSignal := signals.ShutdownOnSignalsWithCancel(ctx)
-	defer waitForSignal()
+	ctx, handler := signals.ShutdownOnSignalsWithCancel(ctx)
+	defer handler.WaitForSignal()
 	// TODO(suharshs): Add ability to specify multiple proxies through this tool.
 	auth, err := authorizer(ctx)
 	if err != nil {

--- a/x/ref/test/hello/helloserver/helloserver.go
+++ b/x/ref/test/hello/helloserver/helloserver.go
@@ -44,7 +44,7 @@ func (*helloServer) Hello(ctx *context.T, call rpc.ServerCall) (string, error) {
 }
 
 func runHelloServer(ctx *context.T, env *cmdline.Env, args []string) error {
-	ctx, waitForSignals := signals.ShutdownOnSignalsWithCancel(ctx)
+	ctx, handler := signals.ShutdownOnSignalsWithCancel(ctx)
 	_, server, err := v23.WithNewServer(ctx, name, &helloServer{}, security.AllowEveryone())
 	if err != nil {
 		return fmt.Errorf("NewServer: %v", err)
@@ -52,6 +52,6 @@ func runHelloServer(ctx *context.T, env *cmdline.Env, args []string) error {
 	if eps := server.Status().Endpoints; len(eps) > 0 {
 		fmt.Printf("SERVER_NAME=%s\n", eps[0].Name())
 	}
-	waitForSignals()
+	handler.WaitForSignal()
 	return nil
 }


### PR DESCRIPTION
Revise the signals API to allow for registering additional cancel functions to be called when a signal is received or the context canceled. It also seems more obvious to call handler.WaitForSignals() rather than 'functionName()' to wait for signals.