### PR TITLE
x/ref/runtime/internal/rpc: ensure that a proxied server expands to use all available proxies

### DIFF
--- a/x/ref/runtime/internal/rpc/proxymgr.go
+++ b/x/ref/runtime/internal/rpc/proxymgr.go
@@ -59,6 +59,9 @@ func newProxyManager(s serverProxyAPI, proxyName string, policy rpc.ProxyPolicy,
 }
 
 func (pm *proxyManager) selectRandomSubsetLocked(needed, available int) map[int]bool {
+	if needed == 0 {
+		return nil
+	}
 	selected := map[int]bool{}
 	for {
 		candidate := pm.rand.Intn(available)
@@ -160,6 +163,7 @@ func (pm *proxyManager) updateAvailableProxies(ctx *context.T) {
 	pm.Lock()
 	defer pm.Unlock()
 	pm.proxies = updated
+
 }
 
 func (pm *proxyManager) markActive(ep naming.Endpoint) {
@@ -175,8 +179,6 @@ func (pm *proxyManager) markInActive(ep naming.Endpoint) {
 }
 
 func (pm *proxyManager) connectToSingleProxy(ctx *context.T, name string, ep naming.Endpoint) {
-	pm.markActive(ep)
-	defer pm.markInActive(ep)
 	for delay := pm.reconnectDelay; ; delay = nextDelay(delay) {
 		if !pm.isAvailable(ep) {
 			ctx.Infof("connectToSingleProxy(%q): proxy is no longer available\n", ep)
@@ -212,12 +214,24 @@ func (pm *proxyManager) tryConnections(ctx *context.T, notifyCh chan struct{}) b
 		return false
 	}
 	for _, ep := range idle {
+		if !pm.canGrow() {
+			continue
+		}
+		pm.markActive(ep)
 		go func(ep naming.Endpoint) {
 			pm.connectToSingleProxy(ctx, pm.proxyName, ep)
-			notifyCh <- struct{}{}
+			pm.markInActive(ep)
+			sendNotify(notifyCh)
 		}(ep)
 	}
 	return true
+}
+
+func sendNotify(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
 }
 
 func drainNotifyChan(ch chan struct{}) {
@@ -233,6 +247,24 @@ func drainNotifyChan(ch chan struct{}) {
 func (pm *proxyManager) manageProxyConnections(ctx *context.T) {
 	notifyCh := make(chan struct{}, 10)
 	pm.updateAvailableProxies(ctx)
+	// Watch for changes in the set of available proxies so that for the
+	// 'all' policy, the server will connect to new proxies as they appear.
+	// For other policies reconnection may be little faster since the
+	// new set of proxies is already available.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(pm.resolveDelay):
+			}
+			pm.updateAvailableProxies(ctx)
+			if pm.shouldGrow() && pm.canGrow() {
+				sendNotify(notifyCh)
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -253,7 +285,7 @@ func (pm *proxyManager) manageProxyConnections(ctx *context.T) {
 			drainNotifyChan(notifyCh)
 		}
 		// Wait for a change in the set of available proxies.
-		if pm.shouldGrow() {
+		if pm.shouldGrow() && !pm.canGrow() {
 			for {
 				select {
 				case <-ctx.Done():

--- a/x/ref/runtime/internal/rpc/test/client_test.go
+++ b/x/ref/runtime/internal/rpc/test/client_test.go
@@ -295,8 +295,15 @@ func TestStartCallErrors(t *testing.T) { //nolint:gocyclo
 	if !errors.Is(err, verror.ErrNoServers) {
 		t.Errorf("wrong error: %s", err)
 	}
-	if want := "connection refused"; !strings.Contains(verror.DebugString(err), want) {
-		t.Errorf("wrong error: %s - doesn't contain %q", err, want)
+	found := false
+	allowed := []string{"connection reset by peer", "connection refused"}
+	for _, want := range allowed {
+		if strings.Contains(verror.DebugString(err), want) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("wrong error: %s - doesn't contain one of %q", err, allowed)
 	}
 
 	// This will fail with NoServers, but because there really is no


### PR DESCRIPTION
Prior to this PR, a server using the 'all' proxy policy would expand the set of proxy instances that it used when it encountered an error with any of existing proxy instances. This PR changes the behavior so that servers will monitor the set of available proxy instances and expand to use all available ones ahead of any errors being encountered.

Also, include a fix for big sur whereby the error messages for connection refused appears to have changed.