### PR TITLE
add go1.17 go:build tags for golangci-lint compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/vanadium/go-mdns-sd v0.0.0-20181006014439-f1a1ccd1252e
 	golang.org/x/crypto v0.0.0-20210513122933-cd7d49e622d5
 	golang.org/x/mod v0.4.2
-	golang.org/x/net v0.0.0-20210510120150-4163338589ed
+	golang.org/x/net v0.0.0-20210924151903-3ad01bbaa167
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed h1:p9UgmWI9wKpfYmgaV/IZKGdXc5qEK45tDwwwDyjS26I=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210924151903-3ad01bbaa167 h1:eDd+TJqbgfXruGQ5sJRU7tEtp/58OAx4+Ayjxg4SM+4=
+golang.org/x/net v0.0.0-20210924151903-3ad01bbaa167/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=

--- a/v23/security/blessings_override.go
+++ b/v23/security/blessings_override.go
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build java || android
 // +build java android
+
 //
 // We only expose the functionality below for the above build tags, to
 // discourage general usage.  The binaries that currently require this

--- a/v23/security/ecdsa_go.go
+++ b/v23/security/ecdsa_go.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !openssl
 // +build !openssl
 
 package security

--- a/v23/security/ecdsa_openssl.go
+++ b/v23/security/ecdsa_openssl.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build openssl
 // +build openssl
 
 // OpenSSL's libcrypto may have faster implementations of ECDSA signing and

--- a/v23/security/ecdsa_openssl_test.go
+++ b/v23/security/ecdsa_openssl_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build openssl
 // +build openssl
 
 package security

--- a/v23/security/ed25519_go.go
+++ b/v23/security/ed25519_go.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !openssl
 // +build !openssl
 
 package security

--- a/v23/security/ed25519_openssl.go
+++ b/v23/security/ed25519_openssl.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build openssl
 // +build openssl
 
 package security

--- a/v23/security/ed25519_openssl_test.go
+++ b/v23/security/ed25519_openssl_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build openssl
 // +build openssl
 
 package security

--- a/v23/security/util_openssl.go
+++ b/v23/security/util_openssl.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build openssl
 // +build openssl
 
 package security

--- a/v23/vdl/bootstrapped.go
+++ b/v23/vdl/bootstrapped.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !vdlbootstrapping
 // +build !vdlbootstrapping
 
 package vdl

--- a/v23/vdl/bootstrapping.go
+++ b/v23/vdl/bootstrapping.go
@@ -3,6 +3,7 @@
 // chain depends on the generated output of this package and
 // v.io/v23/vdlroot/vdltool.
 //
+//go:build vdlbootstrapping
 // +build vdlbootstrapping
 
 package vdl

--- a/v23/vdlroot/vdltool/bootstrapping.go
+++ b/v23/vdlroot/vdltool/bootstrapping.go
@@ -16,6 +16,7 @@
 // generated output of this package and bootstrapping in other packages and
 // in particular the vdl command-line tool and code generation.
 //
+//go:build vdltoolbootstrapping
 // +build vdltoolbootstrapping
 
 package vdltool

--- a/v23/vom/fuzz.go
+++ b/v23/vom/fuzz.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build gofuzz
 // +build gofuzz
 
 package vom

--- a/v23/vom/fuzzdump_test.go
+++ b/v23/vom/fuzzdump_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build fuzzdump
 // +build fuzzdump
 
 package vom_test

--- a/x/ref/cmd/principal/main_darwin.go
+++ b/x/ref/cmd/principal/main_darwin.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin
 // +build darwin
 
 package main

--- a/x/ref/cmd/principal/main_linux.go
+++ b/x/ref/cmd/principal/main_linux.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package main

--- a/x/ref/cmd/vdl/bootstrapped.go
+++ b/x/ref/cmd/vdl/bootstrapped.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !vdlbootstrapping
 // +build !vdlbootstrapping
 
 package main

--- a/x/ref/cmd/vdl/bootstrapping.go
+++ b/x/ref/cmd/vdl/bootstrapping.go
@@ -3,6 +3,7 @@
 // generate go output when boostrapping in order to regenerate
 // v23/vdlroot/vdltool and v23/vdl.
 //
+//go:build vdlbootstrapping
 // +build vdlbootstrapping
 
 package main

