### PR TITLE
fix flaky/incorrect tests

### DIFF
--- a/x/ref/lib/pubsub/config_test.go
+++ b/x/ref/lib/pubsub/config_test.go
@@ -22,7 +22,7 @@ func ExamplePublisher() {
 	pub.CreateStream("net", "network settings", in)
 
 	// Publish an initial Setting to the Stream.
-	// Note that this, and the  coll to ForkStream below are in a race since
+	// Note that this, and the call to ForkStream below are in a race since
 	// although the send below will not complete until the value has been read
 	// from it by the internal goroutine in the publisher, that goroutine may
 	// get descheduled before it can update the internal state in the publisher

--- a/x/ref/lib/security/blessingstore.go
+++ b/x/ref/lib/security/blessingstore.go
@@ -117,8 +117,9 @@ func (bs *blessingStore) SetDefault(blessings security.Blessings) error {
 		bs.state.DefaultBlessings = oldDefault
 		return err
 	}
-	close(bs.defCh)
+	ch := bs.defCh
 	bs.defCh = make(chan struct{})
+	close(ch)
 	return nil
 }
 
@@ -371,7 +372,8 @@ func (bs *blessingStore) load() error {
 		return fmt.Errorf("failed to load BlessingStore: %v", err)
 	}
 	if !state.DefaultBlessings.Equivalent(bs.state.DefaultBlessings) {
-		close(bs.defCh)
+		ch := bs.defCh
+		defer close(ch)
 		bs.defCh = make(chan struct{})
 	}
 	bs.state = state

--- a/x/ref/services/internal/pproflib/proxy_test.go
+++ b/x/ref/services/internal/pproflib/proxy_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	v23 "v.io/v23"
 	"v.io/v23/context"
@@ -51,6 +52,17 @@ func TestPProfProxy(t *testing.T) {
 		"/myprefix/pprof/goroutine",
 		fmt.Sprintf("/pprof/symbol?%p", TestPProfProxy),
 	}
+
+	// Make sure the web server is up and running before starting tests.
+	for {
+		url := fmt.Sprintf("http://%s/myprefix/pprof/", ln.Addr())
+		resp, err := http.Get(url)
+		if err == nil && resp.StatusCode == 200 {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+
 	for _, c := range testcases {
 		url := fmt.Sprintf("http://%s%s", ln.Addr(), c)
 		resp, err := http.Get(url)


### PR DESCRIPTION
This PR fixes the pubsub test that can flake on very slow systems:
- x/ref/lib/pubsub
- x/ref/services/internal/pproflib
- x/ref/lib/security

It also fixes x/ref/runtime/internal/lib/sync to avoid calling t.Fatal from a goroutine which lint now, correctly, complains about.

