### PR TITLE
x/ref/runtime/internal/rpc/test: add to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ test-integration:
 	go test \
 		v.io/x/ref/cmd/principal \
 		v.io/x/ref/runtime/internal \
+		v.io/x/ref/runtime/internal/rpc/test \
 		v.io/x/ref/services/xproxy/xproxyd \
 		v.io/x/ref/services/mounttable/mounttabled \
 		v.io/x/ref/services/debug/debug \


### PR DESCRIPTION
Add the backwards compatibility integration test to the top-level Makefile.