### PR TITLE
v23/vom,v23/rpc,v23: additional debugging, more conservative locking

### DIFF
--- a/v23/model.go
+++ b/v23/model.go
@@ -352,6 +352,8 @@ func getStack(skip int) string {
 
 func internalInit() (*context.T, Shutdown, error) {
 	initState.mu.Lock()
+	defer initState.mu.Unlock()
+
 	runtimeFactory := initState.runtimeFactory
 	if initState.runtimeFactory == nil {
 		initState.mu.Unlock()
@@ -362,7 +364,6 @@ func internalInit() (*context.T, Shutdown, error) {
 	// Skip 3 stack frames: runtime.Callers, getStack, Init
 	stack := getStack(3)
 	if initState.runtimeStack != "" {
-		initState.mu.Unlock()
 		format := `A runtime has already been initialized."
 The previous initialization was from:
 %s
@@ -372,7 +373,6 @@ This registration is from:
 		return nil, nil, fmt.Errorf(format, initState.runtimeStack, stack)
 	}
 	initState.runtimeStack = stack
-	initState.mu.Unlock()
 
 	rootctx, rootcancel := context.RootContext()
 	// Note we derive a second cancelable context here beyond the
@@ -392,9 +392,7 @@ This registration is from:
 		return nil, nil, fmt.Errorf("runtimeFactory returned: %v", err)
 	}
 
-	initState.mu.Lock()
 	initState.runtime = rt
-	initState.mu.Unlock()
 
 	vshutdown := func() {
 		if r := recover(); r != nil {

--- a/v23/model.go
+++ b/v23/model.go
@@ -356,7 +356,6 @@ func internalInit() (*context.T, Shutdown, error) {
 
 	runtimeFactory := initState.runtimeFactory
 	if initState.runtimeFactory == nil {
-		initState.mu.Unlock()
 		return nil, nil, fmt.Errorf("No RuntimeFactory has been registered nor specified. This is most" +
 			" likely because your main package has not imported a RuntimeFactory")
 	}

--- a/v23/rpc/model.go
+++ b/v23/rpc/model.go
@@ -220,12 +220,15 @@ const (
 	// ServerStopped indicates that the server has stopped. It can no longer be
 	// used.
 	ServerStopped
+	ServerReady
 )
 
 func (i ServerState) String() string {
 	switch i {
 	case ServerActive:
 		return "Active"
+	case ServerReady:
+		return "Ready"
 	case ServerStopping:
 		return "Stopping"
 	case ServerStopped:

--- a/v23/rpc/model.go
+++ b/v23/rpc/model.go
@@ -210,8 +210,10 @@ type Server interface {
 type ServerState int
 
 const (
-	// ServerActive indicates that the server is 'active'.
-	ServerActive ServerState = iota
+	// ServerInitializing indicates that the server exists and is initializing.
+	ServerInitializing ServerState = iota
+	// ServerReady indicates that the server is ready to handle requests.
+	ServerReady
 	// ServerStopping indicates that the server has been asked to stop and is
 	// in the process of doing so. It may take a while for the server to
 	// complete this process since it will wait for outstanding operations
@@ -220,13 +222,12 @@ const (
 	// ServerStopped indicates that the server has stopped. It can no longer be
 	// used.
 	ServerStopped
-	ServerReady
 )
 
 func (i ServerState) String() string {
 	switch i {
-	case ServerActive:
-		return "Active"
+	case ServerInitializing:
+		return "Initializing"
 	case ServerReady:
 		return "Ready"
 	case ServerStopping:

--- a/v23/vom/decoder_test.go
+++ b/v23/vom/decoder_test.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"v.io/v23/vdl"
 	"v.io/v23/verror"
 	"v.io/v23/vom"
@@ -255,7 +256,15 @@ func testDecoderFunc(pre string, test vomtest.Entry, rvWant reflect.Value, rvNew
 
 			}
 			if !vdl.DeepEqualReflect(rvGot, rvWant) {
-				return fmt.Errorf("%s\nGOT  %#v\nWANT %#v", name, rvGot, rvWant)
+				spew.Printf("as reflect.Value: %s\nGOT  %v\nWANT %v\n", name, rvGot, rvWant)
+				gotVal, wantVal := rvGot.Interface(), rvWant.Interface()
+				spew.Printf("as interface{}: %s\nGOT  %v\nWANT %v\n", name, gotVal, wantVal)
+				fmt.Printf("IsValid: got %v, want %v\n", rvGot.IsValid(), rvWant.IsValid())
+				fmt.Printf("IsZero: got %v, want %v\n", rvGot.IsZero(), rvWant.IsZero())
+				fmt.Printf("IsNil: got %v, want %v\n", rvGot.IsNil(), rvWant.IsNil())
+				fmt.Printf("Type: got %v, want %v\n", rvGot.Type(), rvWant.Type())
+				fmt.Printf("Kind: got %v, want %v\n", rvGot.Kind(), rvWant.Kind())
+				return fmt.Errorf("%s\nGOT  %v\nWANT %v", name, rvGot, rvWant)
 			}
 			if n, err := reader.Read(readEOF); n != 0 || err != io.EOF {
 				return fmt.Errorf("%s: reader got (%d,%v), want (0,EOF)", name, n, err)

--- a/v23/vom/decoder_test.go
+++ b/v23/vom/decoder_test.go
@@ -242,6 +242,22 @@ func testDecoder(pre string, test vomtest.Entry, rvWant reflect.Value) error {
 	// TODO(toddw): Add tests that start with a randomly-set value.
 }
 
+var printDetailsMu sync.Mutex
+
+func printDetails(name string, rvGot, rvWant reflect.Value) {
+	printDetailsMu.Lock()
+	defer printDetailsMu.Unlock()
+	fmt.Printf("FAILED test: %v\n", name)
+	spew.Printf("as reflect.Value:\nGOT  %v\nWANT %v\n", rvGot, rvWant)
+	gotVal, wantVal := rvGot.Interface(), rvWant.Interface()
+	spew.Printf("as interface{}:\nGOT  %v\nWANT %v\n", gotVal, wantVal)
+	fmt.Printf("IsValid: got %v, want %v\n", rvGot.IsValid(), rvWant.IsValid())
+	fmt.Printf("IsZero: got %v, want %v\n", rvGot.IsZero(), rvWant.IsZero())
+	fmt.Printf("IsNil: got %v, want %v\n", rvGot.IsNil(), rvWant.IsNil())
+	fmt.Printf("Type: got %v, want %v\n", rvGot.Type(), rvWant.Type())
+	fmt.Printf("Kind: got %v, want %v\n", rvGot.Kind(), rvWant.Kind())
+}
+
 func testDecoderFunc(pre string, test vomtest.Entry, rvWant reflect.Value, rvNew func() reflect.Value) error {
 	readEOF := make([]byte, 1)
 	for _, mode := range vom.AllReadModes {
@@ -253,17 +269,9 @@ func testDecoderFunc(pre string, test vomtest.Entry, rvWant reflect.Value, rvNew
 			dec := vom.NewDecoder(reader)
 			if err := dec.Decode(rvGot.Interface()); err != nil {
 				return fmt.Errorf("%s: Decode failed: %v", name, err)
-
 			}
 			if !vdl.DeepEqualReflect(rvGot, rvWant) {
-				spew.Printf("as reflect.Value: %s\nGOT  %v\nWANT %v\n", name, rvGot, rvWant)
-				gotVal, wantVal := rvGot.Interface(), rvWant.Interface()
-				spew.Printf("as interface{}: %s\nGOT  %v\nWANT %v\n", name, gotVal, wantVal)
-				fmt.Printf("IsValid: got %v, want %v\n", rvGot.IsValid(), rvWant.IsValid())
-				fmt.Printf("IsZero: got %v, want %v\n", rvGot.IsZero(), rvWant.IsZero())
-				fmt.Printf("IsNil: got %v, want %v\n", rvGot.IsNil(), rvWant.IsNil())
-				fmt.Printf("Type: got %v, want %v\n", rvGot.Type(), rvWant.Type())
-				fmt.Printf("Kind: got %v, want %v\n", rvGot.Kind(), rvWant.Kind())
+				printDetails(name, rvGot, rvWant)
 				return fmt.Errorf("%s\nGOT  %v\nWANT %v", name, rvGot, rvWant)
 			}
 			if n, err := reader.Read(readEOF); n != 0 || err != io.EOF {
@@ -292,6 +300,7 @@ func testDecoderFunc(pre string, test vomtest.Entry, rvWant reflect.Value, rvNew
 				return fmt.Errorf("%s: Decode failed: %v", name, err)
 			}
 			if !vdl.DeepEqualReflect(rvGot, rvWant) {
+				printDetails(name, rvGot, rvWant)
 				return fmt.Errorf("%s\nGOT  %v\nWANT %v", name, rvGot, rvWant)
 			}
 			if n, err := reader.Read(readEOF); n != 0 || err != io.EOF {

--- a/x/ref/cmd/principal/internal/scripting/scripting_test.go
+++ b/x/ref/cmd/principal/internal/scripting/scripting_test.go
@@ -96,7 +96,6 @@ func TestPrincipal(t *testing.T) {
 	printBlessings(blessings)
 	`)
 	fmt.Println("------------")
-	fmt.Println("xxx ", pk.String())
 	fmt.Println(out)
 
 	if got, want := out, "PublicKey          : "+pk.String(); !strings.Contains(got, want) {

--- a/x/ref/cmd/vrpc/vrpc.go
+++ b/x/ref/cmd/vrpc/vrpc.go
@@ -185,7 +185,7 @@ func runSignature(ctx *context.T, env *cmdline.Env, args []string) error {
 	}
 	// Get the interface or method signature, and pretty-print.  We print the
 	// named types after the signatures, to aid in readability.
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	var types vdlgen.NamedTypes
 	opts, err := rpcOpts(ctx, server)

--- a/x/ref/cmd/vrpc/vrpc.go
+++ b/x/ref/cmd/vrpc/vrpc.go
@@ -185,7 +185,7 @@ func runSignature(ctx *context.T, env *cmdline.Env, args []string) error {
 	}
 	// Get the interface or method signature, and pretty-print.  We print the
 	// named types after the signatures, to aid in readability.
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer cancel()
 	var types vdlgen.NamedTypes
 	opts, err := rpcOpts(ctx, server)

--- a/x/ref/cmd/vrpc/vrpc_test.go
+++ b/x/ref/cmd/vrpc/vrpc_test.go
@@ -19,6 +19,7 @@ import (
 	"v.io/x/ref/lib/v23cmd"
 	_ "v.io/x/ref/runtime/factories/generic"
 	"v.io/x/ref/test"
+	"v.io/x/ref/test/testutil"
 )
 
 type server struct{}
@@ -122,6 +123,7 @@ func initTest(t *testing.T) (ctx *context.T, name string, shutdown v23.Shutdown)
 		t.Fatalf("NewServer failed: %v", err)
 		return
 	}
+	testutil.WaitForServerReady(server)
 	name = server.Status().Endpoints[0].Name()
 	return
 }

--- a/x/ref/lib/discovery/advertise_server.go
+++ b/x/ref/lib/discovery/advertise_server.go
@@ -49,7 +49,7 @@ func AdvertiseServer(ctx *context.T, d discovery.T, server rpc.Server, suffix st
 			select {
 			case <-status.Dirty:
 				status = server.Status()
-				if status.State != rpc.ServerActive {
+				if status.State == rpc.ServerStopping || status.State == rpc.ServerStopped {
 					stop()
 					return
 				}

--- a/x/ref/lib/discovery/directory.go
+++ b/x/ref/lib/discovery/directory.go
@@ -115,7 +115,7 @@ func newDirServer(ctx *context.T, d *idiscovery, opts ...rpc.ServerOpt) (*dirSer
 			select {
 			case <-status.Dirty:
 				status = server.Status()
-				if status.State != rpc.ServerActive {
+				if status.State == rpc.ServerStopping || status.State == rpc.ServerStopped {
 					return
 				}
 				newAddrs := sortedNames(status.Endpoints)

--- a/x/ref/runtime/internal/rpc/server.go
+++ b/x/ref/runtime/internal/rpc/server.go
@@ -519,6 +519,11 @@ func (s *server) acceptLoop(ctx *context.T) error {
 		s.active.Done()
 		s.ctx.VI(1).Infof("rpc: Stopped accepting")
 	}()
+	s.Lock()
+	s.state = rpc.ServerReady
+	close(s.dirty)
+	s.dirty = make(chan struct{})
+	s.Unlock()
 	for {
 		// TODO(mattr): We need to interrupt Accept at some point.
 		// Should we interrupt it by canceling the context?

--- a/x/ref/runtime/internal/rpc/test/server_test.go
+++ b/x/ref/runtime/internal/rpc/test/server_test.go
@@ -91,7 +91,7 @@ func TestServerStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 	status := server.Status()
-	if got, want := status.State, rpc.ServerActive; got != want {
+	if got, want := status.State, rpc.ServerReady; got != want {
 		t.Fatalf("got %s, want %s", got, want)
 	}
 

--- a/x/ref/runtime/internal/rpc/test/server_test.go
+++ b/x/ref/runtime/internal/rpc/test/server_test.go
@@ -90,7 +90,7 @@ func TestServerStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	status := server.Status()
+	status := testutil.WaitForServerReady(server)
 	if got, want := status.State, rpc.ServerReady; got != want {
 		t.Fatalf("got %s, want %s", got, want)
 	}

--- a/x/ref/test/testutil/rpc.go
+++ b/x/ref/test/testutil/rpc.go
@@ -20,6 +20,18 @@ func WaitForServerPublished(s rpc.Server) rpc.ServerStatus {
 	}
 }
 
+// WaitForServerReady blocks until the server is actively listening for
+// new requests.
+func WaitForServerReady(s rpc.Server) rpc.ServerStatus {
+	for {
+		status := s.Status()
+		if status.State == rpc.ServerReady {
+			return status
+		}
+		<-status.Dirty
+	}
+}
+
 // WaitForProxyEndpoints blocks until the server's proxied endpoints appear in
 // status.Endpoints, and returns the resulting server status.
 func WaitForProxyEndpoints(s rpc.Server, proxyName string) rpc.ServerStatus {


### PR DESCRIPTION
The decode tests in v23/vom fail very rarely for unknown reasons on slow CI systems, this PR adds additional debugging to help track that down.

The state transitions for an RPC server are racy in the sense that there is a lot of code between the server being created, initializing itself and being read to accept requests. This seems to show up in some tests where the client code attempts to connect to the server while it is still initializing. This PR changes the states to Initialiazing, Ready, Stopping, Stopped from Active, Stopping and Stopped. A testutil function WaitForServerReady is provided for clients to wait for a server to be ready before attempting to use it, though this only really an issue for tests.

Similarly, the proxyd tests sometimes fail with a panic on slow systems and the change to v23/model.go uses more conservative locking to prevent these panics.