### PR TITLE
x/ref/runtime/internal/rpc: ensure that a proxied server expands to use all available proxies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ jobs:
   test:
     executor:
       name: go/default
-      tag: "1.14"
+      tag: "1.15"
     steps:
       - checkout
       - go/load-cache
@@ -25,7 +25,7 @@ jobs:
   lint:
     executor:
       name: go/default
-      tag: "1.14"
+      tag: "1.15"
     steps:
       - checkout
       - go/load-cache
@@ -47,7 +47,7 @@ jobs:
   integration-tests:
     executor:
       name: go/default
-      tag: "1.14"
+      tag: "1.15"
     steps:
       - checkout
       - go/load-cache

--- a/x/ref/lib/pubsub/config_test.go
+++ b/x/ref/lib/pubsub/config_test.go
@@ -322,7 +322,7 @@ func TestDurationFlag(t *testing.T) {
 	if got, want := d.Duration, time.Second; got != want {
 		t.Errorf("got %s, expected %s", got, want)
 	}
-	if err := d.Set("1t"); err == nil || err.Error() != "time: unknown unit t in duration 1t" {
+	if err := d.Set("1t"); err == nil || err.Error() != `time: unknown unit "t" in duration "1t"` {
 		t.Errorf("expected error %v", err)
 	}
 }

--- a/x/ref/lib/pubsub/config_test.go
+++ b/x/ref/lib/pubsub/config_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -322,7 +323,7 @@ func TestDurationFlag(t *testing.T) {
 	if got, want := d.Duration, time.Second; got != want {
 		t.Errorf("got %s, expected %s", got, want)
 	}
-	if err := d.Set("1t"); err == nil || err.Error() != `time: unknown unit "t" in duration "1t"` {
+	if err := d.Set("1t"); err == nil || !strings.Contains(err.Error(), "time: unknown unit") {
 		t.Errorf("expected error %v", err)
 	}
 }


### PR DESCRIPTION
Prior to this PR, a server using the 'all' proxy policy would expand the set of proxy instances that it used when it encountered an error with any of existing proxy instances. This PR changes the behaviour so that servers will monitor the set of available proxy instances and expand to use all available ones ahead of any errors being encountered.