--- a/x/ref/lib/discovery/factory/plugins_darwin.go
+++ b/x/ref/lib/discovery/factory/plugins_darwin.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin
 // +build darwin
 
 package factory

--- a/x/ref/lib/discovery/factory/plugins_other.go
+++ b/x/ref/lib/discovery/factory/plugins_other.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !android && !darwin
 // +build !android,!darwin
 
 package factory

--- a/x/ref/lib/flags/main.go
+++ b/x/ref/lib/flags/main.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/x/ref/lib/security/internal/lockedfile/filelock/filelock_fcntl.go
+++ b/x/ref/lib/security/internal/lockedfile/filelock/filelock_fcntl.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build aix || solaris
 // +build aix solaris
 
 // This code implements the filelock API using POSIX 'fcntl' locks, which attach

--- a/x/ref/lib/security/internal/lockedfile/filelock/filelock_other.go
+++ b/x/ref/lib/security/internal/lockedfile/filelock/filelock_other.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !plan9 && !solaris && !windows
 // +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!plan9,!solaris,!windows
 
 package filelock

--- a/x/ref/lib/security/internal/lockedfile/filelock/filelock_plan9.go
+++ b/x/ref/lib/security/internal/lockedfile/filelock/filelock_plan9.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build plan9
 // +build plan9
 
 package filelock

--- a/x/ref/lib/security/internal/lockedfile/filelock/filelock_test.go
+++ b/x/ref/lib/security/internal/lockedfile/filelock/filelock_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !js && !plan9
 // +build !js,!plan9
 
 package filelock_test

--- a/x/ref/lib/security/internal/lockedfile/filelock/filelock_unix.go
+++ b/x/ref/lib/security/internal/lockedfile/filelock/filelock_unix.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
 // +build darwin dragonfly freebsd linux netbsd openbsd
 
 package filelock

--- a/x/ref/lib/security/internal/lockedfile/filelock/filelock_windows.go
+++ b/x/ref/lib/security/internal/lockedfile/filelock/filelock_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package filelock

--- a/x/ref/lib/security/internal/lockedfile/lockedfile_filelock.go
+++ b/x/ref/lib/security/internal/lockedfile/lockedfile_filelock.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !plan9
 // +build !plan9
 
 package lockedfile

--- a/x/ref/lib/security/internal/lockedfile/lockedfile_plan9.go
+++ b/x/ref/lib/security/internal/lockedfile/lockedfile_plan9.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build plan9
 // +build plan9
 
 package lockedfile

--- a/x/ref/lib/security/internal/lockedfile/lockedfile_test.go
+++ b/x/ref/lib/security/internal/lockedfile/lockedfile_test.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // js does not support inter-process file locking.
+//go:build !js
 // +build !js
 
 package lockedfile_test

--- a/x/ref/lib/security/internal/lockedfile/transform_test.go
+++ b/x/ref/lib/security/internal/lockedfile/transform_test.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // js does not support inter-process file locking.
+//go:build !js
 // +build !js
 
 package lockedfile_test

--- a/x/ref/lib/slang/main.go
+++ b/x/ref/lib/slang/main.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/x/ref/lib/vdl/codegen/golang/bootstrapped_native.go
+++ b/x/ref/lib/vdl/codegen/golang/bootstrapped_native.go
@@ -5,6 +5,7 @@
 // Native types are not supported in bootstrapping mode.  This
 // file contains the functions used for normal operation.
 //
+//go:build !vdlbootstrapping
 // +build !vdlbootstrapping
 
 package golang

--- a/x/ref/lib/vdl/codegen/golang/bootstrapped_tags.go
+++ b/x/ref/lib/vdl/codegen/golang/bootstrapped_tags.go
@@ -5,6 +5,7 @@
 // struct tags defined in config.vdl are not supported in bootstrapping
 // mode. This file contains the functions used for normal operation.
 //
+//go:build !vdlbootstrapping
 // +build !vdlbootstrapping
 
 package golang

--- a/x/ref/lib/vdl/codegen/golang/bootstrapped_template.go
+++ b/x/ref/lib/vdl/codegen/golang/bootstrapped_template.go
@@ -5,6 +5,7 @@
 // Template functions that differ when bootstrapping. This
 // file contains the functions used for normal operation.
 //
+//go:build !vdlbootstrapping
 // +build !vdlbootstrapping
 
 package golang

