### PR TITLE
v23/vom/internal: update benchmarks to include optional and native types.

### DIFF
--- a/v23/vom/internal/bench_test.go
+++ b/v23/vom/internal/bench_test.go
@@ -21,606 +21,1545 @@ import (
 )
 
 func BenchmarkVom___Encode_____XNumber(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XNumber(2))
 }
 func BenchmarkVom___EncodeMany_XNumber(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XNumber(2))
 }
+func BenchmarkVom___EncodeOptional_____XNumber(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XNumber(2)
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XNumber(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XNumber(2)
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XNumber(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XNumber(2))
 }
 func BenchmarkGob___EncodeMany_XNumber(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XNumber(2))
 }
+func BenchmarkGob___EncodeOptional_____XNumber(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XNumber(2)
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XNumber(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XNumber(2)
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XNumber(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XNumber(2), func() interface{} { return new(XNumber) })
 }
 func BenchmarkVom___DecodeMany_XNumber(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XNumber(2), func() interface{} { return new(XNumber) })
 }
 func BenchmarkGob___Decode_____XNumber(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XNumber(2), func() interface{} { return new(XNumber) })
 }
 func BenchmarkGob___DecodeMany_XNumber(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XNumber(2), func() interface{} { return new(XNumber) })
 }
 func BenchmarkVom___Encode_____VNumber(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VNumber(2))
 }
 func BenchmarkVom___EncodeMany_VNumber(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VNumber(2))
 }
+func BenchmarkVom___EncodeOptional_____VNumber(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VNumber(2)
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VNumber(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VNumber(2)
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VNumber(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VNumber(2), func() interface{} { return new(VNumber) })
 }
 func BenchmarkVom___DecodeMany_VNumber(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VNumber(2), func() interface{} { return new(VNumber) })
 }
 func BenchmarkVom___Encode_____XStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XString("abc"))
 }
 func BenchmarkVom___EncodeMany_XStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XString("abc"))
 }
+func BenchmarkVom___EncodeOptional_____XStringSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XString("abc")
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XStringSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XString("abc")
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XString("abc"))
 }
 func BenchmarkGob___EncodeMany_XStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XString("abc"))
 }
+func BenchmarkGob___EncodeOptional_____XStringSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XString("abc")
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XStringSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XString("abc")
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XString("abc"), func() interface{} { return new(XString) })
 }
 func BenchmarkVom___DecodeMany_XStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XString("abc"), func() interface{} { return new(XString) })
 }
 func BenchmarkGob___Decode_____XStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XString("abc"), func() interface{} { return new(XString) })
 }
 func BenchmarkGob___DecodeMany_XStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XString("abc"), func() interface{} { return new(XString) })
 }
 func BenchmarkVom___Encode_____VStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VString("abc"))
 }
 func BenchmarkVom___EncodeMany_VStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VString("abc"))
 }
+func BenchmarkVom___EncodeOptional_____VStringSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VString("abc")
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VStringSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VString("abc")
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VString("abc"), func() interface{} { return new(VString) })
 }
 func BenchmarkVom___DecodeMany_VStringSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VString("abc"), func() interface{} { return new(VString) })
 }
 func BenchmarkVom___Encode_____XStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XString(createString(65536)))
 }
 func BenchmarkVom___EncodeMany_XStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XString(createString(65536)))
 }
+func BenchmarkVom___EncodeOptional_____XStringLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XString(createString(65536))
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XStringLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XString(createString(65536))
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XString(createString(65536)))
 }
 func BenchmarkGob___EncodeMany_XStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XString(createString(65536)))
 }
+func BenchmarkGob___EncodeOptional_____XStringLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XString(createString(65536))
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XStringLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XString(createString(65536))
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XString(createString(65536)), func() interface{} { return new(XString) })
 }
 func BenchmarkVom___DecodeMany_XStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XString(createString(65536)), func() interface{} { return new(XString) })
 }
 func BenchmarkGob___Decode_____XStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XString(createString(65536)), func() interface{} { return new(XString) })
 }
 func BenchmarkGob___DecodeMany_XStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XString(createString(65536)), func() interface{} { return new(XString) })
 }
 func BenchmarkVom___Encode_____VStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VString(createString(65536)))
 }
 func BenchmarkVom___EncodeMany_VStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VString(createString(65536)))
 }
+func BenchmarkVom___EncodeOptional_____VStringLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VString(createString(65536))
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VStringLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VString(createString(65536))
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VString(createString(65536)), func() interface{} { return new(VString) })
 }
 func BenchmarkVom___DecodeMany_VStringLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VString(createString(65536)), func() interface{} { return new(VString) })
 }
 func BenchmarkVom___Encode_____VEnum(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VEnumA)
 }
 func BenchmarkVom___EncodeMany_VEnum(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VEnumA)
 }
+func BenchmarkVom___EncodeOptional_____VEnum(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VEnumA
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VEnum(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VEnumA
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VEnum(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VEnumA, func() interface{} { return new(VEnum) })
 }
 func BenchmarkVom___DecodeMany_VEnum(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VEnumA, func() interface{} { return new(VEnum) })
 }
 func BenchmarkVom___Encode_____XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XByteList{1, 2, 3})
 }
 func BenchmarkVom___EncodeMany_XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XByteList{1, 2, 3})
 }
+func BenchmarkVom___EncodeOptional_____XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteList{1, 2, 3}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteList{1, 2, 3}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XByteList{1, 2, 3})
 }
 func BenchmarkGob___EncodeMany_XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XByteList{1, 2, 3})
 }
+func BenchmarkGob___EncodeOptional_____XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteList{1, 2, 3}
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteList{1, 2, 3}
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XByteList{1, 2, 3}, func() interface{} { return new(XByteList) })
 }
 func BenchmarkVom___DecodeMany_XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XByteList{1, 2, 3}, func() interface{} { return new(XByteList) })
 }
 func BenchmarkGob___Decode_____XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XByteList{1, 2, 3}, func() interface{} { return new(XByteList) })
 }
 func BenchmarkGob___DecodeMany_XByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XByteList{1, 2, 3}, func() interface{} { return new(XByteList) })
 }
 func BenchmarkVom___Encode_____VByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VByteList{1, 2, 3})
 }
 func BenchmarkVom___EncodeMany_VByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VByteList{1, 2, 3})
 }
