### PR TITLE
x/ref/runtime/internal/rpc/test: add ED25519 and RSA signatures to the RPC protocol.

### DIFF
--- a/v23/flow/message/internal_message_test.go
+++ b/v23/flow/message/internal_message_test.go
@@ -100,3 +100,14 @@ func TestErrInvalidMessage(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }
+
+func ExposeSetAuthMessageType(m *Auth, ecdsa, ed25519, rsa bool) {
+	switch {
+	case ecdsa:
+		m.signatureType = authType
+	case ed25519:
+		m.signatureType = authED25519Type
+	case rsa:
+		m.signatureType = authRSAType
+	}
+}

--- a/v23/flow/message/message.go
+++ b/v23/flow/message/message.go
@@ -356,15 +356,15 @@ func (m *Auth) read(ctx *context.T, orig []byte) error {
 		if m.ChannelBinding.R, data, valid = readLenBytes(ctx, data); !valid {
 			return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 4, nil)
 		}
-		if m.ChannelBinding.S, _, valid = readLenBytes(ctx, data); !valid {
+		if m.ChannelBinding.S, _, _ = readLenBytes(ctx, data); !valid {
 			return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 5, nil)
 		}
 	case authED25519Type:
-		if m.ChannelBinding.Ed25519, data, valid = readLenBytes(ctx, data); !valid {
+		if m.ChannelBinding.Ed25519, _, _ = readLenBytes(ctx, data); !valid {
 			return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 4, nil)
 		}
 	case authRSAType:
-		if m.ChannelBinding.Rsa, data, valid = readLenBytes(ctx, data); !valid {
+		if m.ChannelBinding.Rsa, _, _ = readLenBytes(ctx, data); !valid {
 			return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 4, nil)
 		}
 	}

--- a/v23/flow/message/message.go
+++ b/v23/flow/message/message.go
@@ -39,8 +39,8 @@ func Read(ctx *context.T, from []byte) (Message, error) { //nolint:gocyclo
 		m = &EnterLameDuck{}
 	case ackLameDuckType:
 		m = &AckLameDuck{}
-	case authType:
-		m = &Auth{}
+	case authType, authED25519Type, authRSAType:
+		m = &Auth{signatureType: msgType}
 	case openFlowType:
 		m = &OpenFlow{}
 	case releaseType:
@@ -104,6 +104,8 @@ const (
 	healthCheckRequestType
 	healthCheckResponseType
 	proxyErrorReponseType
+	authED25519Type
+	authRSAType
 )
 
 // setup options.
@@ -298,20 +300,38 @@ func (m *AckLameDuck) read(ctx *context.T, data []byte) error {
 
 // auth is used to complete the auth handshake.
 type Auth struct {
+	signatureType              byte
 	BlessingsKey, DischargeKey uint64
 	ChannelBinding             security.Signature
 }
 
-func (m *Auth) append(ctx *context.T, data []byte) ([]byte, error) {
-	data = append(data, authType)
+func (m *Auth) appendCommon(data []byte) []byte {
 	data = writeVarUint64(m.BlessingsKey, data)
 	data = writeVarUint64(m.DischargeKey, data)
 	data = appendLenBytes(m.ChannelBinding.Purpose, data)
 	data = appendLenBytes([]byte(m.ChannelBinding.Hash), data)
-	data = appendLenBytes(m.ChannelBinding.R, data)
-	data = appendLenBytes(m.ChannelBinding.S, data)
+	return data
+}
+
+func (m *Auth) append(ctx *context.T, data []byte) ([]byte, error) {
+	switch {
+	case len(m.ChannelBinding.Ed25519) > 0:
+		data = append(data, authED25519Type)
+		data = m.appendCommon(data)
+		data = appendLenBytes(m.ChannelBinding.Ed25519, data)
+	case len(m.ChannelBinding.Rsa) > 0:
+		data = append(data, authRSAType)
+		data = m.appendCommon(data)
+		data = appendLenBytes(m.ChannelBinding.Rsa, data)
+	default:
+		data = append(data, authType)
+		data = m.appendCommon(data)
+		data = appendLenBytes(m.ChannelBinding.R, data)
+		data = appendLenBytes(m.ChannelBinding.S, data)
+	}
 	return data, nil
 }
+
 func (m *Auth) read(ctx *context.T, orig []byte) error {
 	var data, tmp []byte
 	var valid bool
@@ -331,11 +351,22 @@ func (m *Auth) read(ctx *context.T, orig []byte) error {
 		return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 3, nil)
 	}
 	m.ChannelBinding.Hash = security.Hash(tmp)
-	if m.ChannelBinding.R, data, valid = readLenBytes(ctx, data); !valid {
-		return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 4, nil)
-	}
-	if m.ChannelBinding.S, _, valid = readLenBytes(ctx, data); !valid {
-		return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 5, nil)
+	switch m.signatureType {
+	case authType:
+		if m.ChannelBinding.R, data, valid = readLenBytes(ctx, data); !valid {
+			return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 4, nil)
+		}
+		if m.ChannelBinding.S, _, valid = readLenBytes(ctx, data); !valid {
+			return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 5, nil)
+		}
+	case authED25519Type:
+		if m.ChannelBinding.Ed25519, data, valid = readLenBytes(ctx, data); !valid {
+			return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 4, nil)
+		}
+	case authRSAType:
+		if m.ChannelBinding.Rsa, data, valid = readLenBytes(ctx, data); !valid {
+			return NewErrInvalidMsg(ctx, openFlowType, uint64(len(orig)), 4, nil)
+		}
 	}
 	return nil
 }

--- a/v23/flow/message/message_test.go
+++ b/v23/flow/message/message_test.go
@@ -88,6 +88,9 @@ func TestAuth(t *testing.T) {
 	for _, kt := range sectestdata.SupportedKeyAlgos {
 		signer := sectestdata.V23Signer(kt, sectestdata.V23KeySetA)
 		p, err := security.CreatePrincipal(signer, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 		sig, err := p.Sign([]byte("message"))
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This PR adds the ability to use ED25519 and RSA keys to authenticate RPC. This requires extending the RPC auth message to carry the new signature types. This is done in a backwards compatible manner.

Tests are included for the expected errors for different combinations of crypto keys against the v0.1.20 release. ED25519 keys used by a server will lead to a client side protocol error. RSA keys cannot be loaded by earlier releases and such applications will fail when loading a principal that contains an RSA key as either a private key or when loading a RSA public key added as a blessing root.