### PR TITLE
x/ref/lib/security/keys/sshkeys: fix racy test again

### DIFF
--- a/x/ref/lib/security/keys/sshkeys/agent.go
+++ b/x/ref/lib/security/keys/sshkeys/agent.go
@@ -7,7 +7,6 @@ package sshkeys
 import (
 	"context"
 	"os"
-	"runtime"
 
 	"golang.org/x/crypto/ssh"
 	"v.io/v23/security"
@@ -58,7 +57,7 @@ func (hk *HostedKey) Comment() string {
 }
 
 // NewHostedKeyFile calls NewHostedKey with the contents of the specified
-// file
+// file.
 func NewHostedKeyFile(publicKeyFile string, passphrase []byte) (*HostedKey, error) {
 	keyBytes, err := os.ReadFile(publicKeyFile)
 	if err != nil {
@@ -73,19 +72,17 @@ func NewHostedKeyFile(publicKeyFile string, passphrase []byte) (*HostedKey, erro
 
 // NewHostedKey creates a connection to the users ssh agent in order to use the
 // private key corresponding to the supplied public for signing operations.
-// If supplied, the passphrase is used to unlock/lock the agent. The supplied passphrase
-// will be zeroed when the returned key is garbage collected.
+// The passphrase, if supplied, is used to unlock/lock the agent. Note that
+// the passphrase for unlocking/locking the agent may also be obtained indirectly
+// when the PEM encoding of the private key is parsed via keys.ParsePrivateKey
+// for example. The passphrase is not zeroed.
 func NewHostedKey(key ssh.PublicKey, comment string, passphrase []byte) *HostedKey {
-	hk := &HostedKey{
+	return &HostedKey{
 		publicKey:  key,
 		comment:    comment,
 		agent:      NewClient(),
 		passphrase: passphrase,
 	}
-	runtime.SetFinalizer(hk, func(hk *HostedKey) {
-		hk.zeroPassphrase()
-	})
-	return hk
 }
 
 // Signer returns a security.Signer that is hosted by an ssh agent. The

--- a/x/ref/lib/security/keys/sshkeys/agent.go
+++ b/x/ref/lib/security/keys/sshkeys/agent.go
@@ -10,7 +10,6 @@ import (
 
 	"golang.org/x/crypto/ssh"
 	"v.io/v23/security"
-	"v.io/x/ref/lib/security/keys"
 )
 
 type internalKey int
@@ -103,11 +102,4 @@ func (hk *HostedKey) setPassphrase(passphrase []byte) {
 		return
 	}
 	hk.passphrase = passphrase
-}
-
-func (hk *HostedKey) zeroPassphrase() {
-	if len(hk.passphrase) == 0 {
-		return
-	}
-	keys.ZeroPassphrase(hk.passphrase)
 }

--- a/x/ref/lib/security/keys/sshkeys/agent_client.go
+++ b/x/ref/lib/security/keys/sshkeys/agent_client.go
@@ -107,9 +107,7 @@ func handleLock(client agent.ExtendedAgent, pw []byte) (func(err error) error, e
 }
 
 // Signer creates a new security.Signer for a private key that's hosted in the
-// ssh agent. The passphrase is used to lock/unlock the ssh agent. The supplied
-// passphrase is not zeroed. A copy of the passphrase is made by the signer
-// and that is zeroed when the returned signer is garbage collected.
+// ssh agent.
 func (ac *Client) Signer(ctx context.Context, hostedKey *HostedKey) (sig security.Signer, err error) {
 	if err := ac.connect(ctx); err != nil {
 		return nil, err


### PR DESCRIPTION
It seems too complicated to zero the agent passphrase automatically without creating a race. Consequently, the sshkeys package no longer attempts to zero the passphrase. This is not so bad since the passphrase is used to unlock/lock the ssh-agent and can be changed easily and frequently and is, in any case, only of value when agent forwarding is used. As more experience is gained with using different types of agent (eg. ones hosted in a Secure Enclave) the handling of the passphrase may also change.