+func BenchmarkVom___EncodeOptional_____VByteListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VByteList{1, 2, 3}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VByteListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VByteList{1, 2, 3}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VByteList{1, 2, 3}, func() interface{} { return new(VByteList) })
 }
 func BenchmarkVom___DecodeMany_VByteListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VByteList{1, 2, 3}, func() interface{} { return new(VByteList) })
 }
 func BenchmarkVom___Encode_____XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XByteList(createByteList(65536)))
 }
 func BenchmarkVom___EncodeMany_XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XByteList(createByteList(65536)))
 }
+func BenchmarkVom___EncodeOptional_____XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteList(createByteList(65536))
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteList(createByteList(65536))
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XByteList(createByteList(65536)))
 }
 func BenchmarkGob___EncodeMany_XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XByteList(createByteList(65536)))
 }
+func BenchmarkGob___EncodeOptional_____XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteList(createByteList(65536))
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteList(createByteList(65536))
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XByteList(createByteList(65536)), func() interface{} { return new(XByteList) })
 }
 func BenchmarkVom___DecodeMany_XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XByteList(createByteList(65536)), func() interface{} { return new(XByteList) })
 }
 func BenchmarkGob___Decode_____XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XByteList(createByteList(65536)), func() interface{} { return new(XByteList) })
 }
 func BenchmarkGob___DecodeMany_XByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XByteList(createByteList(65536)), func() interface{} { return new(XByteList) })
 }
 func BenchmarkVom___Encode_____VByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VByteList(createByteList(65536)))
 }
 func BenchmarkVom___EncodeMany_VByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VByteList(createByteList(65536)))
 }
+func BenchmarkVom___EncodeOptional_____VByteListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VByteList(createByteList(65536))
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VByteListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VByteList(createByteList(65536))
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VByteList(createByteList(65536)), func() interface{} { return new(VByteList) })
 }
 func BenchmarkVom___DecodeMany_VByteListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VByteList(createByteList(65536)), func() interface{} { return new(VByteList) })
 }
 func BenchmarkVom___Encode_____XByteArray(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XByteArray{1, 2, 3})
 }
 func BenchmarkVom___EncodeMany_XByteArray(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XByteArray{1, 2, 3})
 }
+func BenchmarkVom___EncodeOptional_____XByteArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteArray{1, 2, 3}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XByteArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteArray{1, 2, 3}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XByteArray(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XByteArray{1, 2, 3})
 }
 func BenchmarkGob___EncodeMany_XByteArray(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XByteArray{1, 2, 3})
 }
+func BenchmarkGob___EncodeOptional_____XByteArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteArray{1, 2, 3}
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XByteArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XByteArray{1, 2, 3}
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XByteArray(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XByteArray{1, 2, 3}, func() interface{} { return new(XByteArray) })
 }
 func BenchmarkVom___DecodeMany_XByteArray(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XByteArray{1, 2, 3}, func() interface{} { return new(XByteArray) })
 }
 func BenchmarkGob___Decode_____XByteArray(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XByteArray{1, 2, 3}, func() interface{} { return new(XByteArray) })
 }
 func BenchmarkGob___DecodeMany_XByteArray(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XByteArray{1, 2, 3}, func() interface{} { return new(XByteArray) })
 }
 func BenchmarkVom___Encode_____VByteArray(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VByteArray{1, 2, 3})
 }
 func BenchmarkVom___EncodeMany_VByteArray(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VByteArray{1, 2, 3})
 }
+func BenchmarkVom___EncodeOptional_____VByteArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VByteArray{1, 2, 3}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VByteArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VByteArray{1, 2, 3}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VByteArray(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VByteArray{1, 2, 3}, func() interface{} { return new(VByteArray) })
 }
 func BenchmarkVom___DecodeMany_VByteArray(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VByteArray{1, 2, 3}, func() interface{} { return new(VByteArray) })
 }
 func BenchmarkVom___Encode_____XArray(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XArray{1, 2, 3})
 }
 func BenchmarkVom___EncodeMany_XArray(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XArray{1, 2, 3})
 }
+func BenchmarkVom___EncodeOptional_____XArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XArray{1, 2, 3}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XArray{1, 2, 3}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XArray(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XArray{1, 2, 3})
 }
 func BenchmarkGob___EncodeMany_XArray(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XArray{1, 2, 3})
 }
+func BenchmarkGob___EncodeOptional_____XArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XArray{1, 2, 3}
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XArray{1, 2, 3}
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XArray(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XArray{1, 2, 3}, func() interface{} { return new(XArray) })
 }
 func BenchmarkVom___DecodeMany_XArray(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XArray{1, 2, 3}, func() interface{} { return new(XArray) })
 }
 func BenchmarkGob___Decode_____XArray(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XArray{1, 2, 3}, func() interface{} { return new(XArray) })
 }
 func BenchmarkGob___DecodeMany_XArray(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XArray{1, 2, 3}, func() interface{} { return new(XArray) })
 }
 func BenchmarkVom___Encode_____VArray(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VArray{1, 2, 3})
 }
 func BenchmarkVom___EncodeMany_VArray(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VArray{1, 2, 3})
 }
+func BenchmarkVom___EncodeOptional_____VArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VArray{1, 2, 3}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VArray(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VArray{1, 2, 3}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VArray(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VArray{1, 2, 3}, func() interface{} { return new(VArray) })
 }
 func BenchmarkVom___DecodeMany_VArray(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VArray{1, 2, 3}, func() interface{} { return new(VArray) })
 }
 func BenchmarkVom___Encode_____XListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XList{1, 2, 3})
 }
 func BenchmarkVom___EncodeMany_XListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XList{1, 2, 3})
 }
+func BenchmarkVom___EncodeOptional_____XListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XList{1, 2, 3}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XList{1, 2, 3}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XListSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XList{1, 2, 3})
 }
 func BenchmarkGob___EncodeMany_XListSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XList{1, 2, 3})
 }
