### PR TITLE
v23/verror: use CallersFrames rather than FuncForPC

### DIFF
--- a/v23/verror/verror.go
+++ b/v23/verror/verror.go
@@ -646,7 +646,6 @@ func stackToTextIndent(w io.Writer, stack []uintptr, indent string) {
 	if prev < len(stack) {
 		writeFrames(w, indent, stack[prev:])
 	}
-	return
 }
 
 // StackToText emits on w a text representation of stack, which is typically

--- a/v23/verror/verror.go
+++ b/v23/verror/verror.go
@@ -615,7 +615,7 @@ func Stack(err error) PCs {
 
 func (st PCs) String() string {
 	buf := bytes.NewBufferString("")
-	StackToText(buf, st) //nolint:errcheck
+	StackToText(buf, st)
 	return buf.String()
 }
 

--- a/v23/verror/verror.go
+++ b/v23/verror/verror.go
@@ -619,28 +619,41 @@ func (st PCs) String() string {
 	return buf.String()
 }
 
+func writeFrames(w io.Writer, indent string, stack []uintptr) {
+	frames := runtime.CallersFrames(stack)
+	for {
+		frame, more := frames.Next()
+		fmt.Fprintf(w, "%s%s:%d: %s\n", indent, frame.File, frame.Line, frame.Function)
+		if !more {
+			return
+		}
+	}
+}
+
 // stackToTextIndent emits on w a text representation of stack, which is typically
 // obtained from Stack() and represents the source location(s) where an
 // error was generated or passed through in the local address space.
 // indent is added to a prefix of each line printed.
-func stackToTextIndent(w io.Writer, stack []uintptr, indent string) (err error) {
-	for i := 0; i != len(stack) && err == nil; i++ {
+func stackToTextIndent(w io.Writer, stack []uintptr, indent string) {
+	prev := 0
+	for i := 0; i < len(stack); i++ {
 		if stack[i] == 0 {
-			_, err = fmt.Fprintf(w, "%s----- chained verror -----\n", indent)
-		} else {
-			fnc := runtime.FuncForPC(stack[i])
-			file, line := fnc.FileLine(stack[i])
-			_, err = fmt.Fprintf(w, "%s%s:%d: %s\n", indent, file, line, fnc.Name())
+			writeFrames(w, indent, stack[prev:i])
+			fmt.Fprintf(w, "%s----- chained verror -----\n", indent)
+			prev = i + 1
 		}
 	}
-	return err
+	if prev < len(stack) {
+		writeFrames(w, indent, stack[prev:])
+	}
+	return
 }
 
 // StackToText emits on w a text representation of stack, which is typically
 // obtained from Stack() and represents the source location(s) where an
 // error was generated or passed through in the local address space.
-func StackToText(w io.Writer, stack []uintptr) error {
-	return stackToTextIndent(w, stack, "")
+func StackToText(w io.Writer, stack []uintptr) {
+	stackToTextIndent(w, stack, "")
 }
 
 // defaultLangID returns langID is it is not i18n.NoLangID, and the default


### PR DESCRIPTION
Using FuncForPC is deprecated and the problems cited for it show themselves on darwin/arm64 platforms. With this PR all tests apart from openssl,  and v.io/x/ref/services/debug/debug -v23.tests  pass on Apple's A12 based mac-mini.