### PR TITLE
x/ref/lib/aws/vxray: work around goroutine leak in xray.BeginSegmentWithSampling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           name: downloads
           command: |
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0
             go get github.com/matthewloring/validjson/cmd/validjson@v0.0.1
             go install -x github.com/matthewloring/validjson/cmd/validjson
       - go/save-cache

--- a/x/ref/lib/aws/vxray/manager.go
+++ b/x/ref/lib/aws/vxray/manager.go
@@ -170,6 +170,7 @@ func (m *manager) WithNewTrace(ctx *context.T, name string, sr *vtrace.SamplingR
 	if st == nil {
 		panic("nil store")
 	}
+
 	id, err := uniqueid.Random()
 	if err != nil {
 		ctx.Errorf("vtrace: couldn't generate Trace Id, debug data may be lost: %v", err)

--- a/x/ref/lib/aws/vxray/manager.go
+++ b/x/ref/lib/aws/vxray/manager.go
@@ -170,17 +170,18 @@ func (m *manager) WithNewTrace(ctx *context.T, name string, sr *vtrace.SamplingR
 	if st == nil {
 		panic("nil store")
 	}
-	if st.Flags(uniqueid.Id{})&vtrace.AWSXRay == 0 {
-
-	}
 	id, err := uniqueid.Random()
 	if err != nil {
 		ctx.Errorf("vtrace: couldn't generate Trace Id, debug data may be lost: %v", err)
 	}
 
-	newSpan, err := libvtrace.NewSpan(id, id, name, vtrace.GetStore(ctx))
+	newSpan, err := libvtrace.NewSpan(id, id, name, st)
 	if err != nil {
 		ctx.Error(err)
+	}
+
+	if st.Flags(uniqueid.Id{})&vtrace.AWSXRay == 0 {
+		return vtrace.WithSpan(ctx, newSpan), newSpan
 	}
 
 	tid := xray.NewTraceID()

--- a/x/ref/lib/aws/vxray/vxray_test.go
+++ b/x/ref/lib/aws/vxray/vxray_test.go
@@ -147,8 +147,6 @@ func TestSimple(t *testing.T) {
 type simple struct{}
 
 func (s *simple) Ping(ctx *context.T, _ rpc.ServerCall) (string, error) {
-	//defer fmt.Printf("ping: ctx %p\n", ctx)
-	//time.Sleep(500 * time.Millisecond)
 	return "pong", nil
 }
 

--- a/x/ref/lib/aws/vxray/vxray_test.go
+++ b/x/ref/lib/aws/vxray/vxray_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 
 	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
@@ -145,7 +146,9 @@ func TestSimple(t *testing.T) {
 
 type simple struct{}
 
-func (s *simple) Ping(_ *context.T, _ rpc.ServerCall) (string, error) {
+func (s *simple) Ping(ctx *context.T, _ rpc.ServerCall) (string, error) {
+	//defer fmt.Printf("ping: ctx %p\n", ctx)
+	//time.Sleep(500 * time.Millisecond)
 	return "pong", nil
 }
 
@@ -250,11 +253,14 @@ func TestWithRPC(t *testing.T) {
 
 	// Run without vxray.
 	captured.segs = nil
+
 	store, _ := libvtrace.NewStore(flags.VtraceFlags{
 		SampleRate:     1,
 		DumpOnShutdown: false,
 		CacheSize:      1024,
+		EnableAWSXRay:  false,
 	})
+
 	clientCtx = vtrace.WithStore(ctx, store)
 
 	clientCtx, span, err := issueCall(clientCtx, name)
@@ -263,10 +269,17 @@ func TestWithRPC(t *testing.T) {
 	}
 
 	if got, want := len(captured.segs), 0; got != want {
-		t.Fatalf("# segments: got %v, want %v", got, want)
+		for i, s := range captured.segs {
+			t.Logf("segments: %v: %v", i, s)
+		}
+		t.Errorf("# segments: got %v, want %v", got, want)
 	}
+
 	trace := vtrace.GetStore(clientCtx).TraceRecord(span.Trace())
 	if got, want := len(trace.Spans), 4; got != want {
+		for i, s := range trace.Spans {
+			t.Logf("spans: %v: %v", i, s)
+		}
 		t.Fatalf("# spans: got %v, want %v", got, want)
 	}
 
@@ -305,8 +318,11 @@ func TestWithXRayHTTPHandler(t *testing.T) {
 	defer ts.Close()
 
 	res, err := http.Get(ts.URL)
-	if err != nil || res.StatusCode != 200 {
-		t.Fatalf("get failed: %v: code %v", err, res.StatusCode)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("get failed: http status code %v", res.StatusCode)
 	}
 
 	if got, want := len(captured.segs), 5; got != want {
@@ -328,4 +344,31 @@ func TestWithXRayHTTPHandler(t *testing.T) {
 
 	checkSeg(t, captured.segs[4], "http.echo.client")
 
+}
+
+func TestGoRoutineLeak(t *testing.T) {
+	// https://github.com/aws/aws-xray-sdk-go/issues/51 outlines how
+	// the xray SDK can leak goroutines. The vxray package works around
+	// this leak and this test is intended to verify that it does so.
+	ctx, shutdown := v23.Init()
+	defer shutdown()
+
+	captured := &emitter{}
+
+	initialGoRoutines := runtime.NumGoroutine()
+	xrayctx := initXRay(t, ctx, captured)
+	iterations := 1000
+	for i := 0; i < iterations; i++ {
+		sr := &vtrace.SamplingRequest{
+			Name: fmt.Sprintf("%v", i),
+		}
+		_, span := vtrace.WithNewTrace(xrayctx, "test", sr)
+		span.Finish(nil)
+	}
+	runtime.Gosched()
+	currentGoRoutines := runtime.NumGoroutine() - initialGoRoutines
+
+	if currentGoRoutines > iterations/2 {
+		t.Fatalf("%v running goroutines seems too high", currentGoRoutines)
+	}
 }


### PR DESCRIPTION
aws/aws-xray-sdk-go#51 describes the goroutine leak in xray.BeginSegmentWithSampling and an appropriate fix (Cyberax/aws-xray-sdk-go@033bad5). However, a different, incomplete fix was adopted: https://github.com/aws/aws-xray-sdk-go/pull/156/files.

This PR works around this bug by artificially creating a context and then canceling that new context when the xray segment is closed.