### PR TITLE
update README.md

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: integration-tests
           command: |
-            make test-integration
+            make test-integration test-openssl-integration
 
   lint:
     parameters:

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ test-integration:
 		v.io/x/ref/examples/tunnel/tunneld \
 		v.io/x/ref/examples/rps/rpsbot \
 		--v23.tests
+
+test-openssl-integration:
+	@echo "VDLPATH" "${VDLPATH}"
 	go test v.io/v23/security/... -tags openssl
 	go test v.io/x/ref/lib/security/... -tags openssl
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,44 @@
 An easy-to-use secure RPC system with flexible service discovery. See the
 Vanadium [site](https://v.io) for more details, remembering that this repository
 implements RPC, security and naming; it does not provide support for mobile
-development.
+development nor for syncbase.
 
-## Install steps
+## Developing Using Vanadium Core
+
+Vanadium Core is a ```go``` module named ```v.io``` and hence packages are
+imported as ```v.io/...``` (eg. ```v.io/v23/security```) even though the source
+code repository is hosted on [github](https://github.com/vanadium/core).
+
+The associated Vanadium Library (```v.io\x\lib```) is available on
+[github](https://github.com/vanadium/go.lib).
+
+Either can be used directly as ```go``` modules.
+
+A single environment variable VDLPATH is required to run the go tests that
+use the VDL language and code generation, it should be set to the directory
+that contains the ```go.mod``` for Vanadium Core. Note, that this is only
+required for running the VDL code generator and that Vanadium applications
+do not require VDLPATH for their correct operation.
+
+## Installation Steps For Contributors
 
 ```
-go get -t v.io/...
-go test v.io/...
+git clone https://github.com/vanadium/core.git
+export VDLPATH=$(pwd)/core
+cd core
+make test test-integration
 ```
+
+Vanadium Core is capable of using ```openssl``` for various low level cyrographic operations but this is no way required for correct or performant operation. 
+
+To use ```openssl``` a build tag is required (```--tag=openssl```) and the
+```PKG_CONFIG_PATH``` environment variable must be set. For example on an a MacO
+machine using ```brew```:
+
+```
+export PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig"
+```
+
+There is an integration test for ```openssl``` support: ```make test-openssl-integration```.
+
+

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 # Vanadium Core
 
 An easy-to-use secure RPC system with flexible service discovery. See the
-Vanadium [site](https://v.io) for more details, remembering that this repository
+Vanadium [v.io](https://v.io) for more details, remembering that this repository
 implements RPC, security and naming; it does not provide support for mobile
-development nor for syncbase.
+development nor for syncbase as described at [v.io](https://v.io). The tutorials
+on 'Client/Server Basics', 'Security' and 'Naming' are all still current whereas
+the ones on 'Syncbase' and 'Java' will no longer work directly.
 
 ## Developing Using Vanadium Core
 
@@ -14,16 +16,21 @@ Vanadium Core is a ```go``` module named ```v.io``` and hence packages are
 imported as ```v.io/...``` (eg. ```v.io/v23/security```) even though the source
 code repository is hosted on [github](https://github.com/vanadium/core).
 
-The associated Vanadium Library (```v.io\x\lib```) is available on
+The associated Vanadium Library (```v.io/x/lib```) is available on
 [github](https://github.com/vanadium/go.lib).
 
 Either can be used directly as ```go``` modules.
 
-A single environment variable VDLPATH is required to run the go tests that
-use the VDL language and code generation, it should be set to the directory
+A single environment variable ```VDLPATH``` is required to run the go tests that
+use the VDL language and code generation; it should be set to the directory
 that contains the ```go.mod``` for Vanadium Core. Note, that this is only
 required for running the VDL code generator and that Vanadium applications
 do not require VDLPATH for their correct operation.
+
+## Using Vanadium Commands and Services
+
+All Vanadium Core commands and services can be run using regular ```go``` toolchain
+commands, eg: ```go run v.io/x/ref/cmd/principal --help```.
 
 ## Installation Steps For Contributors
 
@@ -34,15 +41,20 @@ cd core
 make test test-integration
 ```
 
-Vanadium Core is capable of using ```openssl``` for various low level cyrographic operations but this is no way required for correct or performant operation. 
+Vanadium Core is capable of using optionally using ```openssl``` for various low level
+cyrographic operations; this is purely optionaly and is not required for correct or
+performant operation. It's primarily intended to demonstrate interoperability and
+to take advantage of more optimized implementations on some systems.
 
 To use ```openssl``` a build tag is required (```--tag=openssl```) and the
-```PKG_CONFIG_PATH``` environment variable must be set. For example on an a MacO
-machine using ```brew```:
+```PKG_CONFIG_PATH``` environment variable must be set. For example on an
+a MacOS system using ```brew```:
 
 ```
 export PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig"
 ```
+
+Note that ```openssl``` version 3 and above is required.
 
 There is an integration test for ```openssl``` support: ```make test-openssl-integration```.
 


### PR DESCRIPTION
Update the top level README.md to be more informative and up to date. Also, break out the openssl integration test into its own make target.