### PR TITLE
v23/verror: support chain matching with errors.Is

### DIFF
--- a/v23/verror/compat.go
+++ b/v23/verror/compat.go
@@ -4,6 +4,10 @@
 
 package verror
 
+import (
+	"errors"
+)
+
 // Error implements error.
 func (id IDAction) Error() string {
 	return string(id.ID)
@@ -45,6 +49,12 @@ type subErrChain struct {
 // Error implements error.
 func (se subErrChain) Error() string {
 	return se.err.Error()
+}
+
+// Is implements the Is method as used by errors.Is to support chained error
+// matching.
+func (se subErrChain) Is(err error) bool {
+	return errors.Is(se.err, err)
 }
 
 // Unwrap implements the Unwrap method as expected by errors.Unwrap.

--- a/v23/verror/verror_errorf_test.go
+++ b/v23/verror/verror_errorf_test.go
@@ -127,6 +127,17 @@ func TestCompatibility(t *testing.T) {
 	if !errors.Is(err3, err4) {
 		t.Errorf("errors.Is returned true, should be false")
 	}
+
+	// Verify chained error matching.
+	if !errors.Is(err3, err1) {
+		t.Errorf("errors.Is returned false, should be true")
+	}
+	if !errors.Is(err3, idActionA) {
+		t.Errorf("errors.Is returned false, should be true")
+	}
+	if errors.Is(err3, idActionB) {
+		t.Errorf("errors.Is returned true, should be false")
+	}
 }
 
 func TestUnwrap(t *testing.T) {


### PR DESCRIPTION
Support `errors.Is` matching of chained errors.  That is:
```go
	err := errors.New("test error")
	errors.Is(verror.Errorf(nil, "wrapping: %v", err), err) // true
```