### PR TITLE
x/ref/lib/securitykeys/...,x/ref/cmd/principal: clean up creating principals and importing keys.

### DIFF
--- a/x/ref/cmd/principal/doc.go
+++ b/x/ref/cmd/principal/doc.go
@@ -137,6 +137,9 @@ setup to use by default.  If a blessing argument is not provided, the new
 principal will have no blessings.
 
 The principal create flags are:
+ -copy-private-key=false
+   If set, the private key will be copied into the newly created principal
+   rather than being referred to in its current location.
  -key-type=ecdsa256
    The type of key to be created, allowed values are ecdsa256, ecdsa384,
    ecdsa521, ed25519, rsa2048, rsa4096.
@@ -177,6 +180,9 @@ Usage:
 The principal fork flags are:
  -caveat=
    "package/path".CaveatName:VDLExpressionParam to attach to this blessing
+ -copy-private-key=false
+   If set, the private key will be copied into the newly created principal
+   rather than being referred to in its current location.
  -for=0s
    Duration of blessing validity (zero implies no expiration)
  -key-type=ecdsa256

--- a/x/ref/cmd/principal/principal_v23_test.go
+++ b/x/ref/cmd/principal/principal_v23_test.go
@@ -13,9 +13,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
+	"golang.org/x/crypto/ssh"
 	"v.io/x/ref"
 	"v.io/x/ref/lib/security"
 	"v.io/x/ref/lib/security/keys"
@@ -594,7 +596,12 @@ func TestV23Create(t *testing.T) {
 		outputDir = sh.MakeTempDir()
 		bin       = v23test.BuildGoPkg(sh, "v.io/x/ref/cmd/principal")
 		aliceDir  = filepath.Join(outputDir, "alice")
+		sslFile   = filepath.Join(outputDir, "ssl.key")
 	)
+
+	if err := os.WriteFile(sslFile, sectestdata.X509PrivateKeyBytes(keys.ED25519, sectestdata.X509Private), 0600); err != nil {
+		t.Fatal(err)
+	}
 
 	checkBlessing := func(want string) {
 		if p, err := security.LoadPersistentPrincipal(aliceDir, nil); err != nil {
@@ -606,14 +613,85 @@ func TestV23Create(t *testing.T) {
 			}
 		}
 	}
-	for _, flags := range [][]string{
-		nil,
-		{"--ssh-public-key=" + filepath.Join(sshKeyDir, "ssh-ed25519.pub")},
-		{"--key-type=ecdsa521"},
+
+	checkPEM := func(keyfile, blockType string) {
+		data, err := os.ReadFile(filepath.Join(aliceDir, keyfile))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _, line, _ := runtime.Caller(1)
+		block, _ := pem.Decode(data)
+		if block == nil {
+			t.Errorf("line %v: failed to decode PEM block in: %s", line, data)
+			return
+		}
+		if got, want := block.Type, blockType; got != want {
+			t.Errorf("line %v: got %v, want %v", line, got, want)
+		}
+	}
+
+	checkSSHKey := func(keyfile, comment string) {
+		data, err := os.ReadFile(filepath.Join(aliceDir, keyfile))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _, line, _ := runtime.Caller(1)
+		_, keyComment, _, _, err := ssh.ParseAuthorizedKey(data)
+		if err != nil {
+			t.Errorf("line %v: failed to parse ssh key from: %s: %v", line, data, err)
+			return
+		}
+		if got, want := keyComment, comment; got != want {
+			t.Errorf("line %v: got %v, want %v", line, got, want)
+		}
+	}
+
+	for _, tc := range []struct {
+		sshComment        string
+		privateKeyPEMType string
+		flags             []string
+	}{
+		{
+			"",
+			"PRIVATE KEY",
+			nil},
+		{
+			"ed25519",
+			"VANADIUM INDIRECT PRIVATE KEY",
+			[]string{"--ssh-public-key=" + filepath.Join(sshKeyDir, "ssh-ed25519.pub")}},
+		{
+			"",
+			"VANADIUM INDIRECT PRIVATE KEY",
+			[]string{"--ssh-key=" + filepath.Join(sshKeyDir, "ssh-ecdsa-521")}},
+		{
+			"",
+			"VANADIUM INDIRECT PRIVATE KEY",
+			[]string{"--ssl-key=" + sslFile}},
+		{
+			"",
+			"PRIVATE KEY",
+			[]string{"--ssh-key=" + filepath.Join(sshKeyDir, "ssh-ecdsa-521"), "--copy-private-key"}},
+		{
+			"",
+			"PRIVATE KEY",
+			[]string{"--ssl-key=" + sslFile, "--copy-private-key"}},
+		{
+			"",
+			"PRIVATE KEY",
+			[]string{"--key-type=ecdsa521"}},
 	} {
+		flags := tc.flags
 		// Creating a principal should succeed the first time.
 		sh.Cmd(bin, mergeFlags("create", flags, aliceDir, "alice")...).Run()
 		checkBlessing("alice")
+
+		if len(tc.sshComment) > 0 {
+			checkSSHKey("publickey.pem", tc.sshComment)
+		} else {
+			checkPEM("publickey.pem", "PUBLIC KEY")
+		}
+
+		checkPEM("privatekey.pem", tc.privateKeyPEMType)
 
 		// The second time should fail (the create command won't override an existing principal).
 		cmd := sh.Cmd(bin, mergeFlags("create", flags, aliceDir, "alice")...)
@@ -623,12 +701,13 @@ func TestV23Create(t *testing.T) {
 		}
 
 		// If we specify -overwrite, it will.
-		sh.Cmd(bin, "create", "--overwrite", aliceDir, "alice").Run()
+		sh.Cmd(bin, mergeFlags("create", flags, "-overwrite", aliceDir, "alice")...).Run()
 		checkBlessing("alice")
 
 		// If we create a principal without specifying a blessing name, it will have no blessing.
-		sh.Cmd(bin, "create", "--overwrite", aliceDir).Run()
+		sh.Cmd(bin, mergeFlags("create", flags, "-overwrite", aliceDir)...).Run()
 		checkBlessing("")
+
 		os.RemoveAll(aliceDir)
 	}
 }

