### PR TITLE
x/ref/runtime/internal/flow/conn: fragment release message

### DIFF
--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -806,7 +806,6 @@ func (c *Conn) fragmentReleaseMessage(ctx *context.T, toRelease map[uint64]uint6
 		var send, remaining map[uint64]uint64
 		rem := len(toRelease) - limit
 		if rem <= 0 {
-			rem = 0
 			send = toRelease
 		} else {
 			send = make(map[uint64]uint64, limit)

--- a/x/ref/runtime/internal/rpc/benchmark/benchmark/doc.go
+++ b/x/ref/runtime/internal/rpc/benchmark/benchmark/doc.go
@@ -9,84 +9,87 @@
 Command benchmark runs the benchmark client.
 
 Usage:
-   benchmark [flags]
+
+	benchmark [flags]
 
 The benchmark flags are:
- -chunk_count=0
-   Number of chunks to send per streaming RPC (if zero, use non-streaming RPC).
- -iterations=100
-   Number of iterations to run.
- -mux_chunk_count=0
-   Number of chunks to send in background.
- -mux_payload_size=0
-   Size of payload to send in background.
- -payload_size=0
-   Size of payload in bytes.
- -server=
-   Address of the server to connect to.
+
+	-chunk_count=0
+	  Number of chunks to send per streaming RPC (if zero, use non-streaming RPC).
+	-iterations=100
+	  Number of iterations to run.
+	-mux_chunk_count=0
+	  Number of chunks to send in background.
+	-mux_payload_size=0
+	  Size of payload to send in background.
+	-payload_size=0
+	  Size of payload in bytes.
+	-server=
+	  Address of the server to connect to.
 
 The global flags are:
- -alsologtostderr=true
-   log to standard error as well as files
- -log_backtrace_at=:0
-   when logging hits line file:N, emit a stack trace
- -log_dir=
-   if non-empty, write log files to this directory
- -logtostderr=false
-   log to standard error instead of files
- -max_stack_buf_size=4292608
-   max size in bytes of the buffer to use for logging stack traces
- -metadata=<just specify -metadata to activate>
-   Displays metadata for the program and exits.
- -stderrthreshold=2
-   logs at or above this threshold go to stderr
- -time=false
-   Dump timing information to stderr before exiting the program.
- -v=0
-   log level for V logs
- -v23.credentials=
-   directory to use for storing security credentials
- -v23.namespace.root=[/(dev.v.io:r:vprod:service:mounttabled)@ns.dev.v.io:8101]
-   local namespace root; can be repeated to provided multiple roots
- -v23.permissions.file=
-   specify a perms file as <name>:<permsfile>
- -v23.permissions.literal=
-   explicitly specify the runtime perms as a JSON-encoded access.Permissions.
-   Overrides all --v23.permissions.file flags
- -v23.proxy=
-   object name of proxy service to use to export services across network
-   boundaries
- -v23.proxy.limit=0
-   max number of proxies to connect to when the policy is to connect to all
-   proxies; 0 implies all proxies
- -v23.proxy.policy=
-   policy for choosing from a set of available proxy instances
- -v23.tcp.address=
-   address to listen on
- -v23.tcp.protocol=
-   protocol to listen with
- -v23.vtrace.cache-size=1024
-   The number of vtrace traces to store in memory
- -v23.vtrace.collect-regexp=
-   Spans and annotations that match this regular expression will trigger trace
-   collection
- -v23.vtrace.dump-on-shutdown=true
-   If true, dump all stored traces on runtime shutdown
- -v23.vtrace.enable-aws-xray=false
-   Enable the use of AWS x-ray integration with vtrace
- -v23.vtrace.root-span-name=
-   Set the name of the root vtrace span created by the runtime at startup
- -v23.vtrace.sample-rate=0
-   Rate (from 0.0 to 1.0) to sample vtrace traces
- -v23.vtrace.v=0
-   The verbosity level of the log messages to be captured in traces
- -vmodule=
-   comma-separated list of globpattern=N settings for filename-filtered logging
-   (without the .go suffix).  E.g. foo/bar/baz.go is matched by patterns baz or
-   *az or b* but not by bar/baz or baz.go or az or b.*
- -vpath=
-   comma-separated list of regexppattern=N settings for file pathname-filtered
-   logging (without the .go suffix).  E.g. foo/bar/baz.go is matched by patterns
-   foo/bar/baz or fo.*az or oo/ba or b.z but not by foo/bar/baz.go or fo*az
+
+	-alsologtostderr=true
+	  log to standard error as well as files
+	-log_backtrace_at=:0
+	  when logging hits line file:N, emit a stack trace
+	-log_dir=
+	  if non-empty, write log files to this directory
+	-logtostderr=false
+	  log to standard error instead of files
+	-max_stack_buf_size=4292608
+	  max size in bytes of the buffer to use for logging stack traces
+	-metadata=<just specify -metadata to activate>
+	  Displays metadata for the program and exits.
+	-stderrthreshold=2
+	  logs at or above this threshold go to stderr
+	-time=false
+	  Dump timing information to stderr before exiting the program.
+	-v=0
+	  log level for V logs
+	-v23.credentials=
+	  directory to use for storing security credentials
+	-v23.namespace.root=[/(dev.v.io:r:vprod:service:mounttabled)@ns.dev.v.io:8101]
+	  local namespace root; can be repeated to provided multiple roots
+	-v23.permissions.file=
+	  specify a perms file as <name>:<permsfile>
+	-v23.permissions.literal=
+	  explicitly specify the runtime perms as a JSON-encoded access.Permissions.
+	  Overrides all --v23.permissions.file flags
+	-v23.proxy=
+	  object name of proxy service to use to export services across network
+	  boundaries
+	-v23.proxy.limit=0
+	  max number of proxies to connect to when the policy is to connect to all
+	  proxies; 0 implies all proxies
+	-v23.proxy.policy=
+	  policy for choosing from a set of available proxy instances
+	-v23.tcp.address=
+	  address to listen on
+	-v23.tcp.protocol=
+	  protocol to listen with
+	-v23.vtrace.cache-size=1024
+	  The number of vtrace traces to store in memory
+	-v23.vtrace.collect-regexp=
+	  Spans and annotations that match this regular expression will trigger trace
+	  collection
+	-v23.vtrace.dump-on-shutdown=true
+	  If true, dump all stored traces on runtime shutdown
+	-v23.vtrace.enable-aws-xray=false
+	  Enable the use of AWS x-ray integration with vtrace
+	-v23.vtrace.root-span-name=
+	  Set the name of the root vtrace span created by the runtime at startup
+	-v23.vtrace.sample-rate=0
+	  Rate (from 0.0 to 1.0) to sample vtrace traces
+	-v23.vtrace.v=0
+	  The verbosity level of the log messages to be captured in traces
+	-vmodule=
+	  comma-separated list of globpattern=N settings for filename-filtered logging
+	  (without the .go suffix).  E.g. foo/bar/baz.go is matched by patterns baz or
+	  *az or b* but not by bar/baz or baz.go or az or b.*
+	-vpath=
+	  comma-separated list of regexppattern=N settings for file pathname-filtered
+	  logging (without the .go suffix).  E.g. foo/bar/baz.go is matched by patterns
+	  foo/bar/baz or fo.*az or oo/ba or b.z but not by foo/bar/baz.go or fo*az
 */
 package main

--- a/x/ref/runtime/internal/rpc/benchmark/benchmarkd/doc.go
+++ b/x/ref/runtime/internal/rpc/benchmark/benchmarkd/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Vanadium Authors. All rights reserved.
+// Copyright 2022 The Vanadium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/x/ref/runtime/internal/rpc/benchmark/benchmarkd/doc.go
+++ b/x/ref/runtime/internal/rpc/benchmark/benchmarkd/doc.go
@@ -9,89 +9,91 @@
 Command benchmarkd runs the benchmark server.
 
 Usage:
-   benchmarkd [flags]
+
+	benchmarkd [flags]
 
 The global flags are:
- -alsologtostderr=true
-   log to standard error as well as files
- -log_backtrace_at=:0
-   when logging hits line file:N, emit a stack trace
- -log_dir=
-   if non-empty, write log files to this directory
- -logtostderr=false
-   log to standard error instead of files
- -max_stack_buf_size=4292608
-   max size in bytes of the buffer to use for logging stack traces
- -metadata=<just specify -metadata to activate>
-   Displays metadata for the program and exits.
- -stderrthreshold=2
-   logs at or above this threshold go to stderr
- -time=false
-   Dump timing information to stderr before exiting the program.
- -v=0
-   log level for V logs
- -v23.credentials=
-   directory to use for storing security credentials
- -v23.namespace.root=[/(dev.v.io:r:vprod:service:mounttabled)@ns.dev.v.io:8101]
-   local namespace root; can be repeated to provided multiple roots
- -v23.permissions.file=
-   specify a perms file as <name>:<permsfile>
- -v23.permissions.literal=
-   explicitly specify the runtime perms as a JSON-encoded access.Permissions.
-   Overrides all --v23.permissions.file flags
- -v23.proxy=
-   object name of proxy service to use to export services across network
-   boundaries
- -v23.proxy.limit=0
-   max number of proxies to connect to when the policy is to connect to all
-   proxies; 0 implies all proxies
- -v23.proxy.policy=
-   policy for choosing from a set of available proxy instances
- -v23.tcp.address=
-   address to listen on
- -v23.tcp.protocol=
-   protocol to listen with
- -v23.virtualized.advertise-private-addresses=
-   if set the process will also advertise its private addresses
- -v23.virtualized.disallow-native-fallback=false
-   if set, a failure to detect the requested virtualization provider will result
-   in an error, otherwise, native mode is used
- -v23.virtualized.dns.public-name=
-   if set the process will use the supplied dns name (and port) without
-   resolution for its entry in the mounttable
- -v23.virtualized.docker=
-   set if the process is running in a docker container and needs to configure
-   itself differently therein
- -v23.virtualized.provider=
-   the name of the virtualization/cloud provider hosting this process if the
-   process needs to configure itself differently therein
- -v23.virtualized.tcp.public-address=
-   if set the process will use this address (resolving via dns if appropriate)
-   for its entry in the mounttable
- -v23.virtualized.tcp.public-protocol=
-   if set the process will use this protocol for its entry in the mounttable
- -v23.vtrace.cache-size=1024
-   The number of vtrace traces to store in memory
- -v23.vtrace.collect-regexp=
-   Spans and annotations that match this regular expression will trigger trace
-   collection
- -v23.vtrace.dump-on-shutdown=true
-   If true, dump all stored traces on runtime shutdown
- -v23.vtrace.enable-aws-xray=false
-   Enable the use of AWS x-ray integration with vtrace
- -v23.vtrace.root-span-name=
-   Set the name of the root vtrace span created by the runtime at startup
- -v23.vtrace.sample-rate=0
-   Rate (from 0.0 to 1.0) to sample vtrace traces
- -v23.vtrace.v=0
-   The verbosity level of the log messages to be captured in traces
- -vmodule=
-   comma-separated list of globpattern=N settings for filename-filtered logging
-   (without the .go suffix).  E.g. foo/bar/baz.go is matched by patterns baz or
-   *az or b* but not by bar/baz or baz.go or az or b.*
- -vpath=
-   comma-separated list of regexppattern=N settings for file pathname-filtered
-   logging (without the .go suffix).  E.g. foo/bar/baz.go is matched by patterns
-   foo/bar/baz or fo.*az or oo/ba or b.z but not by foo/bar/baz.go or fo*az
+
+	-alsologtostderr=true
+	  log to standard error as well as files
+	-log_backtrace_at=:0
+	  when logging hits line file:N, emit a stack trace
+	-log_dir=
+	  if non-empty, write log files to this directory
+	-logtostderr=false
+	  log to standard error instead of files
+	-max_stack_buf_size=4292608
+	  max size in bytes of the buffer to use for logging stack traces
+	-metadata=<just specify -metadata to activate>
+	  Displays metadata for the program and exits.
+	-stderrthreshold=2
+	  logs at or above this threshold go to stderr
+	-time=false
+	  Dump timing information to stderr before exiting the program.
+	-v=0
+	  log level for V logs
+	-v23.credentials=
+	  directory to use for storing security credentials
+	-v23.namespace.root=[/(dev.v.io:r:vprod:service:mounttabled)@ns.dev.v.io:8101]
+	  local namespace root; can be repeated to provided multiple roots
+	-v23.permissions.file=
+	  specify a perms file as <name>:<permsfile>
+	-v23.permissions.literal=
+	  explicitly specify the runtime perms as a JSON-encoded access.Permissions.
+	  Overrides all --v23.permissions.file flags
+	-v23.proxy=
+	  object name of proxy service to use to export services across network
+	  boundaries
+	-v23.proxy.limit=0
+	  max number of proxies to connect to when the policy is to connect to all
+	  proxies; 0 implies all proxies
+	-v23.proxy.policy=
+	  policy for choosing from a set of available proxy instances
+	-v23.tcp.address=
+	  address to listen on
+	-v23.tcp.protocol=
+	  protocol to listen with
+	-v23.virtualized.advertise-private-addresses=
+	  if set the process will also advertise its private addresses
+	-v23.virtualized.disallow-native-fallback=false
+	  if set, a failure to detect the requested virtualization provider will result
+	  in an error, otherwise, native mode is used
+	-v23.virtualized.dns.public-name=
+	  if set the process will use the supplied dns name (and port) without
+	  resolution for its entry in the mounttable
+	-v23.virtualized.docker=
+	  set if the process is running in a docker container and needs to configure
+	  itself differently therein
+	-v23.virtualized.provider=
+	  the name of the virtualization/cloud provider hosting this process if the
+	  process needs to configure itself differently therein
+	-v23.virtualized.tcp.public-address=
+	  if set the process will use this address (resolving via dns if appropriate)
+	  for its entry in the mounttable
+	-v23.virtualized.tcp.public-protocol=
+	  if set the process will use this protocol for its entry in the mounttable
+	-v23.vtrace.cache-size=1024
+	  The number of vtrace traces to store in memory
+	-v23.vtrace.collect-regexp=
+	  Spans and annotations that match this regular expression will trigger trace
+	  collection
+	-v23.vtrace.dump-on-shutdown=true
+	  If true, dump all stored traces on runtime shutdown
+	-v23.vtrace.enable-aws-xray=false
+	  Enable the use of AWS x-ray integration with vtrace
+	-v23.vtrace.root-span-name=
+	  Set the name of the root vtrace span created by the runtime at startup
+	-v23.vtrace.sample-rate=0
+	  Rate (from 0.0 to 1.0) to sample vtrace traces
+	-v23.vtrace.v=0
+	  The verbosity level of the log messages to be captured in traces
+	-vmodule=
+	  comma-separated list of globpattern=N settings for filename-filtered logging
+	  (without the .go suffix).  E.g. foo/bar/baz.go is matched by patterns baz or
+	  *az or b* but not by bar/baz or baz.go or az or b.*
+	-vpath=
+	  comma-separated list of regexppattern=N settings for file pathname-filtered
+	  logging (without the .go suffix).  E.g. foo/bar/baz.go is matched by patterns
+	  foo/bar/baz or fo.*az or oo/ba or b.z but not by foo/bar/baz.go or fo*az
 */
 package main


### PR DESCRIPTION
PR #287 deleted the toRelease/borrowed entries for a flow when it is closed. This greatly reduced the size of the Release messages for the common case. However, those counters are required when borrowed is true past the flow being closed so that the dialer can recover the borrowed tokens to its shared pool of tokens. In cases where a great number of short lived connections are created the resulting Release message can be larger than the default buffer size allowed and hence will require fragmentation. When routed through a proxy these large messages can lead to deadlock since the proxy's encapsulate flow will not forward a message that has to be fragmented if it does not have enough flow control counters for the entire message. This PR explicitly fragments the Release message to get around this limitation.

A better fix is to collect all of the borrowed tokens into a single 'special flow' in the Release message and for the dialer to add these tokens to the shared pool directly rather than iterating over all of the per-flow borrowed counters.