+func BenchmarkGob___EncodeOptional_____XListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XList{1, 2, 3}
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XList{1, 2, 3}
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XList{1, 2, 3}, func() interface{} { return new(XList) })
 }
 func BenchmarkVom___DecodeMany_XListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XList{1, 2, 3}, func() interface{} { return new(XList) })
 }
 func BenchmarkGob___Decode_____XListSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XList{1, 2, 3}, func() interface{} { return new(XList) })
 }
 func BenchmarkGob___DecodeMany_XListSmall(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XList{1, 2, 3}, func() interface{} { return new(XList) })
 }
 func BenchmarkVom___Encode_____VListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VList{1, 2, 3})
 }
 func BenchmarkVom___EncodeMany_VListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VList{1, 2, 3})
 }
+func BenchmarkVom___EncodeOptional_____VListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VList{1, 2, 3}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VListSmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VList{1, 2, 3}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VList{1, 2, 3}, func() interface{} { return new(VList) })
 }
 func BenchmarkVom___DecodeMany_VListSmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VList{1, 2, 3}, func() interface{} { return new(VList) })
 }
 func BenchmarkVom___Encode_____XListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XList(createList(65536)))
 }
 func BenchmarkVom___EncodeMany_XListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XList(createList(65536)))
 }
+func BenchmarkVom___EncodeOptional_____XListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XList(createList(65536))
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XList(createList(65536))
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XListLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XList(createList(65536)))
 }
 func BenchmarkGob___EncodeMany_XListLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XList(createList(65536)))
 }
+func BenchmarkGob___EncodeOptional_____XListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XList(createList(65536))
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XList(createList(65536))
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XList(createList(65536)), func() interface{} { return new(XList) })
 }
 func BenchmarkVom___DecodeMany_XListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XList(createList(65536)), func() interface{} { return new(XList) })
 }
 func BenchmarkGob___Decode_____XListLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XList(createList(65536)), func() interface{} { return new(XList) })
 }
 func BenchmarkGob___DecodeMany_XListLarge(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XList(createList(65536)), func() interface{} { return new(XList) })
 }
 func BenchmarkVom___Encode_____VListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VList(createList(65536)))
 }
 func BenchmarkVom___EncodeMany_VListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VList(createList(65536)))
 }
+func BenchmarkVom___EncodeOptional_____VListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VList(createList(65536))
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VListLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VList(createList(65536))
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VList(createList(65536)), func() interface{} { return new(VList) })
 }
 func BenchmarkVom___DecodeMany_VListLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VList(createList(65536)), func() interface{} { return new(VList) })
 }
 func BenchmarkVom___Encode_____XListAnySmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)})
 }
 func BenchmarkVom___EncodeMany_XListAnySmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)})
 }
+func BenchmarkVom___EncodeOptional_____XListAnySmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XListAnySmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XListAnySmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)}, func() interface{} { return new(XListAny) })
 }
 func BenchmarkVom___DecodeMany_XListAnySmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)}, func() interface{} { return new(XListAny) })
 }
 func BenchmarkVom___Encode_____VListAnySmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)})
 }
 func BenchmarkVom___EncodeMany_VListAnySmall(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)})
 }
+func BenchmarkVom___EncodeOptional_____VListAnySmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VListAnySmall(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VListAnySmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)}, func() interface{} { return new(VListAny) })
 }
 func BenchmarkVom___DecodeMany_VListAnySmall(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VListAny{vom.RawBytesOf(1), vom.RawBytesOf(2), vom.RawBytesOf(3)}, func() interface{} { return new(VListAny) })
 }
 func BenchmarkVom___Encode_____XListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XListAny(createListAny(65536)))
 }
 func BenchmarkVom___EncodeMany_XListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XListAny(createListAny(65536)))
 }
+func BenchmarkVom___EncodeOptional_____XListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XListAny(createListAny(65536))
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XListAny(createListAny(65536))
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XListAny(createListAny(65536)), func() interface{} { return new(XListAny) })
 }
 func BenchmarkVom___DecodeMany_XListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XListAny(createListAny(65536)), func() interface{} { return new(XListAny) })
 }
 func BenchmarkVom___Encode_____VListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VListAny(createListAny(65536)))
 }
 func BenchmarkVom___EncodeMany_VListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VListAny(createListAny(65536)))
 }
+func BenchmarkVom___EncodeOptional_____VListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VListAny(createListAny(65536))
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VListAny(createListAny(65536))
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VListAny(createListAny(65536)), func() interface{} { return new(VListAny) })
 }
 func BenchmarkVom___DecodeMany_VListAnyLarge(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VListAny(createListAny(65536)), func() interface{} { return new(VListAny) })
 }
 func BenchmarkVom___Encode_____VSet(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VSet{"A": struct{}{}, "B": struct{}{}, "C": struct{}{}})
 }
 func BenchmarkVom___EncodeMany_VSet(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VSet{"A": struct{}{}, "B": struct{}{}, "C": struct{}{}})
 }
+func BenchmarkVom___EncodeOptional_____VSet(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VSet{"A": struct{}{}, "B": struct{}{}, "C": struct{}{}}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VSet(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VSet{"A": struct{}{}, "B": struct{}{}, "C": struct{}{}}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VSet(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VSet{"A": struct{}{}, "B": struct{}{}, "C": struct{}{}}, func() interface{} { return new(VSet) })
 }
 func BenchmarkVom___DecodeMany_VSet(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VSet{"A": struct{}{}, "B": struct{}{}, "C": struct{}{}}, func() interface{} { return new(VSet) })
 }
 func BenchmarkVom___Encode_____XMap(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XMap{"A": true, "B": false, "C": true})
 }
 func BenchmarkVom___EncodeMany_XMap(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XMap{"A": true, "B": false, "C": true})
 }
+func BenchmarkVom___EncodeOptional_____XMap(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XMap{"A": true, "B": false, "C": true}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XMap(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XMap{"A": true, "B": false, "C": true}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XMap(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XMap{"A": true, "B": false, "C": true})
 }
 func BenchmarkGob___EncodeMany_XMap(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XMap{"A": true, "B": false, "C": true})
 }
