### PR TITLE
x/ref/lib/security: enable use of x509 certs as public keys and add more tests for creating principals

### DIFF
--- a/v23/security/principal.go
+++ b/v23/security/principal.go
@@ -5,6 +5,7 @@
 package security
 
 import (
+	"crypto/x509"
 	"fmt"
 	"reflect"
 	"time"
@@ -33,6 +34,13 @@ func CreatePrincipal(signer Signer, store BlessingStore, roots BlessingRoots) (P
 		return nil, fmt.Errorf("store's public key: %v does not match signer's public key: %v", got, want)
 	}
 	return &principal{signer: signer, store: store, roots: roots}, nil
+}
+
+// CreateX509Principal is like CreatePrincipal except that it associates the
+// the specified x509 Certificate with the newly created Principal which
+// controls how BlessSelf behaves.
+func CreateX509Principal(signer Signer, cert *x509.Certificate, store BlessingStore, roots BlessingRoots) (Principal, error) {
+	return CreatePrincipal(signer, store, roots)
 }
 
 // CreatePrincipalPublicKeyOnly returns a Principal that cannot sign new blessings

--- a/x/ref/lib/security/create_principal_opts.go
+++ b/x/ref/lib/security/create_principal_opts.go
@@ -226,12 +226,10 @@ func (o createPrincipalOptions) createPersistentPrincipal(ctx context.Context) (
 		return nil, err
 	}
 	publicKeyBytes, privateKeyBytes := o.publicKeyBytes, o.privateKeyBytes
