### PR TITLE
update go go1.15.4 and v.io/x/lib 0.1.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
   integration-tests:
     executor:
       name: go/default
-      tag: "1.15.2"
     steps:
       - checkout
       - go/load-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
   integration-tests:
     executor:
       name: go/default
+      tag: "1.15"
     steps:
       - checkout
       - go/load-cache

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	golang.org/x/tools v0.0.0-20201109182053-3db8fd265862 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/api v0.9.0
-	v.io/x/lib v0.1.6
+	v.io/x/lib v0.1.7
 	v.io/x/ref/internal/logger v0.1.1
 	v.io/x/ref/lib/flags/sitedefaults v0.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -156,3 +156,5 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 v.io/x/lib v0.1.6 h1:Y6/5Gq4kQnOaIQT6UaNrFppJxpOpU3KWNvdDkgGptew=
 v.io/x/lib v0.1.6/go.mod h1:aLm+mPXyXf4Vd/n+1f4LcSQFFgqNhNzwQvHYfXoOLlE=
+v.io/x/lib v0.1.7 h1:FXaiEHSrk6Jduc9JCNCzCVFX6ps/NbUaS45ppufC8Do=
+v.io/x/lib v0.1.7/go.mod h1:aLm+mPXyXf4Vd/n+1f4LcSQFFgqNhNzwQvHYfXoOLlE=


### PR DESCRIPTION
1.15.4 fixes the cgo bug in .3 that broke openssl integration.