### PR TITLE
x/ref/lib/security: use read-only lock for reading/loading principal data.

### DIFF
--- a/x/ref/envvar.go
+++ b/x/ref/envvar.go
@@ -88,6 +88,8 @@ func EnvNamespaceRoots() (map[string]string, []string) {
 func EnvClearCredentials() error {
 	for _, v := range []string{
 		EnvCredentials,
+		EnvCredentialsReadonlyFileSystem,
+		EnvCredentialsNoLockDeprecated,
 	} {
 		if err := os.Unsetenv(v); err != nil {
 			return err

--- a/x/ref/envvar.go
+++ b/x/ref/envvar.go
@@ -22,6 +22,10 @@ const (
 	// See v.io/x/ref/lib/security.CreatePersistentPrincipal.
 	EnvCredentials = "V23_CREDENTIALS"
 
+	// When set and non-empty, EnvCredentials is hosted on a read-only
+	// filesystem.
+	EnvCredentialsReadonlyFileSystem = "V23_CREDENTIALS_EADONLY_FILESYSTEM"
+
 	// EnvCredentialsReloadInterval is the name of the environment variable
 	// that specifies the interval between credentials reloads.
 	EnvCredentialsReloadInterval = "V23_CREDENTIALS_RELOAD_INTERVAL"

--- a/x/ref/envvar.go
+++ b/x/ref/envvar.go
@@ -24,7 +24,13 @@ const (
 
 	// When set and non-empty, EnvCredentials is hosted on a read-only
 	// filesystem.
-	EnvCredentialsReadonlyFileSystem = "V23_CREDENTIALS_EADONLY_FILESYSTEM"
+	EnvCredentialsReadonlyFileSystem = "V23_CREDENTIALS_READONLY_FILESYSTEM"
+
+	// EnvCredentialsNoLockDeprecated and V23_CREDENTIALS_NO_LOCK will
+	// be removed in a subsequent release. This is essentially an alias
+	// for V23_CREDENTIALS_READONLY_FILESYSTEM which should be used
+	// instead.
+	EnvCredentialsNoLockDeprecated = "V23_CREDENTIALS_NO_LOCK"
 
 	// EnvCredentialsReloadInterval is the name of the environment variable
 	// that specifies the interval between credentials reloads.
@@ -88,4 +94,19 @@ func EnvClearCredentials() error {
 		}
 	}
 	return nil
+}
+
+// ReadonlyCredentialsDir returns true if the credentials directory is to be
+// treated as readonly, for example, because it exists on a read-only
+// filesystem. Any attempt to write to this directory should result in an
+// error. It also returns the reason that the directory is considered readonly,
+// for now, the name of the environment variable that is used to indicate this.
+func ReadonlyCredentialsDir() (reason string, readonly bool) {
+	switch {
+	case len(os.Getenv(EnvCredentialsReadonlyFileSystem)) > 0:
+		return EnvCredentialsReadonlyFileSystem, true
+	case len(os.Getenv(EnvCredentialsNoLockDeprecated)) > 0:
+		return EnvCredentialsNoLockDeprecated, true
+	}
+	return "", false
 }

--- a/x/ref/lib/security/blessingroots.go
+++ b/x/ref/lib/security/blessingroots.go
@@ -48,7 +48,7 @@ func (br *blessingRoots) Add(root []byte, pattern security.BlessingPattern) erro
 	br.mu.Lock()
 	defer br.mu.Unlock()
 
-	unlock, err := br.lockAndLoad()
+	unlock, err := br.writeLockAndLoad()
 	if err != nil {
 		return err
 	}
@@ -153,17 +153,12 @@ func (br *blessingRoots) save() error {
 	return encodeAndStore(br.state, data, signature, br.signer)
 }
 
-func (br *blessingRoots) lockAndLoad() (func(), error) {
-	if br.flock == nil {
-		// in-memory store
-		return func() {}, br.load()
-	}
-	unlock, err := br.flock.Lock()
-	if err != nil {
-		return nil, err
-	}
-	err = br.load()
-	return unlock, err
+func (br *blessingRoots) readLockAndLoad() (func(), error) {
+	return readLockAndLoad(br.flock, br.load)
+}
+
+func (br *blessingRoots) writeLockAndLoad() (func(), error) {
+	return writeLockAndLoad(br.flock, br.load)
 }
 
 func (br *blessingRoots) load() error {
@@ -240,7 +235,7 @@ func NewPersistentBlessingRoots(ctx context.Context, lockFilePath string, reader
 		go reload(ctx, func() (func(), error) {
 			br.mu.Lock()
 			defer br.mu.Unlock()
-			return br.lockAndLoad()
+			return br.readLockAndLoad()
 		}, hupCh, update)
 	}
 	return br, nil

--- a/x/ref/lib/security/internal/lockedfile/mutex.go
+++ b/x/ref/lib/security/internal/lockedfile/mutex.go
@@ -65,3 +65,20 @@ func (mu *Mutex) Lock() (unlock func(), err error) {
 		f.Close()
 	}, nil
 }
+
+// Lock attempts to lock the Mutex for read-only access.
+func (mu *Mutex) RLock() (unlock func(), err error) {
+	if mu.Path == "" {
+		panic("lockedfile.Mutex: missing Path during Lock")
+	}
+	f, err := OpenFile(mu.Path, os.O_RDONLY, 0000)
+	if err != nil {
+		return nil, err
+	}
+	mu.mu.Lock()
+
+	return func() {
+		mu.mu.Unlock()
+		f.Close()
+	}, nil
+}

--- a/x/ref/lib/security/principal.go
+++ b/x/ref/lib/security/principal.go
@@ -147,7 +147,7 @@ func LoadPersistentPrincipalDaemon(ctx context.Context, dir string, passphrase [
 
 func loadPersistentPrincipal(ctx context.Context, dir string, passphrase []byte, readonly bool, update time.Duration) (security.Principal, error) {
 	flock := lockedfile.MutexAt(filepath.Join(dir, directoryLockfileName))
-	unlock, err := flock.Lock()
+	unlock, err := flock.RLock()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, err

--- a/x/ref/lib/security/principal_test.go
+++ b/x/ref/lib/security/principal_test.go
@@ -91,7 +91,7 @@ func TestLoadPersistentPEMPrincipal(t *testing.T) {
 		err = os.Chmod(path, mode)
 		nfi, _ := os.Stat(path)
 		if nfi.Mode().Perm() != mode {
-			t.Fatalf("failed to set permisions for %v", path)
+			t.Fatalf("failed to set permissions for %v", path)
 		}
 		return err
 	})

--- a/x/ref/lib/security/util.go
+++ b/x/ref/lib/security/util.go
@@ -47,7 +47,7 @@ func readLockAndLoad(flock *lockedfile.Mutex, loader func() error) (func(), erro
 		// in-memory store
 		return func() {}, loader()
 	}
-	if len(os.Getenv(ref.EnvCredentialsReadonlyFileSystem)) > 0 {
+	if _, ok := ref.ReadonlyCredentialsDir(); ok {
 		// running on a read-only filesystem.
 		return func() {}, loader()
 	}
@@ -63,9 +63,9 @@ func writeLockAndLoad(flock *lockedfile.Mutex, loader func() error) (func(), err
 		// in-memory store
 		return func() {}, loader()
 	}
-	if len(os.Getenv(ref.EnvCredentialsReadonlyFileSystem)) > 0 {
+	if reason, ok := ref.ReadonlyCredentialsDir(); ok {
 		// running on a read-only filesystem.
-		return func() {}, fmt.Errorf("%v is set and hence it is impossible to write to the credentials directory", ref.EnvCredentialsReadonlyFileSystem)
+		return func() {}, fmt.Errorf("the credentials directory is considered read-only and hence writes are disallowed (%v)", reason)
 	}
 	unlock, err := flock.Lock()
 	if err != nil {


### PR DESCRIPTION
This PR changes the locking strategy to use a read-only lock for read/loading principals versus a read-write lock for mutation. This should allow for servers to be run with read-only filesystems hosting their credentials. It also adds an environment variable V23_CREDENTIALS_READONLY_FILESYSTEM to specify when credentials are on a read-only filesystem, the previous V23_CREDENTIALS_NO_LOCK is now an alias for the former and will be deleted in the future.