-	if len(privateKeyBytes) == 0 {
-		if o.privateKey != nil {
-			privateKeyBytes, err = keyRegistrar.MarshalPrivateKey(o.privateKey, o.passphrase)
-			if err != nil {
-				return nil, err
-			}
+	if len(privateKeyBytes) == 0 && o.privateKey != nil {
+		privateKeyBytes, err = keyRegistrar.MarshalPrivateKey(o.privateKey, o.passphrase)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -248,10 +246,6 @@ func (o createPrincipalOptions) createPersistentPrincipal(ctx context.Context) (
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if len(publicKeyBytes) == 0 {
-		return nil, fmt.Errorf("cannot create a new persistent principal without a public key")
 	}
 
 	unlock, err := o.store.Lock(ctx, LockKeyStore)

--- a/x/ref/lib/security/keyfile_util.go
+++ b/x/ref/lib/security/keyfile_util.go
@@ -63,19 +63,3 @@ func publicKeyFromBytes(publicKeyBytes []byte) (security.PublicKey, error) {
 	publicKey, err := api.PublicKey(key)
 	return publicKey, err
 }
-
-func signerFromKey(ctx context.Context, private crypto.PrivateKey) (security.Signer, error) {
-	api, err := keyRegistrar.APIForKey(private)
-	if err != nil {
-		return nil, err
-	}
-	return api.Signer(ctx, private)
-}
-
-func signerFromBytes(ctx context.Context, privateKeyBytes, passphrase []byte) (security.Signer, error) {
-	privateKey, err := keyRegistrar.ParsePrivateKey(ctx, privateKeyBytes, passphrase)
-	if err != nil {
-		return nil, err
-	}
-	return signerFromKey(ctx, privateKey)
-}

--- a/x/ref/lib/security/keys/x509keys/x509keys.go
+++ b/x/ref/lib/security/keys/x509keys/x509keys.go
@@ -18,6 +18,7 @@ import (
 
 	"v.io/v23/security"
 	"v.io/x/ref/lib/security/keys"
+	"v.io/x/ref/lib/security/keys/internal"
 )
 
 // Make the key functions local to this package available to this package.
@@ -38,6 +39,7 @@ func MustRegister(r *keys.Registrar) {
 // private key files via the x/ref/security/keys package.
 func Register(r *keys.Registrar) error {
 	r.RegisterPublicKeyParser(parseCertificateBlock, "CERTIFICATE", nil)
+	r.RegisterPublicKeyMarshaler(marshalCertificate, (*x509.Certificate)(nil))
 	return r.RegisterAPI((*x509CertAPI)(nil), (*x509.Certificate)(nil))
 }
 
@@ -81,4 +83,12 @@ func parseCertificateBlock(block *pem.Block) (crypto.PublicKey, error) {
 		return nil, err
 	}
 	return cert, err
+}
+
+func marshalCertificate(key crypto.PublicKey) ([]byte, error) {
+	cert, ok := key.(*x509.Certificate)
+	if !ok {
+		return nil, fmt.Errorf("x509keys.marshalCertificate: unsupported key type %T", key)
+	}
+	return internal.EncodePEM("CERTIFICATE", cert.Raw, nil)
 }

--- a/x/ref/lib/security/options.go
+++ b/x/ref/lib/security/options.go
@@ -307,7 +307,7 @@ func WithX509VerifyOptions(opts x509.VerifyOptions) CreatePrincipalOption {
 	}
 }
 
-// WithX509Certificate specifices the x509 Certificate to associate with
+// WithX509Certificate specifies the x509 Certificate to associate with
 // this Principal. It is generally used to associate an x509 Certificate
 // with a Principal created from a signer or private key directly rather than
 // via WithPublicKeyBytes or WithPrivateKeyBytes.

--- a/x/ref/lib/security/principal.go
+++ b/x/ref/lib/security/principal.go
@@ -97,7 +97,7 @@ func LoadPersistentPrincipalDaemon(ctx context.Context, dir string, passphrase [
 	opts = append(opts,
 		FromPassphrase(passphrase),
 		RefreshInterval(update),
-		FromPublicKey(true))
+		FromPublicKeyOnly(true))
 	return LoadPrincipalOpts(ctx, opts...)
 }
 

--- a/x/ref/lib/security/principal_opts_test.go
+++ b/x/ref/lib/security/principal_opts_test.go
@@ -1,0 +1,180 @@
+// Copyright 2022 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package security
+
+import (
+	"context"
+	"crypto"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"v.io/v23/security"
+	"v.io/x/ref/lib/security/keys"
+	"v.io/x/ref/test/sectestdata"
+)
+
+type principalOptValues struct {
+	signer          security.Signer
+	privateKey      crypto.PrivateKey
+	publicKeyBytes  []byte
+	privateKeyBytes []byte
+}
+
+func v23Data(kt keys.CryptoAlgo) principalOptValues {
+	return principalOptValues{
+		signer:          sectestdata.V23Signer(kt, sectestdata.V23KeySetA),
+		privateKey:      sectestdata.V23PrivateKey(kt, sectestdata.V23KeySetA),
+		publicKeyBytes:  sectestdata.V23PublicKeyBytes(kt, sectestdata.V23KeySetA),
+		privateKeyBytes: sectestdata.V23PrivateKeyBytes(kt, sectestdata.V23KeySetA),
+	}
+}
+
+func sslData(kt keys.CryptoAlgo) principalOptValues {
+	return principalOptValues{
+		signer:          sectestdata.X509Signer(kt),
+		privateKey:      sectestdata.X509PrivateKey(kt),
+		publicKeyBytes:  sectestdata.X509PublicKeyBytes(kt),
+		privateKeyBytes: sectestdata.X509PrivateKeyBytes(kt, sectestdata.X509Private),
+	}
+}
+
+func checkPEM(keyfile, blockType string) error {
+	data, err := os.ReadFile(keyfile)
+	if err != nil {
+		return err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return fmt.Errorf("failed to decode PEM block in: %s", data)
+	}
+	if got, want := block.Type, blockType; got != want {
+		return fmt.Errorf("got %v, want %v", got, want)
+	}
+	return nil
+}
+
+func newStoreOpt(t *testing.T) (string, CreatePrincipalOption) {
+	dir := t.TempDir()
+	store, err := CreateFilesystemStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, WithStore(store)
+}
+
+func TestCreatePrincipalOpts(t *testing.T) {
+	ctx := context.Background()
+	msg := []byte("hi there")
+	for i, tc := range []struct {
+		vals       principalOptValues
+		publicPEM  []string
+		privatePEM []string
+	}{
+		{v23Data(keys.ECDSA256), []string{
+			"PUBLIC KEY",
+			"PUBLIC KEY",
+			"PUBLIC KEY",
+		}, []string{
+			"PRIVATE KEY",
+			"EC PRIVATE KEY",
+			"EC PRIVATE KEY",
+		}},
+		{sslData(keys.ED25519), []string{
+			"PUBLIC KEY",
+			"PUBLIC KEY",
+			"CERTIFICATE",
+		}, []string{
+			"PRIVATE KEY",
+			"PRIVATE KEY",
+			"PRIVATE KEY",
+		}},
+	} {
+
+		p, err := CreatePrincipalOpts(ctx, WithSigner(tc.vals.signer))
+		if err != nil {
+			t.Fatalf("%v: %v", i, err)
+		}
+		sig, err := p.Sign(msg)
+		if err != nil {
+			t.Fatalf("%v: %v", i, err)
+		}
+		if !sig.Verify(p.PublicKey(), msg) {
+			t.Fatalf("%v: verify failed", i)
+		}
+
+		dir, storeOpt := newStoreOpt(t)
+		_, err = CreatePrincipalOpts(ctx, WithSigner(tc.vals.signer), storeOpt)
+		if err == nil || !strings.Contains(err.Error(), "cannot create a new persistent principal without a private key") {
+			t.Fatalf("missing or incorrect error: %q", err)
+		}
+		_, err = CreatePrincipalOpts(ctx, WithPublicKeyBytes(tc.vals.publicKeyBytes), storeOpt)
+		if err == nil || !strings.Contains(err.Error(), "cannot create a new persistent principal without a private key") {
+			t.Fatalf("missing or incorrect error: %q", err)
+		}
+
+		_, err = CreatePrincipalOpts(ctx, WithPublicKeyBytes(tc.vals.publicKeyBytes), storeOpt, WithPublicKeyOnly(true))
+		if err != nil {
+			t.Fatalf("%v: %v", i, err)
+		}
+
+		_, err = LoadPrincipalOpts(ctx, FromReadonly(FilesystemStoreReader(dir)))
+		if err == nil || !strings.Contains(err.Error(), "no such file or directory") {
+			t.Fatalf("missing or incorrect error: %q", err)
+		}
+
+		_, err = LoadPrincipalOpts(ctx, FromReadonly(FilesystemStoreReader(dir)), FromPublicKeyOnly(true))
+		if err != nil {
+			t.Fatalf("%v: %v", i, err)
+		}
+
+		for j, opt := range []CreatePrincipalOption{
+			WithPrivateKey(tc.vals.privateKey, nil),
+			WithPrivateKeyBytes(ctx, nil, tc.vals.privateKeyBytes, nil),
+			WithPrivateKeyBytes(ctx, tc.vals.publicKeyBytes, tc.vals.privateKeyBytes, nil),
+		} {
+			p, err := CreatePrincipalOpts(ctx, opt)
+			if err != nil {
+				t.Fatalf("%v: %v: %v", i, j, err)
+			}
+			sig, err := p.Sign(msg)
+			if err != nil {
+				t.Fatalf("%v: %v: %v", i, j, err)
+			}
+			if !sig.Verify(p.PublicKey(), msg) {
+				t.Fatalf("%v: %v: verify failed", i, j)
+			}
+			dir, storeOpt := newStoreOpt(t)
+			pp, err := CreatePrincipalOpts(ctx, opt, storeOpt)
+			if err != nil {
+				t.Fatalf("%v: %v: %v", i, j, err)
+			}
+			lp, err := LoadPrincipalOpts(ctx, FromReadonly(FilesystemStoreReader(dir)))
+			if err != nil {
+				t.Fatalf("%v: %v: %v", i, j, err)
+			}
+			if got, want := lp.PublicKey().String(), pp.PublicKey().String(); got != want {
+				t.Fatalf("%v: %v: got %v, want %v", i, j, got, want)
+			}
+			sig, err = lp.Sign(msg)
+			if err != nil {
+				t.Fatalf("%v: %v: %v", i, j, err)
+			}
+			if !sig.Verify(p.PublicKey(), msg) {
+				t.Fatalf("%v: %v: verify failed", i, j)
+			}
+			if err := checkPEM(filepath.Join(dir, publicKeyFile), tc.publicPEM[j]); err != nil {
+				t.Errorf("%v: %v: %v", i, j, err)
+			}
+			if err := checkPEM(filepath.Join(dir, privateKeyFile), tc.privatePEM[j]); err != nil {
+				t.Errorf("%v: %v: %v", i, j, err)
+			}
+		}
+
+	}
+}

--- a/x/ref/lib/security/principal_opts_test.go
+++ b/x/ref/lib/security/principal_opts_test.go
@@ -15,8 +15,10 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/crypto/ssh"
 	"v.io/v23/security"
 	"v.io/x/ref/lib/security/keys"
+	"v.io/x/ref/lib/security/keys/sshkeys"
 	"v.io/x/ref/test/sectestdata"
 )
 
@@ -55,9 +57,10 @@ func sshData(kt keys.CryptoAlgo) principalOptValues {
 }
 
 func sshAgentData(kt keys.CryptoAlgo) principalOptValues {
+	pk := sectestdata.SSHPublicKey(kt)
 	return principalOptValues{
 		signer:          sectestdata.SSHKeySigner(kt, sectestdata.SSHKeyPrivate),
-		privateKey:      sectestdata.SSHPrivateKey(kt, sectestdata.SSHKeyAgentHosted),
+		privateKey:      sshkeys.NewHostedKey(pk.(ssh.PublicKey), kt.String(), nil),
 		publicKeyBytes:  sectestdata.SSHPublicKeyBytes(kt, sectestdata.SSHKeyPublic),
 		privateKeyBytes: sectestdata.SSHPrivateKeyBytes(kt, sectestdata.SSHKeyPrivate),
 	}

--- a/x/ref/test/sectestdata/data_test.go
+++ b/x/ref/test/sectestdata/data_test.go
@@ -11,7 +11,6 @@ import (
 func TestSSHKeys(t *testing.T) {
 	for _, kt := range SupportedKeyAlgos {
 		for _, set := range []SSHKeySetID{
-			SSHKeyAgentHosted,
 			SSHKeyPublic} {
 			publicKey := SSHPublicKeyBytes(kt, set)
 			if len(publicKey) == 0 {
@@ -20,9 +19,6 @@ func TestSSHKeys(t *testing.T) {
 		}
 		for _, set := range []SSHKeySetID{
 			SSHKeyPrivate,
-			// TODO(cnicolaou): enabled this once the handling of ssh public
-			//                  keys is cleaned up.
-			// SSHKeyAgentHosted,
 		} {
 			signer := SSHKeySigner(kt, set)
 			if signer == nil {

--- a/x/ref/test/sectestdata/ssh.go
+++ b/x/ref/test/sectestdata/ssh.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"v.io/v23/security"
 	"v.io/x/ref/lib/security/keys"
+	"v.io/x/ref/lib/security/keys/sshkeys"
 	"v.io/x/ref/test/testutil/testsshagent"
 )
 
@@ -124,9 +125,8 @@ func SSHPrivateKey(typ keys.CryptoAlgo, set SSHKeySetID) crypto.PrivateKey {
 		}
 		return key
 	case SSHKeyAgentHosted:
-		// TODO(cnicolaou): implement this once the ssh public key handling
-		//                  is cleaned up.
-		return nil
+		pk := SSHPublicKey(typ)
+		return sshkeys.NewHostedKey(pk.(ssh.PublicKey), typ.String(), nil)
 	default:
 		panic(fmt.Sprintf("unsupported key set %v", set))
 	}

--- a/x/ref/test/sectestdata/ssh.go
+++ b/x/ref/test/sectestdata/ssh.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/crypto/ssh"
 	"v.io/v23/security"
 	"v.io/x/ref/lib/security/keys"
-	"v.io/x/ref/lib/security/keys/sshkeys"
 	"v.io/x/ref/test/testutil/testsshagent"
 )
 
@@ -33,7 +32,6 @@ type SSHKeySetID int
 const (
 	SSHKeyPrivate SSHKeySetID = iota
 	SSHKeyPublic
-	SSHKeyAgentHosted
 	SSHKeySetPKCS8
 	SSHKeyEncrypted
 )
@@ -99,8 +97,6 @@ func sshFilename(typ keys.CryptoAlgo, set SSHKeySetID) string {
 		return "ssh-" + typ.String() + ".pub"
 	case SSHKeySetPKCS8:
 		return "ssh-" + typ.String() + ".pem"
-	case SSHKeyAgentHosted:
-		return "ssh-" + typ.String() + ".pub"
 	}
 	panic(fmt.Sprintf("unrecognised key set: %v", set))
 }
@@ -124,9 +120,7 @@ func SSHPrivateKey(typ keys.CryptoAlgo, set SSHKeySetID) crypto.PrivateKey {
 			return *k
 		}
 		return key
-	case SSHKeyAgentHosted:
-		pk := SSHPublicKey(typ)
-		return sshkeys.NewHostedKey(pk.(ssh.PublicKey), typ.String(), nil)
+
 	default:
 		panic(fmt.Sprintf("unsupported key set %v", set))
 	}


### PR DESCRIPTION
This PR enables using x509 certificates as public keys. It also fixes some inconsistencies in how options to lib/security.CreatePrincipalOpts are handled and now has a clear precedence order for options. More tests for that use CreatePrincipalOpts are added.