### PR TITLE
x/ref/lib/security: allow for LoadPrincipalOpts to use custom blessing store and blessing roots.

### DIFF
--- a/v23/security/publickey.go
+++ b/v23/security/publickey.go
@@ -80,12 +80,12 @@ type publicKeyCommon struct {
 }
 
 func newPublicKeyCommon(key interface{}, hash Hash) publicKeyCommon {
-	kb, kbe := x509.MarshalPKIXPublicKey(key)
+	kb, err := x509.MarshalPKIXPublicKey(key)
 	return publicKeyCommon{
 		vhash:       hash,
 		chash:       cryptoHash(hash),
 		keyBytes:    kb,
-		keyBytesErr: kbe,
+		keyBytesErr: err,
 	}
 }
 

--- a/x/ref/lib/security/blessingstore.go
+++ b/x/ref/lib/security/blessingstore.go
@@ -307,7 +307,7 @@ func newBlessingStore(ctx context.Context, publicKey security.PublicKey) securit
 // NewBlessingStore returns an implementation of security.BlessingStore
 // according to the supplied options.
 // If no options are supplied all state is kept in memory.
-func NewBlessingStoreOpts(ctx context.Context, publicKey security.PublicKey, opts ...BlessingsStoreOption) (security.BlessingStore, error) {
+func NewBlessingStoreOpts(ctx context.Context, publicKey security.PublicKey, opts ...BlessingStoreOption) (security.BlessingStore, error) {
 	var o blessingsStoreOptions
 	for _, fn := range opts {
 		fn(&o)

--- a/x/ref/lib/security/create_principal_opts.go
+++ b/x/ref/lib/security/create_principal_opts.go
@@ -176,7 +176,7 @@ func (o createPrincipalOptions) createInMemoryPrincipal(ctx context.Context) (se
 	if signer != nil {
 		return security.CreateX509Principal(signer, x509Cert, bs, br)
 	}
-	if publicKey != nil {
+	if publicKey != nil && o.allowPublicKey {
 		return security.CreatePrincipalPublicKeyOnly(publicKey, bs, br)
 	}
 	return nil, fmt.Errorf("no signer/private key or public key information provided")

--- a/x/ref/lib/security/create_principal_opts.go
+++ b/x/ref/lib/security/create_principal_opts.go
@@ -187,9 +187,13 @@ func (o createPrincipalOptions) getBlessingStore(ctx context.Context, publicKey 
 		return o.blessingStore, nil
 	}
 	if signer != nil {
-		return NewBlessingStoreOpts(ctx, publicKey, BlessingStoreWriteable(o.store, signer))
+		return NewBlessingStoreOpts(ctx,
+			publicKey,
+			BlessingStoreWriteable(o.store, signer))
 	}
-	return NewBlessingStoreOpts(ctx, publicKey, BlessingStoreReadonly(o.store, publicKey))
+	return NewBlessingStoreOpts(ctx,
+		publicKey,
+		BlessingStoreReadonly(o.store, publicKey))
 }
 
 func (o createPrincipalOptions) getBlessingRoots(ctx context.Context, publicKey security.PublicKey, signer security.Signer) (security.BlessingRoots, error) {
@@ -197,9 +201,11 @@ func (o createPrincipalOptions) getBlessingRoots(ctx context.Context, publicKey 
 		return o.blessingRoots, nil
 	}
 	if signer != nil {
-		return NewBlessingRootsOpts(ctx, BlessingRootsWriteable(o.store, signer))
+		return NewBlessingRootsOpts(ctx,
+			BlessingRootsWriteable(o.store, signer))
 	}
-	return NewBlessingRootsOpts(ctx, BlessingRootsReadonly(o.store, publicKey))
+	return NewBlessingRootsOpts(ctx,
+		BlessingRootsReadonly(o.store, publicKey))
 }
 
 func (o createPrincipalOptions) createPersistentPrincipal(ctx context.Context) (security.Principal, error) {
@@ -245,7 +251,7 @@ func (o createPrincipalOptions) createPersistentPrincipal(ctx context.Context) (
 		return nil, err
 	}
 
-	// One of publicKey or signer will be nil.
+	// signer may be nil for a public key only principal.
 	bs, err := o.getBlessingStore(ctx, publicKey, signer)
 	if err != nil {
 		return nil, err
@@ -254,11 +260,7 @@ func (o createPrincipalOptions) createPersistentPrincipal(ctx context.Context) (
 	if err != nil {
 		return nil, err
 	}
-
 	if signer == nil {
-		if !o.allowPublicKey {
-			return nil, fmt.Errorf("cannot create a public key only principal without using: WithPublicKey(true)")
-		}
 		return security.CreatePrincipalPublicKeyOnly(publicKey, bs, br)
 	}
 	return security.CreateX509Principal(signer, x509Cert, bs, br)

--- a/x/ref/lib/security/keyfile_util.go
+++ b/x/ref/lib/security/keyfile_util.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 
-	"v.io/v23/security"
 	"v.io/x/ref/lib/security/keys/indirectkeyfiles"
 	"v.io/x/ref/lib/security/passphrase"
 )
@@ -46,20 +45,4 @@ func PrivateKeyWithPrompt(ctx context.Context, privKeyBytes []byte, prompt strin
 // key file.
 func ImportPrivateKeyFile(filename string) ([]byte, error) {
 	return indirectkeyfiles.MarshalPrivateKey([]byte(filename))
-}
-
-func publicKeyFromBytes(publicKeyBytes []byte) (security.PublicKey, error) {
-	if len(publicKeyBytes) == 0 {
-		return nil, nil
-	}
-	key, err := keyRegistrar.ParsePublicKey(publicKeyBytes)
-	if err != nil {
-		return nil, err
-	}
-	api, err := keyRegistrar.APIForKey(key)
-	if err != nil {
-		return nil, err
-	}
-	publicKey, err := api.PublicKey(key)
-	return publicKey, err
 }

--- a/x/ref/lib/security/keys/registrar.go
+++ b/x/ref/lib/security/keys/registrar.go
@@ -188,6 +188,7 @@ func (r *Registrar) getMarshallers(typ interface{}) (MarshalPublicKeyFunc, Marsh
 func (r *Registrar) MarshalPublicKey(key crypto.PublicKey) ([]byte, error) {
 	pub, _ := r.getMarshallers(key)
 	if pub == nil {
+		panic("here")
 		return nil, fmt.Errorf("MarshalPublicKey: unsupported type %T", key)
 	}
 	return pub(key)

--- a/x/ref/lib/security/keys/registrar.go
+++ b/x/ref/lib/security/keys/registrar.go
@@ -188,7 +188,6 @@ func (r *Registrar) getMarshallers(typ interface{}) (MarshalPublicKeyFunc, Marsh
 func (r *Registrar) MarshalPublicKey(key crypto.PublicKey) ([]byte, error) {
 	pub, _ := r.getMarshallers(key)
 	if pub == nil {
-		panic("here")
 		return nil, fmt.Errorf("MarshalPublicKey: unsupported type %T", key)
 	}
 	return pub(key)

--- a/x/ref/lib/security/options.go
+++ b/x/ref/lib/security/options.go
@@ -39,46 +39,46 @@ type blessingRootsOptions struct {
 }
 
 // BlessingStoreReadonly specifies a readonly store from which blessings can be read.
-func BlessingsStoreReadonly(store CredentialsStoreReader, key security.PublicKey) BlessingsStoreOption {
+func BlessingStoreReadonly(store CredentialsStoreReader, publicKey security.PublicKey) BlessingsStoreOption {
 	return func(o *blessingsStoreOptions) {
 		o.reader = store
-		o.publicKey = key
+		o.publicKey = publicKey
 	}
 }
 
-// BlessingsStoreWriteable specifies a writeable store on which blessings
+// BlessingStoreWriteable specifies a writeable store on which blessings
 // can be stored.
-func BlessingsStoreWriteable(store CredentialsStoreReadWriter, signer serialization.Signer) BlessingsStoreOption {
+func BlessingStoreWriteable(store CredentialsStoreReadWriter, signer security.Signer) BlessingsStoreOption {
 	return func(o *blessingsStoreOptions) {
 		o.writer = store
+		o.signer = &serializationSigner{signer}
 		o.publicKey = signer.PublicKey()
-		o.signer = signer
 	}
 }
 
-// BlessingsStoreUpdate specifies that blessings should be periodically
+// BlessingStoreUpdate specifies that blessings should be periodically
 // reloaded to obtain any changes made to them by another entity.
-func BlessingsStoreUpdate(interval time.Duration) BlessingsStoreOption {
+func BlessingStoreUpdate(interval time.Duration) BlessingsStoreOption {
 	return func(o *blessingsStoreOptions) {
 		o.updateInterval = interval
 	}
 }
 
 // BlessingRootsReadonly specifies a readonly store from which blessings can be read.
-func BlessingRootsReadonly(store CredentialsStoreReader, key security.PublicKey) BlessingRootsOption {
+func BlessingRootsReadonly(store CredentialsStoreReader, publicKey security.PublicKey) BlessingRootsOption {
 	return func(o *blessingRootsOptions) {
 		o.reader = store
-		o.publicKey = key
+		o.publicKey = publicKey
 	}
 }
 
 // BlessingRootsWriteable specifies a writeable store on which blessings
 // can be stored.
-func BlessingRootsWriteable(store CredentialsStoreReadWriter, signer serialization.Signer) BlessingRootsOption {
+func BlessingRootsWriteable(store CredentialsStoreReadWriter, signer security.Signer) BlessingRootsOption {
 	return func(o *blessingRootsOptions) {
 		o.writer = store
+		o.signer = &serializationSigner{signer}
 		o.publicKey = signer.PublicKey()
-		o.signer = signer
 	}
 }
 
@@ -104,6 +104,8 @@ type LoadPrincipalOption func(o *principalOptions) error
 type principalOptions struct {
 	readonly       CredentialsStoreReader
 	writeable      CredentialsStoreReadWriter
+	blessingRoots  security.BlessingRoots
+	blessingStore  security.BlessingStore
 	interval       time.Duration
 	allowPublicKey bool
 	passphrase     []byte
@@ -165,6 +167,24 @@ func FromPublicKeyOnly(allow bool) LoadPrincipalOption {
 	}
 }
 
+// FromBlessingStore specifies a security.BlessingStore to use with the new principal.
+// If not specified, a security.BlessingStore will be created by LoadPrincipalOpts.
+func FromBlessingStore(store security.BlessingStore) LoadPrincipalOption {
+	return func(o *principalOptions) error {
+		o.blessingStore = store
+		return nil
+	}
+}
+
+// FromBlessingRoots specifies a security.BlessingRoots to use with the new principal.
+// If not specified, a security.BlessingRoots will be created by LoadPrincipalOpts.
+func FromBlessingRoots(store security.BlessingRoots) LoadPrincipalOption {
+	return func(o *principalOptions) error {
+		o.blessingRoots = store
+		return nil
+	}
+}
+
 // CreatePrincipalOption represents an option to CreatePrincipalOpts.
 type CreatePrincipalOption func(o *createPrincipalOptions) error
 
@@ -178,7 +198,6 @@ type createPrincipalOptions struct {
 	blessingStore   security.BlessingStore
 	blessingRoots   security.BlessingRoots
 	allowPublicKey  bool
-	x509Opts        x509.VerifyOptions
 	x509Cert        *x509.Certificate
 }
 
@@ -204,9 +223,9 @@ func WithStore(store CredentialsStoreCreator) CreatePrincipalOption {
 	}
 }
 
-// WithBlessingsStore specifies the security.BlessingStore to use for
+// WithBlessingStore specifies the security.BlessingStore to use for
 // the new principal.
-func WithBlessingsStore(store security.BlessingStore) CreatePrincipalOption {
+func WithBlessingStore(store security.BlessingStore) CreatePrincipalOption {
 	return func(o *createPrincipalOptions) error {
 		o.blessingStore = store
 		return nil
@@ -298,21 +317,12 @@ func WithPublicKeyOnly(allow bool) CreatePrincipalOption {
 	}
 }
 
-// WithX509VerifyOptions specifies the x509 verification options to use with
-// when verifying blessings derived from x509 Certificates and keys.
-func WithX509VerifyOptions(opts x509.VerifyOptions) CreatePrincipalOption {
-	return func(o *createPrincipalOptions) error {
-		o.x509Opts = opts
-		return nil
-	}
-}
-
-// WithX509Certificate specifies the x509 Certificate to associate with
-// this Principal. It is generally used to associate an x509 Certificate
-// with a Principal created from a signer or private key directly rather than
-// via WithPublicKeyBytes or WithPrivateKeyBytes.
-// The public key of the certificate must match any alternatively specified
-// public key.
+// WithX509Certificate specifices the x509 certificate to associate with
+// this principal. It's public key must match the public key already
+// set for this principal if one has already been set via a private key,
+// a signer or as bytes. Note that if the public key bytes specified
+// via WithPublicKeyBytes is a PEM CERTIFICATE block then the x509
+// Certificate will be used from that also.
 func WithX509Certificate(cert *x509.Certificate) CreatePrincipalOption {
 	return func(o *createPrincipalOptions) error {
 		o.x509Cert = cert

--- a/x/ref/lib/security/principal_opts.go
+++ b/x/ref/lib/security/principal_opts.go
@@ -11,8 +11,8 @@ import (
 )
 
 func (o principalOptions) getBlessingStore(ctx context.Context, publicKey security.PublicKey, signer security.Signer) (security.BlessingStore, error) {
-	if o.blessingStore != nil {
-		return o.blessingStore, nil
+	if o.blessingStoreFactory != nil {
+		return o.blessingStoreFactory(ctx, publicKey, signer)
 	}
 	if o.writeable != nil {
 		return NewBlessingStoreOpts(ctx, publicKey,
@@ -25,8 +25,8 @@ func (o principalOptions) getBlessingStore(ctx context.Context, publicKey securi
 }
 
 func (o principalOptions) getBlessingRoots(ctx context.Context, publicKey security.PublicKey, signer security.Signer) (security.BlessingRoots, error) {
-	if o.blessingRoots != nil {
-		return o.blessingRoots, nil
+	if o.blessingRootsFactory != nil {
+		return o.blessingRootsFactory(ctx, publicKey, signer)
 	}
 	if o.writeable != nil {
 		return NewBlessingRootsOpts(ctx,
@@ -80,23 +80,22 @@ func LoadPrincipalOpts(ctx context.Context, opts ...LoadPrincipalOption) (securi
 			return nil, err
 		}
 	}
-	publicKey, err := reader.NewPublicKey(ctx)
+	publicKey, x509cert, err := reader.NewPublicKey(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	// signer may be nil
 	bs, err := o.getBlessingStore(ctx, publicKey, signer)
 	if err != nil {
 		return nil, err
 	}
-
 	br, err := o.getBlessingRoots(ctx, publicKey, signer)
 	if err != nil {
 		return nil, err
 	}
-
 	if signer == nil {
 		return security.CreatePrincipalPublicKeyOnly(publicKey, bs, br)
 	}
-	return security.CreateX509Principal(signer, nil, bs, br)
+	return security.CreateX509Principal(signer, x509cert, bs, br)
 }

--- a/x/ref/lib/security/principal_opts.go
+++ b/x/ref/lib/security/principal_opts.go
@@ -14,7 +14,7 @@ func (o principalOptions) getBlessingStore(ctx context.Context, publicKey securi
 	if o.blessingStoreFactory != nil {
 		return o.blessingStoreFactory(ctx, publicKey, signer)
 	}
-	if o.writeable != nil {
+	if o.writeable != nil && signer != nil {
 		return NewBlessingStoreOpts(ctx, publicKey,
 			BlessingStoreUpdate(o.interval),
 			BlessingStoreWriteable(o.writeable, signer))
@@ -28,7 +28,7 @@ func (o principalOptions) getBlessingRoots(ctx context.Context, publicKey securi
 	if o.blessingRootsFactory != nil {
 		return o.blessingRootsFactory(ctx, publicKey, signer)
 	}
-	if o.writeable != nil {
+	if o.writeable != nil && signer != nil {
 		return NewBlessingRootsOpts(ctx,
 			BlessingRootsUpdate(o.interval),
 			BlessingRootsWriteable(o.writeable, signer))

--- a/x/ref/lib/security/principal_opts_test.go
+++ b/x/ref/lib/security/principal_opts_test.go
@@ -270,7 +270,7 @@ func TestCreatePrincipalPublicKeyOnly(t *testing.T) {
 	}
 
 	dir, storeOpt := newStoreOpt(t)
-	p, err = CreatePrincipalOpts(ctx,
+	_, err = CreatePrincipalOpts(ctx,
 		WithPublicKeyBytes(publicKeyBytes),
 		WithPublicKeyOnly(true),
 		storeOpt)

--- a/x/ref/lib/security/principal_opts_test.go
+++ b/x/ref/lib/security/principal_opts_test.go
@@ -386,11 +386,11 @@ func hasPeers(p security.Principal, peers ...string) error {
 		roots := p.Roots().DebugString()
 		bre := regexp.MustCompile(peer + `[ ]+test\n`)
 		if !bre.MatchString(blessings) {
-			return fmt.Errorf("failed to find %v in\n%v\n", bre, blessings)
+			return fmt.Errorf("failed to find %v in\n%v", bre, blessings)
 		}
 		rre := regexp.MustCompile(`\[` + peer + `\]\n`)
 		if !rre.MatchString(roots) {
-			return fmt.Errorf("failed to find %v in\n%v\n", rre, roots)
+			return fmt.Errorf("failed to find %v in\n%v", rre, roots)
 		}
 	}
 	return nil
@@ -426,7 +426,7 @@ func TestPrincipalMultiPersistence(t *testing.T) {
 	assert()
 
 	dir, storeOpt = newStoreOpt(t)
-	p, err = CreatePrincipalOpts(ctx,
+	_, err = CreatePrincipalOpts(ctx,
 		WithPrivateKey(privateKey, nil),
 		storeOpt)
 	assert()

--- a/x/ref/lib/security/principal_opts_test.go
+++ b/x/ref/lib/security/principal_opts_test.go
@@ -255,6 +255,46 @@ func TestCreatePrincipalKeyOpts(t *testing.T) {
 	}
 }
 
+func TestCreatePrincipalPublicKeyOnly(t *testing.T) {
+	ctx := context.Background()
+	publicKeyBytes := sectestdata.V23PublicKeyBytes(keys.ECDSA384, sectestdata.V23KeySetA)
+	p, err := CreatePrincipalOpts(ctx,
+		WithPublicKeyBytes(publicKeyBytes),
+		WithPublicKeyOnly(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = p.Sign([]byte("error"))
+	if err == nil || !strings.Contains(err.Error(), "signing not supported") {
+		t.Fatalf("missing or incorrect error: %q", err)
+	}
+
+	dir, storeOpt := newStoreOpt(t)
+	p, err = CreatePrincipalOpts(ctx,
+		WithPublicKeyBytes(publicKeyBytes),
+		WithPublicKeyOnly(true),
+		storeOpt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err = LoadPrincipalOpts(ctx,
+		FromPublicKeyOnly(true),
+		FromWritable(FilesystemStoreWriter(dir)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = p.Sign([]byte("error"))
+	if err == nil || !strings.Contains(err.Error(), "signing not supported") {
+		t.Fatalf("missing or incorrect error: %q", err)
+	}
+}
+
 func TestCreatePrincipalStoreOpts(t *testing.T) {
 	ctx := context.Background()
 	var err error

--- a/x/ref/lib/security/principal_opts_test.go
+++ b/x/ref/lib/security/principal_opts_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -321,7 +322,7 @@ func TestCreatePrincipalStoreOpts(t *testing.T) {
 	}
 
 	// Make another change and verify that it too is persisted.
-	_, err = lp.BlessingStore().Set(blessing, security.AllPrincipals)
+	_, err = lp.BlessingStore().Set(blessing, "some-pattern")
 	assert()
 
 	lpa, err := LoadPrincipalOpts(ctx, FromWritable(FilesystemStoreWriter(dir)))
@@ -330,4 +331,110 @@ func TestCreatePrincipalStoreOpts(t *testing.T) {
 	if got, want := lp.BlessingStore().DebugString(), lpa.BlessingStore().DebugString(); got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
+
+	if got, want := lpa.BlessingStore().DebugString(), "some-pattern"; !strings.Contains(got, want) {
+		t.Errorf("got %v does not contain %v", got, want)
+	}
+}
+
+func setPeers(ctx context.Context, blessing security.Blessings, dir string, customStores bool, peers ...string) error {
+	var blessingStoreFactory CreateBlessingStore
+	var blessingRootsFactory CreateBlessingRoots
+	if customStores {
+		blessingStoreFactory = func(ctx context.Context, publicKey security.PublicKey, signer security.Signer) (security.BlessingStore, error) {
+			return NewBlessingStoreOpts(ctx, publicKey,
+				BlessingStoreWriteable(FilesystemStoreWriter(dir), signer),
+			)
+		}
+
+		blessingRootsFactory = func(tx context.Context, publicKey security.PublicKey, signer security.Signer) (security.BlessingRoots, error) {
+			return NewBlessingRootsOpts(ctx,
+				BlessingRootsWriteable(FilesystemStoreWriter(dir), signer),
+			)
+		}
+	}
+	for i, peer := range peers {
+		peer += "-peer"
+		publicKey := sectestdata.V23Signer(keys.ECDSA256, sectestdata.V23KeySetID(i+1)).PublicKey()
+		der, err := publicKey.MarshalBinary()
+		if err != nil {
+			return err
+		}
+		p, err := LoadPrincipalOpts(ctx,
+			FromBlessingStore(blessingStoreFactory),
+			FromBlessingRoots(blessingRootsFactory),
+			FromWritable(FilesystemStoreWriter(dir)))
+		if err != nil {
+			return err
+		}
+		_, err = p.BlessingStore().Set(blessing, security.BlessingPattern(peer))
+		if err != nil {
+			return err
+		}
+		err = p.Roots().Add(der, security.BlessingPattern(peer))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasPeers(p security.Principal, peers ...string) error {
+	for _, peer := range peers {
+		peer += "-peer"
+		blessings := p.BlessingStore().DebugString()
+		roots := p.Roots().DebugString()
+		bre := regexp.MustCompile(peer + `[ ]+test\n`)
+		if !bre.MatchString(blessings) {
+			return fmt.Errorf("failed to find %v in\n%v\n", bre, blessings)
+		}
+		rre := regexp.MustCompile(`\[` + peer + `\]\n`)
+		if !rre.MatchString(roots) {
+			return fmt.Errorf("failed to find %v in\n%v\n", rre, roots)
+		}
+	}
+	return nil
+}
+
+func TestPrincipalMultiPersistence(t *testing.T) {
+	var err error
+	assert := func() {
+		_, _, line, _ := runtime.Caller(1)
+		if err != nil {
+			t.Fatalf("line %v: err %v", line, err)
+		}
+	}
+
+	ctx := context.Background()
+	privateKey := sectestdata.V23PrivateKey(keys.ED25519, sectestdata.V23KeySetA)
+
+	dir, storeOpt := newStoreOpt(t)
+	p, err := CreatePrincipalOpts(ctx,
+		WithPrivateKey(privateKey, nil),
+		storeOpt)
+	assert()
+	blessing, err := p.BlessSelf("test")
+	assert()
+	err = SetDefaultBlessings(p, blessing)
+	assert()
+
+	err = setPeers(ctx, blessing, dir, false, "a", "b", "c", "d")
+	assert()
+	p, err = LoadPrincipalOpts(ctx, FromReadonly(FilesystemStoreReader(dir)))
+	assert()
+	err = hasPeers(p, "a", "b", "c", "d")
+	assert()
+
+	dir, storeOpt = newStoreOpt(t)
+	p, err = CreatePrincipalOpts(ctx,
+		WithPrivateKey(privateKey, nil),
+		storeOpt)
+	assert()
+
+	err = setPeers(ctx, blessing, dir, true, "e", "f", "g", "h")
+	assert()
+	p, err = LoadPrincipalOpts(ctx, FromReadonly(FilesystemStoreReader(dir)))
+	assert()
+	err = hasPeers(p, "e", "f", "g", "h")
+	assert()
 }


### PR DESCRIPTION
The existing API for loading an existing principal did not allow for using a custom blessing store or blessing root due to the need for those stores to have access to the key information to allow for signing/verification changes to the stores. And since this information is not available prior to loading or outside of the principal it's not possible to create a store externally. This PR fixes this by allowing for a function to be specified as an option to LoadPrincipalOpts which is invoked with the appropriate signer and/or public key to allow for custom stores to be created. It also allows for an x509 certificate to be extracted from a public key that is stored as a certificate.