+func BenchmarkGob___EncodeOptional_____XMap(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XMap{"A": true, "B": false, "C": true}
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XMap(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XMap{"A": true, "B": false, "C": true}
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XMap(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XMap{"A": true, "B": false, "C": true}, func() interface{} { return new(XMap) })
 }
 func BenchmarkVom___DecodeMany_XMap(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XMap{"A": true, "B": false, "C": true}, func() interface{} { return new(XMap) })
 }
 func BenchmarkGob___Decode_____XMap(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XMap{"A": true, "B": false, "C": true}, func() interface{} { return new(XMap) })
 }
 func BenchmarkGob___DecodeMany_XMap(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XMap{"A": true, "B": false, "C": true}, func() interface{} { return new(XMap) })
 }
 func BenchmarkVom___Encode_____VMap(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VMap{"A": true, "B": false, "C": true})
 }
 func BenchmarkVom___EncodeMany_VMap(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VMap{"A": true, "B": false, "C": true})
 }
+func BenchmarkVom___EncodeOptional_____VMap(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VMap{"A": true, "B": false, "C": true}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VMap(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VMap{"A": true, "B": false, "C": true}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VMap(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VMap{"A": true, "B": false, "C": true}, func() interface{} { return new(VMap) })
 }
 func BenchmarkVom___DecodeMany_VMap(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VMap{"A": true, "B": false, "C": true}, func() interface{} { return new(VMap) })
 }
 func BenchmarkVom___Encode_____XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XSmallStruct{1, "A", true})
 }
 func BenchmarkVom___EncodeMany_XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XSmallStruct{1, "A", true})
 }
+func BenchmarkVom___EncodeOptional_____XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XSmallStruct{1, "A", true}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XSmallStruct{1, "A", true}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XSmallStruct{1, "A", true})
 }
 func BenchmarkGob___EncodeMany_XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XSmallStruct{1, "A", true})
 }
+func BenchmarkGob___EncodeOptional_____XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XSmallStruct{1, "A", true}
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XSmallStruct{1, "A", true}
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XSmallStruct{1, "A", true}, func() interface{} { return new(XSmallStruct) })
 }
 func BenchmarkVom___DecodeMany_XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XSmallStruct{1, "A", true}, func() interface{} { return new(XSmallStruct) })
 }
 func BenchmarkGob___Decode_____XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XSmallStruct{1, "A", true}, func() interface{} { return new(XSmallStruct) })
 }
 func BenchmarkGob___DecodeMany_XSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XSmallStruct{1, "A", true}, func() interface{} { return new(XSmallStruct) })
 }
 func BenchmarkVom___Encode_____VSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VSmallStruct{1, "A", true})
 }
 func BenchmarkVom___EncodeMany_VSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VSmallStruct{1, "A", true})
 }
+func BenchmarkVom___EncodeOptional_____VSmallStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VSmallStruct{1, "A", true}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VSmallStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VSmallStruct{1, "A", true}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VSmallStruct{1, "A", true}, func() interface{} { return new(VSmallStruct) })
 }
 func BenchmarkVom___DecodeMany_VSmallStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VSmallStruct{1, "A", true}, func() interface{} { return new(VSmallStruct) })
 }
 func BenchmarkVom___Encode_____XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50})
 }
 func BenchmarkVom___EncodeMany_XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50})
 }
+func BenchmarkVom___EncodeOptional_____XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50})
 }
 func BenchmarkGob___EncodeMany_XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50})
 }
+func BenchmarkGob___EncodeOptional_____XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}, func() interface{} { return new(XLargeStruct) })
 }
 func BenchmarkVom___DecodeMany_XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}, func() interface{} { return new(XLargeStruct) })
 }
 func BenchmarkGob___Decode_____XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}, func() interface{} { return new(XLargeStruct) })
 }
 func BenchmarkGob___DecodeMany_XLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}, func() interface{} { return new(XLargeStruct) })
 }
 func BenchmarkVom___Encode_____VLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50})
 }
 func BenchmarkVom___EncodeMany_VLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50})
 }
+func BenchmarkVom___EncodeOptional_____VLargeStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VLargeStruct(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}, func() interface{} { return new(VLargeStruct) })
 }
 func BenchmarkVom___DecodeMany_VLargeStruct(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VLargeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}, func() interface{} { return new(VLargeStruct) })
 }
 func BenchmarkVom___Encode_____XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, XLargeStruct{})
 }
 func BenchmarkVom___EncodeMany_XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, XLargeStruct{})
 }
+func BenchmarkVom___EncodeOptional_____XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XLargeStruct{}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XLargeStruct{}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, XLargeStruct{})
 }
 func BenchmarkGob___EncodeMany_XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, XLargeStruct{})
 }
+func BenchmarkGob___EncodeOptional_____XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XLargeStruct{}
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XLargeStruct{}
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, XLargeStruct{}, func() interface{} { return new(XLargeStruct) })
 }
 func BenchmarkVom___DecodeMany_XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, XLargeStruct{}, func() interface{} { return new(XLargeStruct) })
 }
 func BenchmarkGob___Decode_____XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, XLargeStruct{}, func() interface{} { return new(XLargeStruct) })
 }
 func BenchmarkGob___DecodeMany_XLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, XLargeStruct{}, func() interface{} { return new(XLargeStruct) })
 }
 func BenchmarkVom___Encode_____VLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, VLargeStruct{})
 }
 func BenchmarkVom___EncodeMany_VLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, VLargeStruct{})
 }
+func BenchmarkVom___EncodeOptional_____VLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VLargeStruct{}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VLargeStruct{}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____VLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, VLargeStruct{}, func() interface{} { return new(VLargeStruct) })
 }
 func BenchmarkVom___DecodeMany_VLargeStructZero(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, VLargeStruct{}, func() interface{} { return new(VLargeStruct) })
 }
-func BenchmarkVom___Encode_____VSmallUnion(b *testing.B) {
-	vomEncode(b, VSmallUnionA{1})
+func BenchmarkVom___Encode_____VStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	vomEncode(b, VStructWithOptional{
+		F1: 32,
+		F2: &VSmallStruct{2, "B", true},
+	})
 }
-func BenchmarkVom___EncodeMany_VSmallUnion(b *testing.B) {
-	vomEncodeMany(b, VSmallUnionA{1})
+func BenchmarkVom___EncodeMany_VStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	vomEncodeMany(b, VStructWithOptional{
+		F1: 32,
+		F2: &VSmallStruct{2, "B", true},
+	})
 }
