### PR TITLE
x/ref/services/internal/logreaderlib: ensure that all entries are read even in the face of a permissions error.

### DIFF
--- a/v23/verror/verror.go
+++ b/v23/verror/verror.go
@@ -646,7 +646,6 @@ func stackToTextIndent(w io.Writer, stack []uintptr, indent string) {
 	if prev < len(stack) {
 		writeFrames(w, indent, stack[prev:])
 	}
-	return
 }
 
 // StackToText emits on w a text representation of stack, which is typically

--- a/v23/verror/verror.go
+++ b/v23/verror/verror.go
@@ -615,7 +615,7 @@ func Stack(err error) PCs {
 
 func (st PCs) String() string {
 	buf := bytes.NewBufferString("")
-	StackToText(buf, st) //nolint:errcheck
+	StackToText(buf, st)
 	return buf.String()
 }
 

--- a/v23/verror/verror.go
+++ b/v23/verror/verror.go
@@ -619,28 +619,41 @@ func (st PCs) String() string {
 	return buf.String()
 }
 
+func writeFrames(w io.Writer, indent string, stack []uintptr) {
+	frames := runtime.CallersFrames(stack)
+	for {
+		frame, more := frames.Next()
+		fmt.Fprintf(w, "%s%s:%d: %s\n", indent, frame.File, frame.Line, frame.Function)
+		if !more {
+			return
+		}
+	}
+}
+
 // stackToTextIndent emits on w a text representation of stack, which is typically
 // obtained from Stack() and represents the source location(s) where an
 // error was generated or passed through in the local address space.
 // indent is added to a prefix of each line printed.
-func stackToTextIndent(w io.Writer, stack []uintptr, indent string) (err error) {
-	for i := 0; i != len(stack) && err == nil; i++ {
+func stackToTextIndent(w io.Writer, stack []uintptr, indent string) {
+	prev := 0
+	for i := 0; i < len(stack); i++ {
 		if stack[i] == 0 {
-			_, err = fmt.Fprintf(w, "%s----- chained verror -----\n", indent)
-		} else {
-			fnc := runtime.FuncForPC(stack[i])
-			file, line := fnc.FileLine(stack[i])
-			_, err = fmt.Fprintf(w, "%s%s:%d: %s\n", indent, file, line, fnc.Name())
+			writeFrames(w, indent, stack[prev:i])
+			fmt.Fprintf(w, "%s----- chained verror -----\n", indent)
+			prev = i + 1
 		}
 	}
-	return err
+	if prev < len(stack) {
+		writeFrames(w, indent, stack[prev:])
+	}
+	return
 }
 
 // StackToText emits on w a text representation of stack, which is typically
 // obtained from Stack() and represents the source location(s) where an
 // error was generated or passed through in the local address space.
-func StackToText(w io.Writer, stack []uintptr) error {
-	return stackToTextIndent(w, stack, "")
+func StackToText(w io.Writer, stack []uintptr) {
+	stackToTextIndent(w, stack, "")
 }
 
 // defaultLangID returns langID is it is not i18n.NoLangID, and the default

--- a/x/ref/services/internal/logreaderlib/logfile.go
+++ b/x/ref/services/internal/logreaderlib/logfile.go
@@ -144,15 +144,19 @@ func (i *logfileService) GlobChildren__(ctx *context.T, call rpc.GlobChildrenSer
 		if err == io.EOF {
 			break
 		}
-		if err != nil {
-			return err
-		}
+		// Ensure that any entries processed before encountering an error
+		// are returned before return the error indication itself. For example
+		// Readdir will return files/directories processed before encountering
+		// a permissions error.
 		for _, file := range fi {
 			name := file.Name()
 			if m.Match(name) {
 				//nolint:errcheck
 				call.SendStream().Send(naming.GlobChildrenReplyName{Value: name})
 			}
+		}
+		if err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
os.Readdir will stop enumerating entries on encountering a permissions error, however there may be subsequent entries that can be read. This PR calls Readdir multiple times until io.EOF is returned even if an error is encountered. It returns the last error
it observes and streams all entries returned by Readdir. This was encountered on apple silicon mac mini, but it's likely due to Big Sur rather than the hardware so will likely be encountered more broadly than apple silicon machines.