### PR TITLE
x/ref/runtime/internal/rpc,x/ref/lib/publisher: reduce default logging output

### DIFF
--- a/v23/vom/vomtest/internal/vomforever/main.go
+++ b/v23/vom/vomtest/internal/vomforever/main.go
@@ -161,7 +161,6 @@ func buildAndRunFromVdlFile(vv *vdl.Value, types []*vdl.Type, vdlFlags []string)
 	cmd.Env = []string{
 		"GOPATH=" + gopath,
 		"PATH=" + os.Getenv("PATH"),
-		"JIRI_ROOT=" + os.Getenv("JIRI_ROOT"),
 	}
 	stderr, err = cmd.StderrPipe()
 	panicOnError(err)

--- a/x/ref/lib/publisher/publisher.go
+++ b/x/ref/lib/publisher/publisher.go
@@ -345,7 +345,7 @@ func (p *T) mount(params mountParams) rpc.PublisherEntry {
 	} else {
 		entry.LastState = rpc.PublisherMounted
 		if last.LastMount.IsZero() || last.LastMountErr != nil || p.ctx.V(2) {
-			p.ctx.Infof("rpc pub: mount(%v, %v, %v)", entry.Name, entry.Server, ttl)
+			p.ctx.VI(1).Infof("rpc pub: mount(%v, %v, %v)", entry.Name, entry.Server, ttl)
 		}
 	}
 	return entry

--- a/x/ref/lib/pubsub/publisher.go
+++ b/x/ref/lib/pubsub/publisher.go
@@ -106,7 +106,7 @@ func (p *Publisher) Latest(name string) *Stream {
 	if f == nil {
 		return nil
 	}
-	var r map[string]Setting
+	r := map[string]Setting{}
 	f.RLock()
 	defer f.RUnlock()
 	for k, v := range f.vals {

--- a/x/ref/lib/pubsub/publisher.go
+++ b/x/ref/lib/pubsub/publisher.go
@@ -106,9 +106,12 @@ func (p *Publisher) Latest(name string) *Stream {
 	if f == nil {
 		return nil
 	}
-	r := map[string]Setting{}
+	var r map[string]Setting
 	f.RLock()
 	defer f.RUnlock()
+	if len(f.vals) > 0 {
+		r = map[string]Setting{}
+	}
 	for k, v := range f.vals {
 		r[k] = v
 	}

--- a/x/ref/runtime/factories/roaming/print_addrs.go
+++ b/x/ref/runtime/factories/roaming/print_addrs.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	al, err := netstate.GetAll()
+	al, err := netstate.GetAccessibleIPs()
 	if err != nil {
 		fmt.Printf("error getting networking state: %s", err)
 		return

--- a/x/ref/runtime/internal/rpc/proxymgr.go
+++ b/x/ref/runtime/internal/rpc/proxymgr.go
@@ -104,16 +104,16 @@ func (pm *proxyManager) idle(ctx *context.T) []naming.Endpoint {
 	}
 	switch pm.policy {
 	case rpc.UseFirstProxy:
-		ctx.Infof("idle proxies: first proxy %v/%v", idle[:1], nidle)
+		ctx.VI(1).Infof("idle proxies: first proxy %v/%v", idle[:1], nidle)
 		return idle[:1]
 	case rpc.UseRandomProxy:
 		chosen := pm.rand.Intn(nidle)
-		ctx.Infof("idle proxies: random proxy %v/%v", chosen, nidle)
+		ctx.VI(1).Infof("idle proxies: random proxy %v/%v", chosen, nidle)
 		return []naming.Endpoint{idle[chosen]}
 	}
 	needed := pm.limit - len(pm.active)
 	if pm.limit == 0 || needed > nidle {
-		ctx.Infof("idle proxies: all idle proxies %v", nidle)
+		ctx.VI(1).Infof("idle proxies: all idle proxies %v", nidle)
 		return idle
 	}
 	// randomize the selection of the subset of proxies.
@@ -123,7 +123,7 @@ func (pm *proxyManager) idle(ctx *context.T) []naming.Endpoint {
 		selected[i] = idle[idx]
 		i++
 	}
-	ctx.Infof("idle proxies: %v of %v idle proxies: %v", needed, nidle, selected)
+	ctx.VI(1).Infof("idle proxies: %v of %v idle proxies: %v", needed, nidle, selected)
 	return selected
 }
 
@@ -181,7 +181,7 @@ func (pm *proxyManager) markInActive(ep naming.Endpoint) {
 func (pm *proxyManager) connectToSingleProxy(ctx *context.T, name string, ep naming.Endpoint) {
 	for delay := pm.reconnectDelay; ; delay = nextDelay(delay) {
 		if !pm.isAvailable(ep) {
-			ctx.Infof("connectToSingleProxy(%q): proxy is no longer available\n", ep)
+			ctx.VI(1).Infof("connectToSingleProxy(%q): proxy is no longer available\n", ep)
 			return
 		}
 		select {

--- a/x/ref/runtime/protocols/lib/websocket/conn_test.go
+++ b/x/ref/runtime/protocols/lib/websocket/conn_test.go
@@ -57,7 +57,7 @@ func TestMultipleGoRoutines(t *testing.T) {
 				http.Error(w, "Method not allowed.", http.StatusMethodNotAllowed)
 				return
 			}
-			ws, err := websocket.Upgrade(w, r, nil, 1024, 1024)
+			ws, err := websocket.Upgrade(w, r, nil, 1024, 1024) //nolint:staticcheck
 			if _, ok := err.(websocket.HandshakeError); ok {
 				http.Error(w, "Not a websocket handshake", 400)
 				return

--- a/x/ref/runtime/protocols/lib/websocket/listener.go
+++ b/x/ref/runtime/protocols/lib/websocket/listener.go
@@ -168,7 +168,7 @@ func (ln *wsTCPListener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Method not allowed.", http.StatusMethodNotAllowed)
 		return
 	}
-	ws, err := websocket.Upgrade(w, r, nil, bufferSize, bufferSize)
+	ws, err := websocket.Upgrade(w, r, nil, bufferSize, bufferSize) //nolint:staticcheck
 	if _, ok := err.(websocket.HandshakeError); ok {
 		// Close the connection to not serve HTTP requests from this connection
 		// any more. Otherwise panic from negative httpReq counter can occur.


### PR DESCRIPTION
This PR reduces the amount of info-level logging output from lib/publisher and rpc/proxymanager.