-func BenchmarkVom___Decode_____VSmallUnion(b *testing.B) {
-	vomDecode(b, VSmallUnionA{1}, func() interface{} { return new(VSmallUnion) })
+func BenchmarkVom___EncodeOptional_____VStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VStructWithOptional{
+		F1: 32,
+		F2: &VSmallStruct{2, "B", true},
+	}
+	vomEncode(b, &tmp)
 }
-func BenchmarkVom___DecodeMany_VSmallUnion(b *testing.B) {
-	vomDecodeMany(b, VSmallUnionA{1}, func() interface{} { return new(VSmallUnion) })
+func BenchmarkVom___EncodeManyOptional_VStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VStructWithOptional{
+		F1: 32,
+		F2: &VSmallStruct{2, "B", true},
+	}
+	vomEncodeMany(b, &tmp)
+}
+func BenchmarkVom___Decode_____VStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	vomDecode(b, VStructWithOptional{
+		F1: 32,
+		F2: &VSmallStruct{2, "B", true},
+	}, func() interface{} { return new(VStructWithOptional) })
+}
+func BenchmarkVom___DecodeMany_VStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	vomDecodeMany(b, VStructWithOptional{
+		F1: 32,
+		F2: &VSmallStruct{2, "B", true},
+	}, func() interface{} { return new(VStructWithOptional) })
+}
+func BenchmarkVom___Encode_____VStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	vomEncode(b, VStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	})
+}
+func BenchmarkVom___EncodeMany_VStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	vomEncodeMany(b, VStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	})
+}
+func BenchmarkVom___EncodeOptional_____VStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_VStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	tmp := VStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}
+	vomEncodeMany(b, &tmp)
+}
+func BenchmarkVom___Decode_____VStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	vomDecode(b, VStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}, func() interface{} { return new(VStructWithNative) })
+}
+func BenchmarkVom___DecodeMany_VStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	vomDecodeMany(b, VStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}, func() interface{} { return new(VStructWithNative) })
+}
+func BenchmarkVom___Encode_____XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	vomEncode(b, XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	})
+}
+func BenchmarkVom___EncodeMany_XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	vomEncodeMany(b, XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	})
+}
+func BenchmarkVom___EncodeOptional_____XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	}
+	vomEncodeMany(b, &tmp)
+}
+func BenchmarkGob___Encode_____XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	gobEncode(b, XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	})
+}
+func BenchmarkGob___EncodeMany_XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	gobEncodeMany(b, XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	})
+}
+func BenchmarkGob___EncodeOptional_____XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	}
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	}
+	gobEncodeMany(b, &tmp)
+}
+func BenchmarkVom___Decode_____XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	vomDecode(b, XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	}, func() interface{} { return new(XStructWithOptional) })
+}
+func BenchmarkVom___DecodeMany_XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	vomDecodeMany(b, XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	}, func() interface{} { return new(XStructWithOptional) })
+}
+func BenchmarkGob___Decode_____XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	gobDecode(b, XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	}, func() interface{} { return new(XStructWithOptional) })
+}
+func BenchmarkGob___DecodeMany_XStructWithOptional(b *testing.B) {
+	b.ReportAllocs()
+	gobDecodeMany(b, XStructWithOptional{
+		F1: 32,
+		F2: &XSmallStruct{2, "B", true},
+	}, func() interface{} { return new(XStructWithOptional) })
+}
+func BenchmarkVom___Encode_____XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	vomEncode(b, XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	})
+}
+func BenchmarkVom___EncodeMany_XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	vomEncodeMany(b, XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	})
+}
+func BenchmarkVom___EncodeOptional_____XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}
+	vomEncodeMany(b, &tmp)
+}
+func BenchmarkGob___Encode_____XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	gobEncode(b, XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	})
+}
+func BenchmarkGob___EncodeMany_XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	gobEncodeMany(b, XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	})
+}
+func BenchmarkGob___EncodeOptional_____XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	tmp := XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}
+	gobEncodeMany(b, &tmp)
+}
+func BenchmarkVom___Decode_____XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	vomDecode(b, XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}, func() interface{} { return new(XStructWithNative) })
+}
+func BenchmarkVom___DecodeMany_XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	vomDecodeMany(b, XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}, func() interface{} { return new(XStructWithNative) })
+}
+func BenchmarkGob___Decode_____XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	gobDecode(b, XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}, func() interface{} { return new(XStructWithNative) })
+}
+func BenchmarkGob___DecodeMany_XStructWithNative(b *testing.B) {
+	b.ReportAllocs()
+	gobDecodeMany(b, XStructWithNative{
+		Time:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		Duration: time.Second,
+	}, func() interface{} { return new(XStructWithNative) })
 }
 func BenchmarkVom___Encode_____Time(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
 }
 func BenchmarkVom___EncodeMany_Time(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
 }
+func BenchmarkVom___EncodeOptional_____Time(b *testing.B) {
+	b.ReportAllocs()
+	tmp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_Time(b *testing.B) {
+	b.ReportAllocs()
+	tmp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkGob___Encode_____Time(b *testing.B) {
+	b.ReportAllocs()
 	gobEncode(b, time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
 }
 func BenchmarkGob___EncodeMany_Time(b *testing.B) {
+	b.ReportAllocs()
 	gobEncodeMany(b, time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
 }
+func BenchmarkGob___EncodeOptional_____Time(b *testing.B) {
+	b.ReportAllocs()
+	tmp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	gobEncode(b, &tmp)
+}
+func BenchmarkGob___EncodeManyOptional_Time(b *testing.B) {
+	b.ReportAllocs()
+	tmp := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	gobEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____Time(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), func() interface{} { return new(time.Time) })
 }
 func BenchmarkVom___DecodeMany_Time(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), func() interface{} { return new(time.Time) })
 }
 func BenchmarkGob___Decode_____Time(b *testing.B) {
+	b.ReportAllocs()
 	gobDecode(b, time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), func() interface{} { return new(time.Time) })
 }
 func BenchmarkGob___DecodeMany_Time(b *testing.B) {
+	b.ReportAllocs()
 	gobDecodeMany(b, time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), func() interface{} { return new(time.Time) })
 }
 func BenchmarkVom___Encode_____Blessings(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, createTypicalBlessings())
 }
 func BenchmarkVom___EncodeMany_Blessings(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, createTypicalBlessings())
 }
