### PR TITLE
v23/context: add a logging prefix to context based logging.

### DIFF
--- a/v23/context/context.go
+++ b/v23/context/context.go
@@ -190,12 +190,18 @@ func WithContextLogger(parent *T, logger Logger) *T {
 
 // WithLoggingPrefix returns a child of the current context that embeds the
 // supplied prefix. The prefix will be prepended to all log output, both
-// formated and unformated.
+// formated and unformatted.
 func WithLoggingPrefix(parent *T, prefix interface{}) *T {
 	if !parent.Initialized() {
 		return nil
 	}
 	return WithValue(parent, prefixKey, prefix)
+}
+
+// LoggingPrefix returns the value set by the most recent call of
+// WithLoggingPrefix.
+func LoggingPrefix(ctx *T) interface{} {
+	return ctx.Value(prefixKey)
 }
 
 // LoggerFromContext returns the implementation of the logger

--- a/v23/context/context.go
+++ b/v23/context/context.go
@@ -81,6 +81,7 @@ const (
 	rootKey = internalKey(iota)
 	loggerKey
 	ctxLoggerKey
+	prefixKey
 )
 
 // Logger is a logger that uses a passed in T to configure the logging behavior;
@@ -176,8 +177,8 @@ func WithLogger(parent *T, logger logging.Logger) *T {
 	return child
 }
 
-// WithContextLogger returns a child of the current context that embeds the supplied
-// context logger.
+// WithContextLogger returns a child of the current context that embeds the
+// supplied context logger.
 func WithContextLogger(parent *T, logger Logger) *T {
 	if !parent.Initialized() {
 		return nil
@@ -185,6 +186,16 @@ func WithContextLogger(parent *T, logger Logger) *T {
 	child := WithValue(parent, ctxLoggerKey, logger)
 	child.ctxLogger = logger
 	return child
+}
+
+// WithLoggingPrefix returns a child of the current context that embeds the
+// supplied prefix. The prefix will be prepended to all log output, both
+// formated and unformated.
+func WithLoggingPrefix(parent *T, prefix interface{}) *T {
+	if !parent.Initialized() {
+		return nil
+	}
+	return WithValue(parent, prefixKey, prefix)
 }
 
 // LoggerFromContext returns the implementation of the logger

--- a/v23/context/context_test.go
+++ b/v23/context/context_test.go
@@ -472,6 +472,7 @@ func TestLogging(t *testing.T) {
 	}
 	logger.Reset()
 	clogger.Reset()
+	prefix := uuid("1234")
 	ctx = context.WithLoggingPrefix(ctx, uuid("1234"))
 	ctx.Infof("1st: %v", 1)
 	if got, want := logger.String(), "uuid: 1234: 1st: 1\n"; got != want {
@@ -482,6 +483,10 @@ func TestLogging(t *testing.T) {
 	defer cancel()
 	ctx.Infof("2nd: %v", 2)
 	if got, want := logger.String(), "uuid: 1234: 1st: 1\nuuid: 1234: 2nd: 2\n"; got != want {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+
+	if got, want := context.LoggingPrefix(ctx).(uuid), prefix; got != want {
 		t.Fatalf("got %v, want %v", got, want)
 	}
 }

--- a/v23/context/internal_test.go
+++ b/v23/context/internal_test.go
@@ -2,13 +2,15 @@ package context
 
 import (
 	"context"
+	"runtime"
 	"testing"
 )
 
 func hasKeys(ctx *T, t *testing.T, keys ...interface{}) {
 	for _, key := range keys {
 		if ctx.Value(key) == nil {
-			t.Errorf("key %T %v missing", key, key)
+			_, _, line, _ := runtime.Caller(1)
+			t.Errorf("line: %v: key %T %v missing", line, key, key)
 		}
 	}
 }

--- a/v23/context/wraplog.go
+++ b/v23/context/wraplog.go
@@ -23,24 +23,40 @@ func (ld *loggerDiscard) VIDepth(ctx *T, depth int, level int) Logger {
 
 func (ld *loggerDiscard) FlushLog() {}
 
+func (t *T) prefixedArgs(args []interface{}) []interface{} {
+	prefix := t.Value(prefixKey)
+	if prefix == nil {
+		return args
+	}
+	return append([]interface{}{prefix}, args...)
+}
+
+func (t *T) prefixedFormat(format string) string {
+	prefix := t.Value(prefixKey)
+	if prefix == nil {
+		return format
+	}
+	return "%v: " + format
+}
+
 // Info implements logging.InfoLog, it calls the registered Logger and then
 // the registered ContextLogger.
 func (t *T) Info(args ...interface{}) {
-	t.logger.InfoDepth(1, args...)
-	t.ctxLogger.InfoDepth(t, 1, args...)
+	t.logger.InfoDepth(1, t.prefixedArgs(args)...)
+	t.ctxLogger.InfoDepth(t, 1, t.prefixedArgs(args)...)
 }
 
 // InfoDepth implements logging.InfoLog; it calls the registered Logger and then
 // the registered ContextLogger.
 func (t *T) InfoDepth(depth int, args ...interface{}) {
-	t.logger.InfoDepth(depth+1, args...)
-	t.ctxLogger.InfoDepth(t, depth+1, args...)
+	t.logger.InfoDepth(depth+1, t.prefixedArgs(args)...)
+	t.ctxLogger.InfoDepth(t, depth+1, t.prefixedArgs(args)...)
 }
 
 // Infof implements logging.InfoLog; it calls the registered Logger and then
 // the registered ContextLogger.
 func (t *T) Infof(format string, args ...interface{}) {
-	line := fmt.Sprintf(format, args...)
+	line := fmt.Sprintf(t.prefixedFormat(format), t.prefixedArgs(args)...)
 	t.logger.InfoDepth(1, line)
 	t.ctxLogger.InfoDepth(t, 1, line)
 }
@@ -55,21 +71,21 @@ func (t *T) InfoStack(all bool) {
 // Error immplements and calls logging.ErrorLog; it calls the registered Logger and then
 // the registered ContextLogger.
 func (t *T) Error(args ...interface{}) {
-	t.logger.ErrorDepth(1, args...)
-	t.ctxLogger.InfoDepth(t, 1, args...)
+	t.logger.ErrorDepth(1, t.prefixedArgs(args)...)
+	t.ctxLogger.InfoDepth(t, 1, t.prefixedArgs(args)...)
 }
 
 // ErrorDepth immplements and calls logging.ErrorLog; it calls the registered Logger and then
 // the registered ContextLogger.
 func (t *T) ErrorDepth(depth int, args ...interface{}) {
-	t.logger.ErrorDepth(depth+1, args...)
-	t.ctxLogger.InfoDepth(t, depth+1, args...)
+	t.logger.ErrorDepth(depth+1, t.prefixedArgs(args)...)
+	t.ctxLogger.InfoDepth(t, depth+1, t.prefixedArgs(args)...)
 }
 
 // Errorf immplements and calls logging.ErrorLog; it calls the registered Logger and then
 // the registered ContextLogger.
 func (t *T) Errorf(format string, args ...interface{}) {
-	line := fmt.Sprintf(format, args...)
+	line := fmt.Sprintf(t.prefixedFormat(format), t.prefixedArgs(args)...)
 	t.logger.ErrorDepth(1, line)
 	t.ctxLogger.InfoDepth(t, 1, line)
 }
@@ -77,37 +93,37 @@ func (t *T) Errorf(format string, args ...interface{}) {
 // Fatal implements logging.FatalLog; it calls the registered Logger but not
 // the ContextLogger.
 func (t *T) Fatal(args ...interface{}) {
-	t.logger.FatalDepth(1, args...)
+	t.logger.FatalDepth(1, t.prefixedArgs(args)...)
 }
 
 // FatalDepth implements logging.FatalLog; it calls the registered Logger but not
 // the ContextLogger.
 func (t *T) FatalDepth(depth int, args ...interface{}) {
-	t.logger.FatalDepth(depth+1, args...)
+	t.logger.FatalDepth(depth+1, t.prefixedArgs(args)...)
 }
 
 // Fatalf implements logging.FatalLog; it calls the registered Logger but not
 // the ContextLogger.
 func (t *T) Fatalf(format string, args ...interface{}) {
-	t.logger.FatalDepth(1, fmt.Sprintf(format, args...))
+	t.logger.FatalDepth(1, fmt.Sprintf(t.prefixedFormat(format), t.prefixedArgs(args)...))
 }
 
 // Panic implements logging.PanicLog; it calls the registered Logger but not
 // the ContextLogger.
 func (t *T) Panic(args ...interface{}) {
-	t.logger.PanicDepth(1, args...)
+	t.logger.PanicDepth(1, t.prefixedArgs(args)...)
 }
 
 // PanicDepth implements logging.PanicLog; it calls the registered Logger but not
 // the ContextLogger.
 func (t *T) PanicDepth(depth int, args ...interface{}) {
-	t.logger.PanicDepth(depth+1, args...)
+	t.logger.PanicDepth(depth+1, t.prefixedArgs(args)...)
 }
 
 // Panicf implements logging.PanicLog; it calls the registered Logger but not
 // the ContextLogger.
 func (t *T) Panicf(format string, args ...interface{}) {
-	t.logger.PanicDepth(1, fmt.Sprintf(format, args...))
+	t.logger.PanicDepth(1, fmt.Sprintf(t.prefixedFormat(format), t.prefixedArgs(args)...))
 }
 
 // V implements logging.Verbosity; it returns the 'or' of the values
@@ -134,19 +150,19 @@ type viLogger struct {
 }
 
 func (v *viLogger) Info(args ...interface{}) {
-	v.logger.InfoDepth(1, args...)
-	v.ctxLogger.InfoDepth(v.ctx, 1, args...)
+	v.logger.InfoDepth(1, v.ctx.prefixedArgs(args)...)
+	v.ctxLogger.InfoDepth(v.ctx, 1, v.ctx.prefixedArgs(args)...)
 }
 
 func (v *viLogger) Infof(format string, args ...interface{}) {
-	line := fmt.Sprintf(format, args...)
+	line := fmt.Sprintf(v.ctx.prefixedFormat(format), v.ctx.prefixedArgs(args)...)
 	v.logger.InfoDepth(1, line)
 	v.ctxLogger.InfoDepth(v.ctx, 1, line)
 }
 
 func (v *viLogger) InfoDepth(depth int, args ...interface{}) {
-	v.logger.InfoDepth(depth+1, args...)
-	v.ctxLogger.InfoDepth(v.ctx, depth+1, args...)
+	v.logger.InfoDepth(depth+1, v.ctx.prefixedArgs(args)...)
+	v.ctxLogger.InfoDepth(v.ctx, depth+1, v.ctx.prefixedArgs(args)...)
 }
 
 func (v *viLogger) InfoStack(all bool) {


### PR DESCRIPTION
Add `context.WithLoggingPrefix(*T, interface{})` to allow setting a context mediated 'prefix' to be prepended to every line of log output generated via the implementation of logging.Logger provided by context.T. This should make it straightforward for example to prepend all log entries generated for a specific operation or RPC request with an id unique to that operation/request.