--- a/x/ref/lib/vdl/codegen/golang/bootstrapping.go
+++ b/x/ref/lib/vdl/codegen/golang/bootstrapping.go
@@ -1,3 +1,4 @@
+//go:build vdlbootstrapping
 // +build vdlbootstrapping
 
 package golang

--- a/x/ref/runtime/factories/library/library.go
+++ b/x/ref/runtime/factories/library/library.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || darwin
 // +build linux darwin
 
 // Package library implements a RuntimeFactory suitable for building a Vanadium

--- a/x/ref/runtime/factories/roaming/print_addrs.go
+++ b/x/ref/runtime/factories/roaming/print_addrs.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/x/ref/runtime/factories/roaming/roaming-cgo.go
+++ b/x/ref/runtime/factories/roaming/roaming-cgo.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin && linux && !cgo
 // +build darwin,linux,!cgo
 
 package roaming

--- a/x/ref/runtime/factories/roaming/roaming.go
+++ b/x/ref/runtime/factories/roaming/roaming.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || darwin
 // +build linux darwin
 
 // Package roaming implements a RuntimeFactory suitable for a variety of network

--- a/x/ref/runtime/factories/roaming/static.go
+++ b/x/ref/runtime/factories/roaming/static.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build darwin && linux && cgo
 // +build darwin,linux,cgo
 
 package roaming

--- a/x/ref/runtime/factories/static/static.go
+++ b/x/ref/runtime/factories/static/static.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux || darwin
 // +build linux darwin
 
 // Package static implements a RuntimeFactory suitable for a variety of network

--- a/x/ref/runtime/internal/platform/platform_nacl.go
+++ b/x/ref/runtime/internal/platform/platform_nacl.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build nacl
 // +build nacl
 
 package platform

--- a/x/ref/runtime/internal/platform/uts_str_linux_arm.go
+++ b/x/ref/runtime/internal/platform/uts_str_linux_arm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux && arm
 // +build linux,arm
 
 package platform

--- a/x/ref/runtime/internal/platform/uts_str_linux_nonarm.go
+++ b/x/ref/runtime/internal/platform/uts_str_linux_nonarm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux && !arm
 // +build linux,!arm
 
 package platform

--- a/x/ref/runtime/protocols/lib/websocket/conn.go
+++ b/x/ref/runtime/protocols/lib/websocket/conn.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !nacl
 // +build !nacl
 
 package websocket

--- a/x/ref/runtime/protocols/lib/websocket/conn_test.go
+++ b/x/ref/runtime/protocols/lib/websocket/conn_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !nacl
 // +build !nacl
 
 package websocket

--- a/x/ref/runtime/protocols/lib/websocket/listener.go
+++ b/x/ref/runtime/protocols/lib/websocket/listener.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !nacl
 // +build !nacl
 
 package websocket

--- a/x/ref/runtime/protocols/lib/websocket/listener_test.go
+++ b/x/ref/runtime/protocols/lib/websocket/listener_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !nacl
 // +build !nacl
 
 package websocket

--- a/x/ref/runtime/protocols/lib/websocket/ws.go
+++ b/x/ref/runtime/protocols/lib/websocket/ws.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !nacl
 // +build !nacl
 
 package websocket

--- a/x/ref/runtime/protocols/lib/websocket/wsh.go
+++ b/x/ref/runtime/protocols/lib/websocket/wsh.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !nacl
 // +build !nacl
 
 package websocket

--- a/x/ref/runtime/protocols/wsh_nacl/init.go
+++ b/x/ref/runtime/protocols/wsh_nacl/init.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build nacl
 // +build nacl
 
 package wsh_nacl

--- a/x/ref/services/internal/logreaderlib/logfile.go
+++ b/x/ref/services/internal/logreaderlib/logfile.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !android
 // +build !android
 
 // Package logreaderlib implements the LogFile interface from

--- a/x/ref/services/internal/logreaderlib/logfile_test.go
+++ b/x/ref/services/internal/logreaderlib/logfile_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !android
 // +build !android
 
 package logreaderlib_test

--- a/x/ref/test/testutil/no_race.go
+++ b/x/ref/test/testutil/no_race.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !race
 // +build !race
 
 package testutil

--- a/x/ref/test/testutil/race.go
+++ b/x/ref/test/testutil/race.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build race
 // +build race
 
 package testutil


### PR DESCRIPTION
golangci-lint now expects. the go1.17 style go:build tags to be present as well as the old style +build.