### PR TITLE
v23/context: fix goroutine leak in WithRootCancel

### DIFF
--- a/v23/context/context.go
+++ b/v23/context/context.go
@@ -303,8 +303,12 @@ func WithRootCancel(parent *T) (*T, CancelFunc) {
 		// Forward the cancelation from the root context to the newly
 		// created context.
 		go func() {
-			<-rootCtx.Done()
-			cancel()
+			select {
+			case <-rootCtx.Done():
+				cancel()
+			case <-ctx.Done():
+				cancel()
+			}
 		}()
 	} else if atomic.AddInt32(&nRootCancelWarning, 1) < 3 {
 		vlog.Errorf("context.WithRootCancel: context %+v is not derived from root v23 context.\n", parent)


### PR DESCRIPTION
Whenever a child context is created via `WithRootCancel`, a goroutine
spawns to gracefully handle closing the child context whenever the root
context gets canceled.

However, the current implementation leaks goroutines whenever the child
context exits before the root context exits. This pull request looks to
fix the problem by exiting the goroutine whenever the child context is
done.

See `TestRootCancelGoroutineLeak` for the reproduction use case and test
that demonstrates the leak. This is also easily visible via `pprof`
using the `goroutine` module.

Fix #1419