### PR TITLE
x/ref/lib/security/keys/sshkeys: fix racy test

### DIFF
--- a/x/ref/lib/security/keys/sshkeys/agent.go
+++ b/x/ref/lib/security/keys/sshkeys/agent.go
@@ -48,8 +48,8 @@ var DefaultSockNameFunc = func() string {
 type HostedKey struct {
 	publicKey  ssh.PublicKey
 	comment    string
-	passphrase []byte
 	agent      *Client
+	passphrase []byte
 }
 
 // Comment returns the comment associated with the original ssh public key.
@@ -82,7 +82,7 @@ func NewHostedKey(key ssh.PublicKey, comment string, passphrase []byte) *HostedK
 		passphrase: passphrase,
 	}
 	runtime.SetFinalizer(hk, func(k *HostedKey) {
-		keys.ZeroPassphrase(k.passphrase)
+		hk.zeroPassphrase()
 	})
 	return hk
 }
@@ -97,4 +97,18 @@ func (hk *HostedKey) Signer(ctx context.Context) (security.Signer, error) {
 // PublicKey returns the ssh.PublicKey associated with this sshagent hosted key.
 func (hk *HostedKey) PublicKey() ssh.PublicKey {
 	return hk.publicKey
+}
+
+func (hk *HostedKey) setPassphrase(passphrase []byte) {
+	if len(passphrase) == 0 {
+		return
+	}
+	hk.passphrase = passphrase
+}
+
+func (hk *HostedKey) zeroPassphrase() {
+	if len(hk.passphrase) == 0 {
+		return
+	}
+	keys.ZeroPassphrase(hk.passphrase)
 }

--- a/x/ref/lib/security/keys/sshkeys/agent.go
+++ b/x/ref/lib/security/keys/sshkeys/agent.go
@@ -73,7 +73,8 @@ func NewHostedKeyFile(publicKeyFile string, passphrase []byte) (*HostedKey, erro
 
 // NewHostedKey creates a connection to the users ssh agent in order to use the
 // private key corresponding to the supplied public for signing operations.
-// If supplied, the passphrase is used to unlock/lock the agent.
+// If supplied, the passphrase is used to unlock/lock the agent. The supplied passphrase
+// will be zeroed when the returned key is garbage collected.
 func NewHostedKey(key ssh.PublicKey, comment string, passphrase []byte) *HostedKey {
 	hk := &HostedKey{
 		publicKey:  key,
@@ -91,7 +92,7 @@ func NewHostedKey(key ssh.PublicKey, comment string, passphrase []byte) *HostedK
 // returned signer will retain a copy of any passphrase in ctx and will
 // zero that copy when it is itself garbage collected.
 func (hk *HostedKey) Signer(ctx context.Context) (security.Signer, error) {
-	return hk.agent.Signer(ctx, hk.publicKey, hk.passphrase)
+	return hk.agent.Signer(ctx, hk)
 }
 
 // PublicKey returns the ssh.PublicKey associated with this sshagent hosted key.

--- a/x/ref/lib/security/keys/sshkeys/agent.go
+++ b/x/ref/lib/security/keys/sshkeys/agent.go
@@ -48,8 +48,8 @@ var DefaultSockNameFunc = func() string {
 type HostedKey struct {
 	publicKey  ssh.PublicKey
 	comment    string
-	agent      *Client
 	passphrase []byte
+	agent      *Client
 }
 
 // Comment returns the comment associated with the original ssh public key.
@@ -101,6 +101,7 @@ func (hk *HostedKey) PublicKey() ssh.PublicKey {
 
 func (hk *HostedKey) setPassphrase(passphrase []byte) {
 	if len(passphrase) == 0 {
+		hk.passphrase = nil
 		return
 	}
 	hk.passphrase = passphrase

--- a/x/ref/lib/security/keys/sshkeys/agent.go
+++ b/x/ref/lib/security/keys/sshkeys/agent.go
@@ -81,7 +81,7 @@ func NewHostedKey(key ssh.PublicKey, comment string, passphrase []byte) *HostedK
 		agent:      NewClient(),
 		passphrase: passphrase,
 	}
-	runtime.SetFinalizer(hk, func(k *HostedKey) {
+	runtime.SetFinalizer(hk, func(hk *HostedKey) {
 		hk.zeroPassphrase()
 	})
 	return hk

--- a/x/ref/lib/security/keys/sshkeys/agent_client.go
+++ b/x/ref/lib/security/keys/sshkeys/agent_client.go
@@ -10,14 +10,12 @@ import (
 	"fmt"
 	"math/big"
 	"net"
-	"runtime"
 	"strings"
 	"sync"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"v.io/v23/security"
-	"v.io/x/ref/lib/security/keys"
 )
 
 // Client represents an ssh agent client.
@@ -112,11 +110,11 @@ func handleLock(client agent.ExtendedAgent, pw []byte) (func(err error) error, e
 // ssh agent. The passphrase is used to lock/unlock the ssh agent. The supplied
 // passphrase is not zeroed. A copy of the passphrase is made by the signer
 // and that is zeroed when the returned signer is garbage collected.
-func (ac *Client) Signer(ctx context.Context, key ssh.PublicKey, passphrase []byte) (sig security.Signer, err error) {
+func (ac *Client) Signer(ctx context.Context, hostedKey *HostedKey) (sig security.Signer, err error) {
 	if err := ac.connect(ctx); err != nil {
 		return nil, err
 	}
-	relock, err := handleLock(ac.agent, passphrase)
+	relock, err := handleLock(ac.agent, hostedKey.passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -124,13 +122,13 @@ func (ac *Client) Signer(ctx context.Context, key ssh.PublicKey, passphrase []by
 		err = relock(err)
 	}()
 
-	k, err := ac.lookup(key)
+	k, err := ac.lookup(hostedKey.publicKey)
 	if err != nil {
 		return nil, err
 	}
 	pk, err := ssh.ParsePublicKey(k.Marshal())
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse public key for %v: %v", key, err)
+		return nil, fmt.Errorf("failed to parse public key for %v: %v", hostedKey.publicKey, err)
 	}
 	var vpk security.PublicKey
 	var impl signImpl
@@ -151,19 +149,12 @@ func (ac *Client) Signer(ctx context.Context, key ssh.PublicKey, passphrase []by
 		return nil, err
 	}
 	s := &signer{
-		service: ac,
-		sshPK:   pk,
-		v23PK:   vpk,
-		key:     k,
-		name:    ssh.FingerprintSHA256(key),
-		impl:    impl,
-	}
-	if len(passphrase) > 0 {
-		s.passphrase = make([]byte, len(passphrase))
-		copy(s.passphrase, passphrase)
-		runtime.SetFinalizer(s, func(s *signer) {
-			keys.ZeroPassphrase(s.passphrase)
-		})
+		service:   ac,
+		hostedKey: hostedKey,
+		v23PK:     vpk,
+		key:       k,
+		name:      ssh.FingerprintSHA256(hostedKey.publicKey),
+		impl:      impl,
 	}
 	return s, nil
 }
@@ -193,14 +184,14 @@ func (ac *Client) lookup(key ssh.PublicKey) (*agent.Key, error) {
 	return nil, fmt.Errorf("key not found in ssh agent: %v ", ssh.FingerprintSHA256(key))
 }
 
-func ecdsaSign(ac *Client, sshPK ssh.PublicKey, v23PK, purpose, message []byte, name string) (security.Signature, error) {
-	digest, digestType, err := digestsForSSH(sshPK, v23PK, purpose, message)
+func ecdsaSign(sn *signer, v23PK, purpose, message []byte) (security.Signature, error) {
+	digest, digestType, err := digestsForSSH(sn.hostedKey.publicKey, v23PK, purpose, message)
 	if err != nil {
 		return security.Signature{}, fmt.Errorf("failed to generate message digesT: %v", err)
 	}
-	sig, err := ac.agent.Sign(sshPK, digest)
+	sig, err := sn.service.agent.Sign(sn.hostedKey.publicKey, digest)
 	if err != nil {
-		return security.Signature{}, fmt.Errorf("signature operation failed for %v: %v", name, err)
+		return security.Signature{}, fmt.Errorf("signature operation failed for %v: %v", sn.name, err)
 	}
 	var ecSig struct {
 		R, S *big.Int
@@ -216,14 +207,14 @@ func ecdsaSign(ac *Client, sshPK ssh.PublicKey, v23PK, purpose, message []byte, 
 	}, nil
 }
 
-func ed25519Sign(ac *Client, sshPK ssh.PublicKey, v23PK, purpose, message []byte, name string) (security.Signature, error) {
-	digest, digestType, err := hashedDigestsForSSH(sshPK, v23PK, purpose, message)
+func ed25519Sign(sn *signer, v23PK, purpose, message []byte) (security.Signature, error) {
+	digest, digestType, err := hashedDigestsForSSH(sn.hostedKey.publicKey, v23PK, purpose, message)
 	if err != nil {
 		return security.Signature{}, fmt.Errorf("failed to generate message digesT: %v", err)
 	}
-	sig, err := ac.agent.Sign(sshPK, digest)
+	sig, err := sn.service.agent.Sign(sn.hostedKey.publicKey, digest)
 	if err != nil {
-		return security.Signature{}, fmt.Errorf("signature operation failed for %v: %v", name, err)
+		return security.Signature{}, fmt.Errorf("signature operation failed for %v: %v", sn.name, err)
 	}
 	return security.Signature{
 		Purpose: purpose,
@@ -232,14 +223,14 @@ func ed25519Sign(ac *Client, sshPK ssh.PublicKey, v23PK, purpose, message []byte
 	}, nil
 }
 
-func rsaSign(ac *Client, sshPK ssh.PublicKey, v23PK, purpose, message []byte, name string) (security.Signature, error) {
-	digest, digestType, err := digestsForSSH(sshPK, v23PK, purpose, message)
+func rsaSign(sn *signer, v23PK, purpose, message []byte) (security.Signature, error) {
+	digest, digestType, err := digestsForSSH(sn.hostedKey.publicKey, v23PK, purpose, message)
 	if err != nil {
 		return security.Signature{}, fmt.Errorf("failed to generate message digesT: %v", err)
 	}
-	sig, err := ac.agent.SignWithFlags(sshPK, digest, agent.SignatureFlagRsaSha512)
+	sig, err := sn.service.agent.SignWithFlags(sn.hostedKey.publicKey, digest, agent.SignatureFlagRsaSha512)
 	if err != nil {
-		return security.Signature{}, fmt.Errorf("signature operation failed for %v: %v", name, err)
+		return security.Signature{}, fmt.Errorf("signature operation failed for %v: %v", sn.name, err)
 	}
 	return security.Signature{
 		Purpose: purpose,
@@ -248,33 +239,33 @@ func rsaSign(ac *Client, sshPK ssh.PublicKey, v23PK, purpose, message []byte, na
 	}, nil
 }
 
-type signImpl func(ac *Client, sshPK ssh.PublicKey, v23PK, purpose, message []byte, name string) (security.Signature, error)
+type signImpl func(sn *signer, v23PK, purpose, message []byte) (security.Signature, error)
 
 type signer struct {
-	service    *Client
-	passphrase []byte
-	name       string
-	sshPK      ssh.PublicKey
-	v23PK      security.PublicKey
-	key        *agent.Key
-	impl       signImpl
+	service   *Client
+	name      string
+	hostedKey *HostedKey
+	v23PK     security.PublicKey
+	key       *agent.Key
+	impl      signImpl
 }
 
 // Sign implements security.Signer.
-func (sn *signer) Sign(purpose, message []byte) (security.Signature, error) {
-	relock, err := handleLock(sn.service.agent, sn.passphrase)
+func (sn *signer) Sign(purpose, message []byte) (sig security.Signature, err error) {
+	relock, err := handleLock(sn.service.agent, sn.hostedKey.passphrase)
 	if err != nil {
-		return security.Signature{}, err
+		return
 	}
+	defer func() {
+		err = relock(err)
+	}()
 	keyBytes, err := sn.v23PK.MarshalBinary()
 	if err != nil {
-		return security.Signature{}, relock(fmt.Errorf("failed to marshal public key: %v", sn.v23PK))
+		err = fmt.Errorf("failed to marshal public key: %v", sn.v23PK)
+		return
 	}
-	sig, err := sn.impl(sn.service, sn.sshPK, keyBytes, purpose, message, sn.name)
-	if err != nil {
-		return security.Signature{}, relock(err)
-	}
-	return sig, relock(err)
+	sig, err = sn.impl(sn, keyBytes, purpose, message)
+	return
 }
 
 // PublicKey implements security.PublicKey.

--- a/x/ref/lib/security/keys/sshkeys/agent_test.go
+++ b/x/ref/lib/security/keys/sshkeys/agent_test.go
@@ -156,7 +156,7 @@ func TestAgentLocked(t *testing.T) {
 		if err := client.Lock(ctx, passphrase); err != nil {
 			t.Fatalf("%v: %v", kt, err)
 		}
-		// the passphrase will get zero'ed by the signer created by
+		// The passphrase will get zero'ed by the signer created by
 		// testAgent as well as by the Unlock function below. Common use
 		// is to rely on the agent client to lock/unlock the agent rather
 		// than doing so explicitly as in this test.

--- a/x/ref/lib/security/keys/sshkeys/agent_test.go
+++ b/x/ref/lib/security/keys/sshkeys/agent_test.go
@@ -157,12 +157,8 @@ func TestAgentLocked(t *testing.T) {
 			t.Fatalf("%v: %v", kt, err)
 		}
 		// The passphrase will get zero'ed by the signer created by
-		// testAgent as well as by the Unlock function below. Common use
-		// is to rely on the agent client to lock/unlock the agent rather
-		// than doing so explicitly as in this test.
-		passphraseCopy := make([]byte, len(passphrase))
-		copy(passphraseCopy, passphrase)
-		testAgent(ctx, t, kt, passphraseCopy)
+		// testAgent so use a copy to avoid interfering with Unlock below.
+		testAgent(ctx, t, kt, []byte("locked"))
 
 		err := getSigner(ctx, t, kt)
 		if err == nil || !strings.Contains(err.Error(), "key not found in ssh agent") {

--- a/x/ref/lib/security/keys/sshkeys/agent_test.go
+++ b/x/ref/lib/security/keys/sshkeys/agent_test.go
@@ -156,7 +156,13 @@ func TestAgentLocked(t *testing.T) {
 		if err := client.Lock(ctx, passphrase); err != nil {
 			t.Fatalf("%v: %v", kt, err)
 		}
-		testAgent(ctx, t, kt, passphrase)
+		// the passphrase will get zero'ed by the signer created by
+		// testAgent as well as by the Unlock function below. Common use
+		// is to rely on the agent client to lock/unlock the agent rather
+		// than doing so explicitly as in this test.
+		passphraseCopy := make([]byte, len(passphrase))
+		copy(passphraseCopy, passphrase)
+		testAgent(ctx, t, kt, passphraseCopy)
 
 		err := getSigner(ctx, t, kt)
 		if err == nil || !strings.Contains(err.Error(), "key not found in ssh agent") {

--- a/x/ref/lib/security/keys/sshkeys/sshkeys.go
+++ b/x/ref/lib/security/keys/sshkeys/sshkeys.go
@@ -227,12 +227,7 @@ type indirection struct {
 
 // Next implements keys.Indirection.
 func (i *indirection) Next(ctx context.Context, passphrase []byte) (crypto.PrivateKey, []byte) {
-	if len(passphrase) > 0 {
-		i.hostedKey.passphrase = make([]byte, len(passphrase))
-		copy(i.hostedKey.passphrase, passphrase)
-	} else {
-		i.hostedKey.passphrase = nil
-	}
+	i.hostedKey.setPassphrase(passphrase)
 	return i.hostedKey, nil
 }
 


### PR DESCRIPTION
There was a rare race between zeroing out the passphrase stored in the ssh agent signer implementations via its finalizer and it being used by the signer implementation in a deferred function. This PR simplifies this logic and hopefully avoids the race by not having the signer zero out the passphrase, rather, it keeps a reference to the HostedKey which creates the signer and accesses the passphrase directly from that key.