### PR TITLE
v23/verror: fix how default verror package paths are calculated

### DIFF
--- a/v23/verror/pkgpath.go
+++ b/v23/verror/pkgpath.go
@@ -63,6 +63,7 @@ func IDPath(val interface{}, id string) ID {
 	return ID(reflect.TypeOf(val).PkgPath() + "." + id)
 }
 
+/*
 func longestCommonSuffix(pkgPath, filename string) string {
 	longest := ""
 	for {
@@ -86,6 +87,14 @@ func initThisPkg() {
 	type dummy int
 	thisPkg = reflect.TypeOf(dummy(0)).PkgPath()
 }
+*/
+
+var thisDir string
+
+func init() {
+	_, file, _, _ := runtime.Caller(0)
+	thisDir := filepath.Dir(file)
+}
 
 func (pc *pathCache) pkgPath(file string) string {
 	thisPkgOnce.Do(initThisPkg)
@@ -99,20 +108,29 @@ func (pc *pathCache) pkgPath(file string) string {
 }
 
 func ensurePackagePath(id ID) ID {
+	fmt.Printf("EP: %v\n", id)
 	sid := string(id)
 	if strings.Contains(sid, ".") && sid[0] != '.' {
+		fmt.Printf("EP: 1 %v\n", id)
+
 		return id
 	}
 	_, file, _, _ := runtime.Caller(2)
 	pkg := pkgPathCache.pkgPath(file)
 	if len(pkg) == 0 {
+		fmt.Printf("EP: 2 %v ... %v\n", file, id)
 		return id
 	}
 	if strings.HasPrefix(sid, pkg) {
+		fmt.Printf("EP: 3 %v\n", id)
+
 		return id
 	}
 	if strings.HasPrefix(sid, ".") {
+		fmt.Printf("EP: 4 %v\n", id)
+
 		return ID(pkg + sid)
 	}
+	fmt.Printf("SEP: %v -> %v\n", id, ID(pkg+"."+sid))
 	return ID(pkg + "." + sid)
 }

--- a/v23/verror/pkgpath_test.go
+++ b/v23/verror/pkgpath_test.go
@@ -1,0 +1,51 @@
+package verror
+
+import (
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestLCS(t *testing.T) {
+	for i, tc := range []struct {
+		pkg, path       string
+		lcsPkg, lcsPath string
+	}{
+		{"a", "b", "", ""},
+		{"/a/b/c", "/a/b/c", "/a/b/c", "/a/b/c"},
+		{"/a/b/c/d", "/x/y/c/d", "c/d", "c/d"},
+	} {
+		lcsPkg, lcsPath := longestCommonSuffix(tc.pkg, tc.path)
+		if got, want := lcsPkg, tc.lcsPkg; got != want {
+			t.Errorf("%v: got %v, want %v", i, got, want)
+		}
+		if got, want := lcsPath, tc.lcsPath; got != want {
+			t.Errorf("%v: got %v, want %v", i, got, want)
+		}
+	}
+}
+
+func TestPkgPath(t *testing.T) {
+	type dummy int
+	ps := &pathState{}
+	_, file, _, _ := runtime.Caller(0)
+	ps.init(reflect.TypeOf(dummy(0)).PkgPath(), file)
+	if got, want := ps.pkg, "v.io/v23/verror"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := ps.dir, filepath.Dir(file); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := strings.HasPrefix(file, ps.filePrefix), true; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := ps.pkgPrefix, "v.io"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	ps.init("github.com/grailbio/base", "/a/b/src/base/file")
+	if got, want := ps.pkgPrefix, "github.com/grailbio"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/v23/verror/verror.go
+++ b/v23/verror/verror.go
@@ -178,9 +178,8 @@ type IDAction struct {
 
 // Register returns a IDAction with the given ID and Action fields, and
 // inserts a message into the default i18n Catalogue in US English.
-// Other languages can be added by adding to the Catalogue. Register
-// will internally prepend the caller's package path to id if it's not
-// already present.
+// Other languages can be added by adding to the Catalogue.
+// IDPath can be used to generate an appropriate ID.
 func Register(id ID, action ActionCode, englishText string) IDAction {
 	id = ensurePackagePath(id)
 	i18n.Cat().SetWithBase(defaultLangID(i18n.NoLangID), i18n.MsgID(id), englishText)
@@ -189,8 +188,7 @@ func Register(id ID, action ActionCode, englishText string) IDAction {
 
 // NewIDAction creates a new instance of IDAction with the given ID and Action
 // field. It should be used when localization support is not required instead
-// of Register.  NewIDAction will internally prepend the caller's package path
-// to id if it's not already present.
+// of Register. IDPath can be used to
 func NewIDAction(id ID, action ActionCode) IDAction {
 	return IDAction{ensurePackagePath(id), action}
 }

--- a/v23/verror/verror_id_test.go
+++ b/v23/verror/verror_id_test.go
@@ -1,0 +1,24 @@
+package verror_test
+
+import (
+	"testing"
+
+	"v.io/v23/flow"
+	"v.io/v23/verror"
+	"v.io/x/ref/lib/security"
+)
+
+func TestPackageErrorIDs(t *testing.T) {
+	for i, tc := range []struct {
+		err error
+		id  string
+	}{
+		{verror.ErrInternal.Errorf(nil, "x"), "v.io/v23/verror.Internal"},
+		{flow.ErrAuth.Errorf(nil, "x"), "v.io/v23/flow.Auth"},
+		{security.ErrBadPassphrase.Errorf(nil, "x"), "v.io/x/ref/lib/security.errBadPassphrase"},
+	} {
+		if got, want := verror.ErrorID(tc.err), verror.ID(tc.id); got != want {
+			t.Errorf("%v: got %v, want %v", i, got, want)
+		}
+	}
+}

--- a/x/ref/runtime/internal/flow/util.go
+++ b/x/ref/runtime/internal/flow/util.go
@@ -5,7 +5,6 @@
 package flow
 
 import (
-	"fmt"
 	"strings"
 
 	"v.io/v23/context"
@@ -36,7 +35,6 @@ func shouldWrap(err error) bool {
 	}
 	id := verror.ErrorID(err)
 	for _, pkg := range noWrapPackages {
-		fmt.Printf("COMPARE: %v %v %v\n", err, id, pkg)
 		if strings.HasPrefix(string(id), pkg) {
 			return false
 		}

--- a/x/ref/runtime/internal/flow/util.go
+++ b/x/ref/runtime/internal/flow/util.go
@@ -5,6 +5,7 @@
 package flow
 
 import (
+	"fmt"
 	"strings"
 
 	"v.io/v23/context"
@@ -35,6 +36,7 @@ func shouldWrap(err error) bool {
 	}
 	id := verror.ErrorID(err)
 	for _, pkg := range noWrapPackages {
+		fmt.Printf("COMPARE: %v %v %v\n", err, id, pkg)
 		if strings.HasPrefix(string(id), pkg) {
 			return false
 		}

--- a/x/ref/runtime/internal/flow/util_test.go
+++ b/x/ref/runtime/internal/flow/util_test.go
@@ -24,7 +24,7 @@ func TestMaybeWrapError(t *testing.T) {
 		{verror.ErrUnknown.Errorf(ctx, "some random thing"), false},
 		{flow.ErrAuth.Errorf(ctx, ""), false},
 	}
-	for _, test := range tests {
+	for i, test := range tests {
 		werr := MaybeWrapError(flow.ErrAuth, ctx, test.err)
 		// If the returned error is not equal to the original error it was wrapped.
 		msg := ""
@@ -33,9 +33,9 @@ func TestMaybeWrapError(t *testing.T) {
 		}
 		if wasWrapped := werr.Error() != msg; wasWrapped != test.wrap {
 			if test.wrap {
-				t.Errorf("wanted %v to be wrapped", test.err)
+				t.Errorf("%v: wanted %v to be wrapped", i, test.err)
 			} else {
-				t.Errorf("did not want %v to be wrapped", test.err)
+				t.Errorf("%v: did not want %v to be wrapped", i, test.err)
 			}
 		}
 	}


### PR DESCRIPTION
It was a mistake to use go.mod files at runtime since they are likely not present when apps are actually run!