+func BenchmarkVom___EncodeOptional_____Blessings(b *testing.B) {
+	b.ReportAllocs()
+	tmp := createTypicalBlessings()
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_Blessings(b *testing.B) {
+	b.ReportAllocs()
+	tmp := createTypicalBlessings()
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____Blessings(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, createTypicalBlessings(), func() interface{} { return new(security.Blessings) })
 }
 func BenchmarkVom___DecodeMany_Blessings(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, createTypicalBlessings(), func() interface{} { return new(security.Blessings) })
 }
 func BenchmarkVom___Encode_____RPCRequestZero(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, rpc.Request{})
 }
 func BenchmarkVom___EncodeMany_RPCRequestZero(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, rpc.Request{})
 }
+func BenchmarkVom___EncodeOptional_____RPCRequestZero(b *testing.B) {
+	b.ReportAllocs()
+	tmp := rpc.Request{}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_RPCRequestZero(b *testing.B) {
+	b.ReportAllocs()
+	tmp := rpc.Request{}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____RPCRequestZero(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, rpc.Request{}, func() interface{} { return new(rpc.Request) })
 }
 func BenchmarkVom___DecodeMany_RPCRequestZero(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, rpc.Request{}, func() interface{} { return new(rpc.Request) })
 }
 func BenchmarkVom___Encode_____RPCRequestFull(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, rpc.Request{
 		Suffix:        "a suffix",
 		Method:        "a method",
@@ -640,6 +1579,7 @@ func BenchmarkVom___Encode_____RPCRequestFull(b *testing.B) {
 	})
 }
 func BenchmarkVom___EncodeMany_RPCRequestFull(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, rpc.Request{
 		Suffix:        "a suffix",
 		Method:        "a method",
@@ -658,7 +1598,50 @@ func BenchmarkVom___EncodeMany_RPCRequestFull(b *testing.B) {
 		Language: "en-us",
 	})
 }
+func BenchmarkVom___EncodeOptional_____RPCRequestFull(b *testing.B) {
+	b.ReportAllocs()
+	tmp := rpc.Request{
+		Suffix:        "a suffix",
+		Method:        "a method",
+		NumPosArgs:    23,
+		EndStreamArgs: true,
+		Deadline: wiretime.Deadline{
+			Time: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		},
+		GrantedBlessings: createTypicalBlessings(),
+		TraceRequest: vtrace.Request{
+			SpanId:   uniqueid.Id{1, 2, 3, 4},
+			TraceId:  uniqueid.Id{5, 6, 7, 8},
+			Flags:    vtrace.CollectInMemory,
+			LogLevel: 3,
+		},
+		Language: "en-us",
+	}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_RPCRequestFull(b *testing.B) {
+	b.ReportAllocs()
+	tmp := rpc.Request{
+		Suffix:        "a suffix",
+		Method:        "a method",
+		NumPosArgs:    23,
+		EndStreamArgs: true,
+		Deadline: wiretime.Deadline{
+			Time: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		},
+		GrantedBlessings: createTypicalBlessings(),
+		TraceRequest: vtrace.Request{
+			SpanId:   uniqueid.Id{1, 2, 3, 4},
+			TraceId:  uniqueid.Id{5, 6, 7, 8},
+			Flags:    vtrace.CollectInMemory,
+			LogLevel: 3,
+		},
+		Language: "en-us",
+	}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____RPCRequestFull(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, rpc.Request{
 		Suffix:        "a suffix",
 		Method:        "a method",
@@ -678,6 +1661,7 @@ func BenchmarkVom___Decode_____RPCRequestFull(b *testing.B) {
 	}, func() interface{} { return new(rpc.Request) })
 }
 func BenchmarkVom___DecodeMany_RPCRequestFull(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, rpc.Request{
 		Suffix:        "a suffix",
 		Method:        "a method",
@@ -697,18 +1681,33 @@ func BenchmarkVom___DecodeMany_RPCRequestFull(b *testing.B) {
 	}, func() interface{} { return new(rpc.Request) })
 }
 func BenchmarkVom___Encode_____RPCResponseZero(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, rpc.Response{})
 }
 func BenchmarkVom___EncodeMany_RPCResponseZero(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, rpc.Response{})
 }