--- a/x/ref/lib/security/create_principal.go
+++ b/x/ref/lib/security/create_principal.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CreatePersistentPrincipal wraps CreatePersistentPrincipalUsingKey to
-// creates a new Principal using a newly generated ECSDA key.
+// creates a new Principal using a newly generated ECSDA key using the P.256 curve.
 func CreatePersistentPrincipal(dir string, passphrase []byte) (security.Principal, error) {
 	store, err := CreateFilesystemStore(dir)
 	if err != nil {
@@ -30,8 +30,6 @@ func CreatePersistentPrincipal(dir string, passphrase []byte) (security.Principa
 // If the directory has any preexisting principal data, an error is returned.
 //
 // The specified directory may not exist, in which case it will be created.
-// The follow key types are supported:
-// *ecdsa.PrivateKey, ed25519.PrivateKey, *rsa.PrivateKey and *sshkeys.HostedKey.
 func CreatePersistentPrincipalUsingKey(ctx context.Context, key crypto.PrivateKey, dir string, passphrase []byte) (security.Principal, error) {
 	store, err := CreateFilesystemStore(dir)
 	if err != nil {

--- a/x/ref/lib/security/create_principal.go
+++ b/x/ref/lib/security/create_principal.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CreatePersistentPrincipal wraps CreatePersistentPrincipalUsingKey to
-// creates a new Principal using a newly generated ECSDA key using the P.256 curve.
+// create a new Principal using a newly generated ECSDA key using the P.256 curve.
 func CreatePersistentPrincipal(dir string, passphrase []byte) (security.Principal, error) {
 	store, err := CreateFilesystemStore(dir)
 	if err != nil {

--- a/x/ref/lib/security/create_principal_opts.go
+++ b/x/ref/lib/security/create_principal_opts.go
@@ -28,8 +28,7 @@ func (o createPrincipalOptions) checkPrivateKey(msg string) error {
 }
 
 // CreatePrincipalOpts creates a Principal using the specified options. It is
-// intended to replace all of the other 'Create' methods provided by this
-// package.
+// intended to replace the other 'Create' methods provided by this package.
 // If no private key was specified via an option then a plaintext ecdsa key
 // with the P256 curve will be created and used.
 func CreatePrincipalOpts(ctx context.Context, opts ...CreatePrincipalOption) (security.Principal, error) {
@@ -67,10 +66,6 @@ func (o createPrincipalOptions) getSigner(ctx context.Context) (security.Signer,
 	return nil, nil
 }
 
-func (o createPrincipalOptions) getPublicKey(ctx context.Context) (security.PublicKey, error) {
-	return publicKeyFromBytes(o.publicKeyBytes)
-}
-
 func (o createPrincipalOptions) inMemoryStores(publicKey security.PublicKey) (blessingStore security.BlessingStore, blessingRoots security.BlessingRoots) {
 	blessingStore, blessingRoots = o.blessingStore, o.blessingRoots
 	if blessingStore == nil {
@@ -90,7 +85,7 @@ func (o createPrincipalOptions) createInMemoryPrincipal(ctx context.Context) (se
 		bs, br := o.inMemoryStores(signer.PublicKey())
 		return security.CreatePrincipal(signer, bs, br)
 	}
-	if publicKey, err := o.getPublicKey(ctx); publicKey != nil {
+	if publicKey, err := publicKeyFromBytes(o.publicKeyBytes); publicKey != nil {
 		if err != nil {
 			return nil, err
 		}
@@ -132,7 +127,7 @@ func (o createPrincipalOptions) createPersistentPrincipal(ctx context.Context) (
 	}
 	var publicKey security.PublicKey
 	if signer == nil {
-		publicKey, err = o.getPublicKey(ctx)
+		publicKey, err = publicKeyFromBytes(o.publicKeyBytes)
 		if err != nil {
 			return nil, err
 		}

--- a/x/ref/lib/security/keyfile_util.go
+++ b/x/ref/lib/security/keyfile_util.go
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"v.io/v23/security"
+	"v.io/x/ref/lib/security/keys/indirectkeyfiles"
 	"v.io/x/ref/lib/security/passphrase"
 )
 
@@ -28,24 +29,6 @@ func writeKeyFile(keyfile string, data []byte) error {
 	defer to.Close()
 	_, err = io.Copy(to, bytes.NewReader(data))
 	return err
-}
-
-func marshalKeyPair(private crypto.PrivateKey, passphrase []byte) (pubBytes, privBytes []byte, err error) {
-	privBytes, err = keyRegistrar.MarshalPrivateKey(private, passphrase)
-	if err != nil {
-		err = translatePassphraseError(err)
-		return
-	}
-	api, err := keyRegistrar.APIForKey(private)
-	if err != nil {
-		return
-	}
-	pubKey, err := api.CryptoPublicKey(private)
-	if err != nil {
-		return
-	}
-	pubBytes, err = keyRegistrar.MarshalPublicKey(pubKey)
-	return
 }
 
 // PrivateKeyFromFileWithPrompt reads a private key file from the specified file
@@ -72,6 +55,12 @@ func PrivateKeyWithPrompt(ctx context.Context, privKeyBytes []byte, prompt strin
 	}
 	defer ZeroPassphrase(pass)
 	return keyRegistrar.ParsePrivateKey(ctx, privKeyBytes, pass)
+}
+
+// ImportPrivateKeyFile returns the byte representation for an imported private
+// key file.
+func ImportPrivateKeyFile(filename string) ([]byte, error) {
+	return indirectkeyfiles.MarshalPrivateKey([]byte(filename))
 }
 
 func publicKeyFromBytes(publicKeyBytes []byte) (security.PublicKey, error) {

--- a/x/ref/lib/security/keys/internal/key_util.go
+++ b/x/ref/lib/security/keys/internal/key_util.go
@@ -10,15 +10,6 @@ import (
 	"fmt"
 )
 
-// ZeroPassphrases zeros out the supplied byte slices.
-func ZeroPassphrases(passphrases ...[]byte) {
-	for _, pp := range passphrases {
-		for i := range pp {
-			pp[i] = 0x0
-		}
-	}
-}
-
 // EncodePEM creates an encodes a PEM block with the specified type, headers
 // and bytes.
 func EncodePEM(typ string, der []byte, headers map[string]string) ([]byte, error) {

--- a/x/ref/lib/security/keys/internal/key_util.go
+++ b/x/ref/lib/security/keys/internal/key_util.go
@@ -10,33 +10,6 @@ import (
 	"fmt"
 )
 
-// ImportOptions represents options accecpted by the various MarshalForImport
-// functions supported by the subpackages of security/keys.
-type ImportOptions struct {
-	KeyBytes       []byte
-	OrigPassphrase []byte
-	NewPassphrase  []byte
-	KeyFilename    string
-	UseAgent       bool
-}
-
-// PrivateKeyBytes specifies the private key as a raw bytes.
-func (o *ImportOptions) PrivateKeyBytes(keyBytes []byte, origPassphrase, newPassphrase []byte) {
-	o.KeyBytes = keyBytes
-	o.OrigPassphrase = origPassphrase
-	o.NewPassphrase = newPassphrase
-}
-
-// PrivateKeyFile specifies a file containing a private key.
-func (o *ImportOptions) PrivateKeyFile(filename string) {
-	o.KeyFilename = filename
-}
-
-// UsingAgent specifies that an agent be used for accessing
-func (o *ImportOptions) UsingAgent(v bool) {
-	o.UseAgent = v
-}
-
 // ZeroPassphrases zeros out the supplied byte slices.
 func ZeroPassphrases(passphrases ...[]byte) {
 	for _, pp := range passphrases {

--- a/x/ref/lib/security/keys/sshkeys/agent_test.go
+++ b/x/ref/lib/security/keys/sshkeys/agent_test.go
@@ -64,50 +64,14 @@ func TestContext(t *testing.T) {
 	if got, want := sshkeys.AgentSocketName(ctx), "my-value"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
-	/*
-		if got, want := sshkeys.AgentPassphrase(ctx), []byte(nil); !bytes.Equal(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
-
-		ctx = sshkeys.WithAgentPassphrase(ctx, []byte("oh-my"))
-		if got, want := sshkeys.AgentPassphrase(ctx), []byte("oh-my"); !bytes.Equal(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
-		if got, want := sshkeys.AgentPassphrase(ctx), []byte("oh-my"); !bytes.Equal(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
-
-		passphrase := []byte("test-finalizer")
-		{
-			nctx := sshkeys.WithAgentPassphrase(ctx, passphrase)
-			if got, want := sshkeys.AgentPassphrase(nctx), passphrase; !bytes.Equal(got, want) {
-				t.Errorf("got %v, want %v", got, want)
-			}
-		}
-		runtime.GC()
-		if got, want := passphrase, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}; !bytes.Equal(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
-
-		ctx = sshkeys.WithAgentPassphrase(context.Background(), nil)
-		if got := sshkeys.AgentPassphrase(ctx); got != nil {
-			t.Errorf("got %v, want nil", got)
-		}
-
-		ctx = sshkeys.WithAgentPassphrase(context.Background(), []byte{})
-		if got := sshkeys.AgentPassphrase(ctx); got != nil {
-			t.Errorf("got %v, want nil", got)
-		}*/
 }
 
 func testAgent(ctx context.Context, t *testing.T, kt keys.CryptoAlgo, passphrase []byte) {
-	publicKeyBytes := sectestdata.SSHPublicKeyBytes(kt, sectestdata.SSHKeyPublic)
-
-	publicKeyBytes, privateKeyBytes, err := sshkeys.MarshalForImport(ctx, publicKeyBytes, sshkeys.ImportUsingAgent(true))
+	publicKeyBytes, privateKeyBytes, err := sshkeys.ImportAgentHostedKeyBytes(
+		sectestdata.SSHPublicKeyBytes(kt, sectestdata.SSHKeyPublic))
 	if err != nil {
 		t.Fatalf("%v: %v", kt, err)
 	}
-
 	key, err := keyRegistrar.ParsePublicKey(publicKeyBytes)
 	if err != nil {
 		t.Fatalf("%v: %v", kt, err)
@@ -165,12 +129,7 @@ func TestAgent(t *testing.T) {
 
 func getSigner(ctx context.Context, t *testing.T, kt keys.CryptoAlgo) error {
 	publicKeyBytes := sectestdata.SSHPublicKeyBytes(kt, sectestdata.SSHKeyPublic)
-
-	_, privateKeyBytes, err := sshkeys.MarshalForImport(ctx, publicKeyBytes, sshkeys.ImportUsingAgent(true))
-	if err != nil {
-		t.Fatalf("%v: %v", kt, err)
-	}
-
+	_, privateKeyBytes, err := sshkeys.ImportAgentHostedKeyBytes(publicKeyBytes)
 	hk, err := keyRegistrar.ParsePrivateKey(ctx, privateKeyBytes, nil)
 	if err != nil {
 		t.Fatalf("%v: %v", kt, err)

--- a/x/ref/lib/security/keys/sshkeys/agent_test.go
+++ b/x/ref/lib/security/keys/sshkeys/agent_test.go
@@ -130,6 +130,9 @@ func TestAgent(t *testing.T) {
 func getSigner(ctx context.Context, t *testing.T, kt keys.CryptoAlgo) error {
 	publicKeyBytes := sectestdata.SSHPublicKeyBytes(kt, sectestdata.SSHKeyPublic)
 	_, privateKeyBytes, err := sshkeys.ImportAgentHostedKeyBytes(publicKeyBytes)
+	if err != nil {
+		t.Fatalf("%v: %v", kt, err)
+	}
 	hk, err := keyRegistrar.ParsePrivateKey(ctx, privateKeyBytes, nil)
 	if err != nil {
 		t.Fatalf("%v: %v", kt, err)

--- a/x/ref/lib/security/keys/sshkeys/ssh_import.go
+++ b/x/ref/lib/security/keys/sshkeys/ssh_import.go
@@ -10,7 +10,8 @@ import (
 
 // ImportAgentHostedPrivateKeyBytes returns the byte representation for an imported
 // ssh public key and associated private key that is hosted in an ssh agent.
-// This is essentially a reference to the private key.
+// The resulting private key representations is essentially a reference to
+// the agent managed key.
 func ImportAgentHostedKeyBytes(keyBytes []byte) (publicKeyBytes, privateKeyBytes []byte, err error) {
 	publicKey, comment, _, _, err := ssh.ParseAuthorizedKey(keyBytes)
 	if err != nil {

--- a/x/ref/lib/security/keys/sshkeys/ssh_import.go
+++ b/x/ref/lib/security/keys/sshkeys/ssh_import.go
@@ -6,81 +6,9 @@ package sshkeys
 
 import (
 	"context"
-	"fmt"
 
-	"golang.org/x/crypto/ssh"
 	"v.io/x/ref/lib/security/keys"
-	"v.io/x/ref/lib/security/keys/indirectkeyfiles"
-	"v.io/x/ref/lib/security/keys/internal"
 )
-
-// ImportOption represents an option to MarshalForImport.
-type ImportOption func(o *internal.ImportOptions)
-
-// ImportUsingAgent requests that the private key is hosted by an ssh agent.
-func ImportUsingAgent(v bool) ImportOption {
-	return func(o *internal.ImportOptions) {
-		o.UsingAgent(v)
-	}
-}
-
-// ImportPrivateKeyFile will result in the private key in the specified
-// file being used. The Vanadium principal will refer to that file and
-// not copy it.
-func ImportPrivateKeyFile(filename string) ImportOption {
-	return func(o *internal.ImportOptions) {
-		o.PrivateKeyFile(filename)
-	}
-}
-
-// ImportPrivateKeyBytes will result in the supplied bytes being used
-// as the private key, that is, those bytes will be copied to the
-// Vanadium principal. If newPassphrase is provided the copied key will
-// be encrypted in pkcs8 format.
-func ImportPrivateKeyBytes(keyBytes []byte, origPassphrase, newPassphrase []byte) ImportOption {
-	return func(o *internal.ImportOptions) {
-		o.PrivateKeyBytes(keyBytes, origPassphrase, newPassphrase)
-	}
-}
-
-// MarshalForImport will marshal the supplied public and private keys
-// according to the supplied option which specifies how the private key
-// is to imported.
-func MarshalForImport(ctx context.Context, publicKeyBytes []byte, option ImportOption) (importedPublicKeyBytes, importedPrivateKeyBytes []byte, err error) {
-	opts := internal.ImportOptions{}
-	option(&opts)
-	defer internal.ZeroPassphrases(opts.OrigPassphrase, opts.NewPassphrase)
-
-	publicKey, comment, _, _, err := ssh.ParseAuthorizedKey(publicKeyBytes)
-	if err != nil {
-		return
-	}
-
-	if opts.UseAgent {
-		hostedKey := NewHostedKey(publicKey, comment, nil)
-		privKeyBytes, err := marshalHostedKey(hostedKey, nil)
-		if err != nil {
-			return nil, nil, err
-		}
-		return publicKeyBytes, privKeyBytes, nil
-	}
-
-	if filename := opts.KeyFilename; len(filename) > 0 {
-		privKeyBytes, err := indirectkeyfiles.MarshalPrivateKey([]byte(filename))
-		if err != nil {
-			return nil, nil, err
-		}
-		return publicKeyBytes, privKeyBytes, nil
-	}
-
-	if keyBytes := opts.KeyBytes; len(keyBytes) > 0 {
-		privKeyBytes, err := importPrivateKeyBytes(ctx, keyBytes,
-			opts.OrigPassphrase, opts.NewPassphrase)
-		return publicKeyBytes, privKeyBytes, err
-	}
-
-	return nil, nil, fmt.Errorf("no options were specified for how to import the private key")
-}
 
 // Make the key functions local to this package available to this package.
 var keyRegistrar = keys.NewRegistrar()

--- a/x/ref/lib/security/keys/sshkeys/ssh_import_test.go
+++ b/x/ref/lib/security/keys/sshkeys/ssh_import_test.go
@@ -94,7 +94,9 @@ func TestImport(t *testing.T) {
 		}
 
 		ipriv, err = seclib.ImportPrivateKeyFile(filename)
-
+		if err != nil {
+			t.Fatalf("%v: %v", kt, err)
+		}
 		key, err = keyRegistrar.ParsePrivateKey(ctx, ipriv, nil)
 		validatePrivateKey(err, kt, key)
 	}
@@ -115,7 +117,9 @@ func TestImportCopy(t *testing.T) {
 		} {
 			privateKeyBytes := sectestdata.SSHPrivateKeyBytes(kt, tc.set)
 			privateKey, err := seclib.ParsePrivateKey(ctx, privateKeyBytes, nil)
-
+			if err != nil {
+				t.Fatalf("%v: %v", kt, err)
+			}
 			ipriv, err := seclib.MarshalPrivateKey(privateKey, tc.newPassphrase)
 			if err != nil {
 				t.Fatalf("%v: %v: passphrase: %v", kt, tc.set, err)

--- a/x/ref/lib/security/keys/sshkeys/ssh_import_test.go
+++ b/x/ref/lib/security/keys/sshkeys/ssh_import_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	seclib "v.io/x/ref/lib/security"
 	"v.io/x/ref/lib/security/keys"
 	"v.io/x/ref/lib/security/keys/sshkeys"
 	"v.io/x/ref/test/sectestdata"
@@ -54,16 +55,15 @@ func TestImport(t *testing.T) {
 		default:
 			t.Fatalf("line: %v: %v: parsed private key is a crypto key: %T", line, kt, key)
 		}
-
 	}
 
 	for _, kt := range sectestdata.SupportedKeyAlgos {
 		var err error
+
 		publicKeyBytes = sectestdata.SSHPublicKeyBytes(kt, sectestdata.SSHKeyPublic)
 		privateKeyBytes := sectestdata.SSHPrivateKeyBytes(kt, sectestdata.SSHKeyPrivate)
 
-		ipub, ipriv, err = sshkeys.MarshalForImport(ctx, publicKeyBytes,
-			sshkeys.ImportUsingAgent(true))
+		ipub, ipriv, err = sshkeys.ImportAgentHostedKeyBytes(publicKeyBytes)
 		validatePublicKey(err, kt)
 
 		key, err := keyRegistrar.ParsePrivateKey(ctx, ipriv, nil)
@@ -75,15 +75,10 @@ func TestImport(t *testing.T) {
 			t.Fatalf("%v: parsed private key is not an ssh agent hosted key: %T", kt, key)
 		}
 
-		ipub, ipriv, err = sshkeys.MarshalForImport(ctx, publicKeyBytes,
-			sshkeys.ImportPrivateKeyBytes(privateKeyBytes, nil, nil))
-		validatePublicKey(err, kt)
-
-		key, err = keyRegistrar.ParsePrivateKey(ctx, ipriv, nil)
+		key, err = keyRegistrar.ParsePrivateKey(ctx, privateKeyBytes, nil)
 		validatePrivateKey(err, kt, key)
 
-		ipub, ipriv, err = sshkeys.MarshalForImport(ctx, publicKeyBytes,
-			sshkeys.ImportPrivateKeyFile("some-file-somewhere"))
+		ipriv, err = seclib.ImportPrivateKeyFile("some-file-somewhere")
 		validatePublicKey(err, kt)
 
 		// This will fail since the file is non-existent.
@@ -98,28 +93,11 @@ func TestImport(t *testing.T) {
 			t.Fatalf("%v: %v", kt, err)
 		}
 
-		ipub, ipriv, err = sshkeys.MarshalForImport(ctx, publicKeyBytes,
-			sshkeys.ImportPrivateKeyFile(filename))
-		validatePublicKey(err, kt)
+		ipriv, err = seclib.ImportPrivateKeyFile(filename)
 
 		key, err = keyRegistrar.ParsePrivateKey(ctx, ipriv, nil)
 		validatePrivateKey(err, kt, key)
 	}
-}
-
-func copyPassphrase(pp []byte) []byte {
-	n := make([]byte, len(pp))
-	copy(n, pp)
-	return n
-}
-
-func isZero(pp []byte) bool {
-	for _, v := range pp {
-		if v != 0 {
-			return false
-		}
-	}
-	return true
 }
 
 // This test is very similar to x509keys/x509_import_test.go - make sure to
@@ -127,50 +105,35 @@ func isZero(pp []byte) bool {
 func TestImportCopy(t *testing.T) {
 	ctx := context.Background()
 	for _, kt := range sectestdata.SupportedKeyAlgos {
-		publicKeyBytes := sectestdata.SSHPublicKeyBytes(kt, sectestdata.SSHKeyPublic)
 		privateKeyType, _ := sectestdata.CryptoType(kt)
 		for _, tc := range []struct {
-			set            sectestdata.SSHKeySetID
-			origPassphrase []byte
-			newPassphrase  []byte
+			set           sectestdata.SSHKeySetID
+			newPassphrase []byte
 		}{
-			{sectestdata.SSHKeyPrivate, nil, []byte("foobar")},
-			{sectestdata.SSHKeyEncrypted, sectestdata.Password(), nil},
-			{sectestdata.SSHKeyEncrypted, sectestdata.Password(), []byte("foobar")},
+			{sectestdata.SSHKeyPrivate, []byte("foobar")},
+			{sectestdata.SSHKeyPrivate, nil},
 		} {
 			privateKeyBytes := sectestdata.SSHPrivateKeyBytes(kt, tc.set)
+			privateKey, err := seclib.ParsePrivateKey(ctx, privateKeyBytes, nil)
 
-			origPassphrase := copyPassphrase(tc.origPassphrase)
-			newPassphrase := copyPassphrase(tc.newPassphrase)
-
-			_, ipriv, err := sshkeys.MarshalForImport(ctx, publicKeyBytes,
-				sshkeys.ImportPrivateKeyBytes(privateKeyBytes, origPassphrase, newPassphrase))
+			ipriv, err := seclib.MarshalPrivateKey(privateKey, tc.newPassphrase)
 			if err != nil {
-				t.Fatalf("%v: %v: passphrase %v - %v: %v", kt, tc.set, len(tc.origPassphrase) > 0, len(tc.newPassphrase) > 0, err)
-			}
-
-			if !isZero(origPassphrase) || !isZero(newPassphrase) {
-				t.Fatalf("%v: %v: failed to zero passphrase", kt, tc.set)
+				t.Fatalf("%v: %v: passphrase: %v", kt, tc.set, err)
 			}
 
 			if len(tc.newPassphrase) == 0 {
-				if got, want := ipriv, privateKeyBytes; !bytes.Equal(got, want) {
-					t.Fatalf("%v: %v: passphrase %v - %v: got %s, want %s", kt, tc.set, len(tc.origPassphrase) > 0, len(tc.newPassphrase) > 0, got, want)
+				if got, want := ipriv, "PRIVATE KEY"; !bytes.Contains(got, []byte(want)) {
+					t.Fatalf("%v: %v: passphrase: got %s, want %s", kt, tc.set, got, want)
 				}
 			} else {
 				if got, want := ipriv, "ENCRYPTED PRIVATE KEY"; !bytes.Contains(got, []byte(want)) {
-					t.Fatalf("%v: %v: passphrase %v - %v: got %s, want %s", kt, tc.set, len(tc.origPassphrase) > 0, len(tc.newPassphrase) > 0, got, want)
+					t.Fatalf("%v: %v: passphrase: got %s, want %s", kt, tc.set, got, want)
 				}
 			}
 
-			passphrase := tc.origPassphrase
-			if len(tc.newPassphrase) > 0 {
-				passphrase = tc.newPassphrase
-			}
-
-			key, err := keyRegistrar.ParsePrivateKey(ctx, ipriv, passphrase)
+			key, err := keyRegistrar.ParsePrivateKey(ctx, ipriv, tc.newPassphrase)
 			if err != nil {
-				t.Fatalf("%v: %v: passphrase %v - %v: %v", kt, tc.set, len(tc.origPassphrase) > 0, len(tc.newPassphrase) > 0, err)
+				t.Fatalf("%v: %v: passphrase: %v", kt, tc.set, err)
 			}
 
 			if got, want := reflect.TypeOf(key).String(), privateKeyType; got != want {
@@ -178,5 +141,4 @@ func TestImportCopy(t *testing.T) {
 			}
 		}
 	}
-
 }

--- a/x/ref/lib/security/keys/sshkeys/sshkeys.go
+++ b/x/ref/lib/security/keys/sshkeys/sshkeys.go
@@ -36,6 +36,13 @@ ecdsa-sha2-nistp384`
 	sshPrivateKeyPEMType = "OPENSSH PRIVATE KEY"
 )
 
+// Make the key functions local to this package available to this package.
+var keyRegistrar = keys.NewRegistrar()
+
+func init() {
+	MustRegister(keyRegistrar)
+}
+
 // MustRegister is like Register but panics on error.
 func MustRegister(r *keys.Registrar) {
 	if err := Register(r); err != nil {
@@ -65,6 +72,7 @@ func Register(r *keys.Registrar) error {
 	ecdsaKey, _ := parseAuthorizedKey([]byte(sshECDSA))
 	ed25519Key, _ := parseAuthorizedKey([]byte(sshED25519))
 	rsaKey, _ := parseAuthorizedKey([]byte(sshRSA))
+
 	if err := r.RegisterAPI((*sshkeyAPI)(nil), ecdsaKey, ed25519Key, rsaKey); err != nil {
 		return err
 	}

--- a/x/ref/lib/security/keys/x509keys/x509_import.go
+++ b/x/ref/lib/security/keys/x509keys/x509_import.go
@@ -7,66 +7,10 @@ package x509keys
 import (
 	"context"
 	"crypto/x509"
-	"fmt"
 
 	"v.io/x/ref/lib/security/keys"
-	"v.io/x/ref/lib/security/keys/indirectkeyfiles"
 	"v.io/x/ref/lib/security/keys/internal"
 )
-
-// ImportOption represents an option to MarshalForImport.
-type ImportOption func(o *internal.ImportOptions)
-
-// ImportPrivateKeyBytes will result in the supplied bytes being used
-// as the private key, that is, those bytes will be copied to the
-// Vanadium principal. If newPassphrase is provided the copied key will
-// be encrypted in pkcs8 format.
-func ImportPrivateKeyBytes(keyBytes []byte, origPassphrase, newPassphrase []byte) ImportOption {
-	return func(o *internal.ImportOptions) {
-		o.PrivateKeyBytes(keyBytes, origPassphrase, newPassphrase)
-	}
-}
-
-// ImportPrivateKeyFile will result in the private key in the specified
-// file being used. The Vanadium principal will refer to that file and
-// not copy it.
-func ImportPrivateKeyFile(filename string) ImportOption {
-	return func(o *internal.ImportOptions) {
-		o.PrivateKeyFile(filename)
-	}
-}
-
-// MarshalForImport will marshal the supplied public and private keys
-// according to the supplied option which specifies how the private key
-// is to imported.
-func MarshalForImport(ctx context.Context, publicKeyBytes []byte, option ImportOption) (importedPublicKeyBytes, importedPrivateKeyBytes []byte, err error) {
-	opts := internal.ImportOptions{}
-	option(&opts)
-	defer internal.ZeroPassphrases(opts.OrigPassphrase, opts.NewPassphrase)
-
-	// Read the first certificate and then re-encode just that one cert.
-	cert, err := parseFirstCertificate(publicKeyBytes)
-	if err != nil {
-		return nil, nil, err
-	}
-	publicKeyBytes, err = internal.EncodePEM("CERTIFICATE", cert.Raw, nil)
-
-	if filename := opts.KeyFilename; len(filename) > 0 {
-		privKeyBytes, err := indirectkeyfiles.MarshalPrivateKey([]byte(filename))
-		if err != nil {
-			return nil, nil, err
-		}
-		return publicKeyBytes, privKeyBytes, nil
-	}
-
-	if keyBytes := opts.KeyBytes; len(keyBytes) > 0 {
-		privKeyBytes, err := importPrivateKeyBytes(ctx, keyBytes,
-			opts.OrigPassphrase, opts.NewPassphrase)
-		return publicKeyBytes, privKeyBytes, err
-	}
-
-	return nil, nil, fmt.Errorf("no options were specified for how to import the private key")
-}
 
 func parseFirstCertificate(pemBytes []byte) (*x509.Certificate, error) {
 	block, err := internal.DecodePEM(pemBytes, "CERTIFICATE")

--- a/x/ref/lib/security/keys/x509keys/x509_import_test.go
+++ b/x/ref/lib/security/keys/x509keys/x509_import_test.go
@@ -84,7 +84,9 @@ func TestX509Import(t *testing.T) {
 		validatePrivateKey(err, kt, key)
 
 		ipriv, err = seclib.ImportPrivateKeyFile("some-file-somewhere")
-
+		if err != nil {
+			t.Fatal(err)
+		}
 		// This will fail since the file is non-existent.
 		_, err = keyRegistrar.ParsePrivateKey(ctx, ipriv, nil)
 		if err == nil || !strings.Contains(err.Error(), "no such file or directory") {

--- a/x/ref/lib/security/keys/x509keys/x509_import_test.go
+++ b/x/ref/lib/security/keys/x509keys/x509_import_test.go
@@ -120,7 +120,9 @@ func TestImportCopy(t *testing.T) {
 		} {
 			privateKeyBytes := sectestdata.X509PrivateKeyBytes(kt, tc.set)
 			privateKey, err := seclib.ParsePrivateKey(ctx, privateKeyBytes, nil)
-
+			if err != nil {
+				t.Fatalf("%v: %v", kt, err)
+			}
 			ipriv, err := seclib.MarshalPrivateKey(privateKey, tc.newPassphrase)
 			if err != nil {
 				t.Fatalf("%v: %v: passphrase: %v", kt, tc.set, err)

--- a/x/ref/lib/security/keys/x509keys/x509keys.go
+++ b/x/ref/lib/security/keys/x509keys/x509keys.go
@@ -20,6 +20,13 @@ import (
 	"v.io/x/ref/lib/security/keys"
 )
 
+// Make the key functions local to this package available to this package.
+var keyRegistrar = keys.NewRegistrar()
+
+func init() {
+	keys.MustRegister(keyRegistrar)
+}
+
 // MustRegister is like Register but panics on error.
 func MustRegister(r *keys.Registrar) {
 	if err := Register(r); err != nil {

--- a/x/ref/lib/security/keys/x509keys/x509keys_test.go
+++ b/x/ref/lib/security/keys/x509keys/x509keys_test.go
@@ -26,12 +26,9 @@ func init() {
 
 func TestX509Keys(t *testing.T) {
 	ctx := context.Background()
-
 	for _, kt := range sectestdata.SupportedKeyAlgos {
-		publicKeyBytes, privateKeyBytes, err := x509keys.MarshalForImport(ctx,
-			sectestdata.X509PublicKeyBytes(kt),
-			x509keys.ImportPrivateKeyBytes(sectestdata.X509PrivateKeyBytes(kt, sectestdata.X509Private), nil, nil),
-		)
+		privateKeyBytes := sectestdata.X509PrivateKeyBytes(kt, sectestdata.X509Private)
+		publicKeyBytes, err := x509keys.ImportPublicKeyBytes(sectestdata.X509PublicKeyBytes(kt))
 		if err != nil {
 			t.Fatalf("%v: %v", kt, err)
 		}

--- a/x/ref/lib/vdl/parse/grammar.y.go
+++ b/x/ref/lib/vdl/parse/grammar.y.go
@@ -9,13 +9,14 @@
 
 package parse
 
+import __yyfmt__ "fmt"
+
+//line grammar.y:20
+
 import (
-	__yyfmt__ "fmt"
 	"math/big"
 	"strings"
 )
-
-//line grammar.y:20
 
 type intPos struct {
 	int *big.Int


### PR DESCRIPTION
This PR deletes unnecessary code intended for importing existing existing keys when creating vanadium principals. The principal command is simplified to use CreatePrincipalOpts and can now use external ssh and ssl private keys, or copy them into the principal's credentials directory, as well as creating new keys and using private keys hosted in ssh agents.