### PR TITLE
fix README link and namespace.T.Glob() docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/vanadium/core.svg?style=svg)](https://circleci.com/gh/vanadium/core)
 
 An easy-to-use secure RPC system with flexible service discovery. See the
-Vanadium [site](v.io) for more details, remembering that this repository
+Vanadium [site](https://v.io) for more details, remembering that this repository
 implements RPC, security and naming; it does not provide support for mobile
 development.
 

--- a/v23/namespace/model.go
+++ b/v23/namespace/model.go
@@ -50,7 +50,7 @@ type T interface {
 	// CacheCtl sets controls and returns the current control values.
 	CacheCtl(ctls ...naming.CacheCtl) []naming.CacheCtl
 
-	// Glob returns MountEntry's whose name matches the pattern and GlobError's
+	// Glob returns GlobReplyEntrys whose name matches the pattern and GlobReplyErrors
 	// for any piece of the space that can't be traversed.
 	//
 	// Two special patterns:
@@ -67,10 +67,10 @@ type T interface {
 	//	}
 	//	for s := range rc {
 	//		switch v := s.(type) {
-	//		case *naming.MountEntry:
-	//			fmt.Printf("%s: %v\n", v.Name, v.Servers)
-	//		case *naming.GlobError:
-	//			fmt.Fprintf(stderr, "%s can't be traversed: %s\n", v.Name, v.Error)
+	//		case *naming.GlobReplyEntry:
+	//			fmt.Printf("%s: %v\n", v.Value.Name, v.Value.Servers)
+	//		case *naming.GlobReplyError:
+	//			fmt.Fprintf(stderr, "%s can't be traversed: %s\n", v.Value.Name, v.Value.Error)
 	//		}
 	//	}
 	Glob(ctx *context.T, pattern string, opts ...naming.NamespaceOpt) (<-chan naming.GlobReply, error)


### PR DESCRIPTION
Update the README link to v23 site such that Github will not parse it
as a file in the repository.

Update docs for namespace.T.Glob() method to refer to the
GlobReplyEntry and GlobReplyError return types, both in the docstring
and in the given example.