+func BenchmarkVom___EncodeOptional_____RPCResponseZero(b *testing.B) {
+	b.ReportAllocs()
+	tmp := rpc.Response{}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_RPCResponseZero(b *testing.B) {
+	b.ReportAllocs()
+	tmp := rpc.Response{}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____RPCResponseZero(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, rpc.Response{}, func() interface{} { return new(rpc.Response) })
 }
 func BenchmarkVom___DecodeMany_RPCResponseZero(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, rpc.Response{}, func() interface{} { return new(rpc.Response) })
 }
 func BenchmarkVom___Encode_____RPCResponseFull(b *testing.B) {
+	b.ReportAllocs()
 	vomEncode(b, rpc.Response{
 		Error:            errors.New("testerror"),
 		EndStreamResults: true,
@@ -737,6 +1736,7 @@ func BenchmarkVom___Encode_____RPCResponseFull(b *testing.B) {
 	})
 }
 func BenchmarkVom___EncodeMany_RPCResponseFull(b *testing.B) {
+	b.ReportAllocs()
 	vomEncodeMany(b, rpc.Response{
 		Error:            errors.New("testerror"),
 		EndStreamResults: true,
@@ -764,7 +1764,68 @@ func BenchmarkVom___EncodeMany_RPCResponseFull(b *testing.B) {
 		},
 	})
 }
+func BenchmarkVom___EncodeOptional_____RPCResponseFull(b *testing.B) {
+	b.ReportAllocs()
+	tmp := rpc.Response{
+		Error:            errors.New("testerror"),
+		EndStreamResults: true,
+		NumPosResults:    4,
+		TraceResponse: vtrace.Response{
+			Flags: vtrace.CollectInMemory,
+			Trace: vtrace.TraceRecord{
+				Id: uniqueid.Id{1, 2, 3, 4},
+				Spans: []vtrace.SpanRecord{
+					{
+						Id:     uniqueid.Id{1, 2, 3, 4},
+						Parent: uniqueid.Id{4, 3, 2, 1},
+						Name:   "span name",
+						Start:  time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+						End:    time.Date(2009, time.November, 11, 23, 0, 0, 0, time.UTC),
+						Annotations: []vtrace.Annotation{
+							{
+								When:    time.Date(2009, time.November, 10, 23, 0, 0, 4, time.UTC),
+								Message: "Annotation Message",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	vomEncode(b, &tmp)
+}
+func BenchmarkVom___EncodeManyOptional_RPCResponseFull(b *testing.B) {
+	b.ReportAllocs()
+	tmp := rpc.Response{
+		Error:            errors.New("testerror"),
+		EndStreamResults: true,
+		NumPosResults:    4,
+		TraceResponse: vtrace.Response{
+			Flags: vtrace.CollectInMemory,
+			Trace: vtrace.TraceRecord{
+				Id: uniqueid.Id{1, 2, 3, 4},
+				Spans: []vtrace.SpanRecord{
+					{
+						Id:     uniqueid.Id{1, 2, 3, 4},
+						Parent: uniqueid.Id{4, 3, 2, 1},
+						Name:   "span name",
+						Start:  time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+						End:    time.Date(2009, time.November, 11, 23, 0, 0, 0, time.UTC),
+						Annotations: []vtrace.Annotation{
+							{
+								When:    time.Date(2009, time.November, 10, 23, 0, 0, 4, time.UTC),
+								Message: "Annotation Message",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	vomEncodeMany(b, &tmp)
+}
 func BenchmarkVom___Decode_____RPCResponseFull(b *testing.B) {
+	b.ReportAllocs()
 	vomDecode(b, rpc.Response{
 		Error:            errors.New("testerror"),
 		EndStreamResults: true,
@@ -793,6 +1854,7 @@ func BenchmarkVom___Decode_____RPCResponseFull(b *testing.B) {
 	}, func() interface{} { return new(rpc.Response) })
 }
 func BenchmarkVom___DecodeMany_RPCResponseFull(b *testing.B) {
+	b.ReportAllocs()
 	vomDecodeMany(b, rpc.Response{
 		Error:            errors.New("testerror"),
 		EndStreamResults: true,

--- a/v23/vom/internal/internal.vdl.go
+++ b/v23/vom/internal/internal.vdl.go
@@ -10,8 +10,10 @@ package internal
 
 import (
 	"fmt"
+	"time"
 
 	"v.io/v23/vdl"
+	vdltime "v.io/v23/vdlroot/time"
 	"v.io/v23/vom"
 )
 
@@ -1429,22 +1431,214 @@ func VDLReadVSmallUnion(dec vdl.Decoder, x *VSmallUnion) error { //nolint:gocycl
 	return dec.FinishValue()
 }
 
+type VStructWithOptional struct {
+	F1 int32
+	F2 *VSmallStruct
+}
+
+func (VStructWithOptional) VDLReflect(struct {
+	Name string `vdl:"v.io/v23/vom/internal.VStructWithOptional"`
+}) {
+}
+
+func (x VStructWithOptional) VDLIsZero() bool { //nolint:gocyclo
+	return x == VStructWithOptional{}
+}
+
+func (x VStructWithOptional) VDLWrite(enc vdl.Encoder) error { //nolint:gocyclo
+	if err := enc.StartValue(vdlTypeStruct14); err != nil {
+		return err
+	}
+	if x.F1 != 0 {
+		if err := enc.NextFieldValueInt(0, vdl.Int32Type, int64(x.F1)); err != nil {
+			return err
+		}
+	}
+	if x.F2 != nil {
+		if err := enc.NextField(1); err != nil {
+			return err
+		}
+		enc.SetNextStartValueIsOptional()
+		if err := x.F2.VDLWrite(enc); err != nil {
+			return err
+		}
+	}
+	if err := enc.NextField(-1); err != nil {
+		return err
+	}
+	return enc.FinishValue()
+}
+
+func (x *VStructWithOptional) VDLRead(dec vdl.Decoder) error { //nolint:gocyclo
+	*x = VStructWithOptional{}
+	if err := dec.StartValue(vdlTypeStruct14); err != nil {
+		return err
+	}
+	decType := dec.Type()
+	for {
+		index, err := dec.NextField()
+		switch {
+		case err != nil:
+			return err
+		case index == -1:
+			return dec.FinishValue()
+		}
+		if decType != vdlTypeStruct14 {
+			index = vdlTypeStruct14.FieldIndexByName(decType.Field(index).Name)
+			if index == -1 {
+				if err := dec.SkipValue(); err != nil {
+					return err
+				}
+				continue
+			}
+		}
+		switch index {
+		case 0:
+			switch value, err := dec.ReadValueInt(32); {
+			case err != nil:
+				return err
+			default:
+				x.F1 = int32(value)
+			}
+		case 1:
+			if err := dec.StartValue(vdlTypeOptional15); err != nil {
+				return err
+			}
+			if dec.IsNil() {
+				x.F2 = nil
+				if err := dec.FinishValue(); err != nil {
+					return err
+				}
+			} else {
+				x.F2 = new(VSmallStruct)
+				dec.IgnoreNextStartValue()
+				if err := x.F2.VDLRead(dec); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+type VStructWithNative struct {
+	Time     time.Time
+	Duration time.Duration
+}
+
+func (VStructWithNative) VDLReflect(struct {
+	Name string `vdl:"v.io/v23/vom/internal.VStructWithNative"`
+}) {
+}
+
+func (x VStructWithNative) VDLIsZero() bool { //nolint:gocyclo
+	if !x.Time.IsZero() {
+		return false
+	}
+	if x.Duration != 0 {
+		return false
+	}
+	return true
+}
+
+func (x VStructWithNative) VDLWrite(enc vdl.Encoder) error { //nolint:gocyclo
+	if err := enc.StartValue(vdlTypeStruct16); err != nil {
+		return err
+	}
+	if !x.Time.IsZero() {
+		if err := enc.NextField(0); err != nil {
+			return err
+		}
+		var wire vdltime.Time
+		if err := vdltime.TimeFromNative(&wire, x.Time); err != nil {
+			return err
+		}
+		if err := wire.VDLWrite(enc); err != nil {
+			return err
+		}
+	}
+	if x.Duration != 0 {
+		if err := enc.NextField(1); err != nil {
+			return err
+		}
+		var wire vdltime.Duration
+		if err := vdltime.DurationFromNative(&wire, x.Duration); err != nil {
+			return err
+		}
+		if err := wire.VDLWrite(enc); err != nil {
+			return err
+		}
+	}
+	if err := enc.NextField(-1); err != nil {
+		return err
+	}
+	return enc.FinishValue()
+}
+
+func (x *VStructWithNative) VDLRead(dec vdl.Decoder) error { //nolint:gocyclo
+	*x = VStructWithNative{}
+	if err := dec.StartValue(vdlTypeStruct16); err != nil {
+		return err
+	}
+	decType := dec.Type()
+	for {
+		index, err := dec.NextField()
+		switch {
+		case err != nil:
+			return err
+		case index == -1:
+			return dec.FinishValue()
+		}
+		if decType != vdlTypeStruct16 {
+			index = vdlTypeStruct16.FieldIndexByName(decType.Field(index).Name)
+			if index == -1 {
+				if err := dec.SkipValue(); err != nil {
+					return err
+				}
+				continue
+			}
+		}
+		switch index {
+		case 0:
+			var wire vdltime.Time
+			if err := wire.VDLRead(dec); err != nil {
+				return err
+			}
+			if err := vdltime.TimeToNative(wire, &x.Time); err != nil {
+				return err
+			}
+		case 1:
+			var wire vdltime.Duration
+			if err := wire.VDLRead(dec); err != nil {
+				return err
+			}
+			if err := vdltime.DurationToNative(wire, &x.Duration); err != nil {
+				return err
+			}
+		}
+	}
+}
+
 // Hold type definitions in package-level variables, for better performance.
 //nolint:unused
 var (
-	vdlTypeInt321   *vdl.Type
-	vdlTypeString2  *vdl.Type
-	vdlTypeEnum3    *vdl.Type
-	vdlTypeList4    *vdl.Type
-	vdlTypeArray5   *vdl.Type
-	vdlTypeArray6   *vdl.Type
-	vdlTypeList7    *vdl.Type
-	vdlTypeList8    *vdl.Type
-	vdlTypeSet9     *vdl.Type
-	vdlTypeMap10    *vdl.Type
-	vdlTypeStruct11 *vdl.Type
-	vdlTypeStruct12 *vdl.Type
-	vdlTypeUnion13  *vdl.Type
+	vdlTypeInt321     *vdl.Type
+	vdlTypeString2    *vdl.Type
+	vdlTypeEnum3      *vdl.Type
+	vdlTypeList4      *vdl.Type
+	vdlTypeArray5     *vdl.Type
+	vdlTypeArray6     *vdl.Type
+	vdlTypeList7      *vdl.Type
+	vdlTypeList8      *vdl.Type
+	vdlTypeSet9       *vdl.Type
+	vdlTypeMap10      *vdl.Type
+	vdlTypeStruct11   *vdl.Type
+	vdlTypeStruct12   *vdl.Type
+	vdlTypeUnion13    *vdl.Type
+	vdlTypeStruct14   *vdl.Type
+	vdlTypeOptional15 *vdl.Type
+	vdlTypeStruct16   *vdl.Type
+	vdlTypeStruct17   *vdl.Type
+	vdlTypeStruct18   *vdl.Type
 )
 
 var initializeVDLCalled bool
@@ -1482,6 +1676,8 @@ func initializeVDL() struct{} {
 	vdl.Register((*VSmallStruct)(nil))
 	vdl.Register((*VLargeStruct)(nil))
 	vdl.Register((*VSmallUnion)(nil))
+	vdl.Register((*VStructWithOptional)(nil))
+	vdl.Register((*VStructWithNative)(nil))
 
 	// Initialize type definitions.
 	vdlTypeInt321 = vdl.TypeOf((*VNumber)(nil))
@@ -1497,6 +1693,11 @@ func initializeVDL() struct{} {
 	vdlTypeStruct11 = vdl.TypeOf((*VSmallStruct)(nil)).Elem()
 	vdlTypeStruct12 = vdl.TypeOf((*VLargeStruct)(nil)).Elem()
 	vdlTypeUnion13 = vdl.TypeOf((*VSmallUnion)(nil))
+	vdlTypeStruct14 = vdl.TypeOf((*VStructWithOptional)(nil)).Elem()
+	vdlTypeOptional15 = vdl.TypeOf((*VSmallStruct)(nil))
+	vdlTypeStruct16 = vdl.TypeOf((*VStructWithNative)(nil)).Elem()
+	vdlTypeStruct17 = vdl.TypeOf((*vdltime.Time)(nil)).Elem()
+	vdlTypeStruct18 = vdl.TypeOf((*vdltime.Duration)(nil)).Elem()
 
 	return struct{}{}
 }

--- a/v23/vom/internal/types.go
+++ b/v23/vom/internal/types.go
@@ -5,6 +5,8 @@
 package internal
 
 import (
+	"time"
+
 	"v.io/v23/vom"
 )
 
@@ -72,4 +74,14 @@ type XLargeStruct struct {
 	F48 int32
 	F49 int32
 	F50 int32
+}
+
+type XStructWithOptional struct {
+	F1 int32
+	F2 *XSmallStruct
+}
+
+type XStructWithNative struct {
+	Time     time.Time
+	Duration time.Duration
 }

--- a/v23/vom/internal/types.vdl
+++ b/v23/vom/internal/types.vdl
@@ -4,6 +4,8 @@
 
 package internal
 
+import "time"
+
 type VNumber int32
 type VString string
 type VEnum enum {
@@ -79,4 +81,12 @@ type VSmallUnion union {
     A int32
     B string
     C bool
+}
+type VStructWithOptional struct {
+    F1 int32
+    F2 ?VSmallStruct
+}
+type VStructWithNative struct {
+	Time time.Time
+	Duration time.Duration
 }


### PR DESCRIPTION
This PR updates the existing benchmarks to include vdl optional and native types. It turns out these are significantly slower than they could be and become apparent when benchmarking vdl/vom against other encodings. Subsequent PRs will address the actual performance issues.