### PR TITLE
v23/rpc/versions,x/ref/internal/runtime/internal: clean up version handling

### DIFF
--- a/v23/flow/message/message_test.go
+++ b/v23/flow/message/message_test.go
@@ -56,16 +56,16 @@ func TestSetup(t *testing.T) {
 		t.Fatal(err)
 	}
 	testMessages(t, ctx, []message.Message{
-		&message.Setup{Versions: version.RPCVersionRange{Min: 3, Max: 5}},
+		&message.Setup{Versions: version.RPCVersionRange{Min: 1, Max: 5}},
 		&message.Setup{
-			Versions: version.RPCVersionRange{Min: 3, Max: 5},
+			Versions: version.RPCVersionRange{Min: 1, Max: 5},
 			PeerNaClPublicKey: &[32]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
 				14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31},
 			PeerRemoteEndpoint: ep1,
 			PeerLocalEndpoint:  ep2,
 		},
 		&message.Setup{
-			Versions:     version.RPCVersionRange{Min: 3, Max: 5},
+			Versions:     version.RPCVersionRange{Min: 1, Max: 5},
 			Mtu:          1 << 16,
 			SharedTokens: 1 << 20,
 		},

--- a/v23/rpc/version/version.go
+++ b/v23/rpc/version/version.go
@@ -47,6 +47,11 @@ const (
 	// RPCVersion14 adds the setup message to the channel binding during
 	// connection setup.
 	RPCVersion14
+
+	// Placeholder for the forthcoming RPC reimplementation. At the very
+	// least the mechanism for how borrowed flow control tokens are
+	// returned to the dialer will change.
+	RPCVersion15
 )
 
 // RPCVersionRange allows you to optionally specify a range of versions to

--- a/x/ref/runtime/internal/flow/conn/auth.go
+++ b/x/ref/runtime/internal/flow/conn/auth.go
@@ -189,7 +189,6 @@ func (c *Conn) setup(ctx *context.T, versions version.RPCVersionRange, dialer bo
 	if c.common_version, err = version.CommonVersion(ctx, lSetup.Versions, rSetup.Versions); err != nil {
 		return nil, naming.Endpoint{}, rttstart, err
 	}
-	c.remote_versions = rSetup.Versions
 	if c.local.IsZero() {
 		c.local = rSetup.PeerRemoteEndpoint
 	}

--- a/x/ref/runtime/internal/flow/conn/auth.go
+++ b/x/ref/runtime/internal/flow/conn/auth.go
@@ -186,7 +186,7 @@ func (c *Conn) setup(ctx *context.T, versions version.RPCVersionRange, dialer bo
 		}
 		return nil, naming.Endpoint{}, rttstart, ErrSend.Errorf(ctx, "conn.setup: remote %v: %v", remoteStr, err)
 	}
-	if c.common_version, err = version.CommonVersion(ctx, lSetup.Versions, rSetup.Versions); err != nil {
+	if c.version, err = version.CommonVersion(ctx, lSetup.Versions, rSetup.Versions); err != nil {
 		return nil, naming.Endpoint{}, rttstart, err
 	}
 	if c.local.IsZero() {
@@ -207,7 +207,7 @@ func (c *Conn) setup(ctx *context.T, versions version.RPCVersionRange, dialer bo
 	c.mu.Lock()
 	binding := c.mp.setupEncryption(ctx, pk, sk, rSetup.PeerNaClPublicKey)
 	c.mu.Unlock()
-	if c.common_version >= version.RPCVersion14 {
+	if c.version >= version.RPCVersion14 {
 		// We include the setup messages in the channel binding to prevent attacks
 		// where a man in the middle changes fields in the Setup message (e.g. a
 		// downgrade attack wherein a MITM attacker changes the Version field of

--- a/x/ref/runtime/internal/flow/conn/auth.go
+++ b/x/ref/runtime/internal/flow/conn/auth.go
@@ -186,9 +186,10 @@ func (c *Conn) setup(ctx *context.T, versions version.RPCVersionRange, dialer bo
 		}
 		return nil, naming.Endpoint{}, rttstart, ErrSend.Errorf(ctx, "conn.setup: remote %v: %v", remoteStr, err)
 	}
-	if c.version, err = version.CommonVersion(ctx, lSetup.Versions, rSetup.Versions); err != nil {
+	if c.common_version, err = version.CommonVersion(ctx, lSetup.Versions, rSetup.Versions); err != nil {
 		return nil, naming.Endpoint{}, rttstart, err
 	}
+	c.remote_versions = rSetup.Versions
 	if c.local.IsZero() {
 		c.local = rSetup.PeerRemoteEndpoint
 	}
@@ -207,7 +208,7 @@ func (c *Conn) setup(ctx *context.T, versions version.RPCVersionRange, dialer bo
 	c.mu.Lock()
 	binding := c.mp.setupEncryption(ctx, pk, sk, rSetup.PeerNaClPublicKey)
 	c.mu.Unlock()
-	if c.version >= version.RPCVersion14 {
+	if c.common_version >= version.RPCVersion14 {
 		// We include the setup messages in the channel binding to prevent attacks
 		// where a man in the middle changes fields in the Setup message (e.g. a
 		// downgrade attack wherein a MITM attacker changes the Version field of

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -91,18 +91,18 @@ type healthCheckState struct {
 type Conn struct {
 	// All the variables here are set before the constructor returns
 	// and never changed after that.
-	mp             *messagePipe
-	common_version version.RPCVersion
-	local, remote  naming.Endpoint
-	remoteAddr     net.Addr
-	closed         chan struct{}
-	lameDucked     chan struct{}
-	blessingsFlow  *blessingsFlow
-	loopWG         sync.WaitGroup
-	unopenedFlows  sync.WaitGroup
-	cancel         context.CancelFunc
-	handler        FlowHandler
-	mtu            uint64
+	mp            *messagePipe
+	version       version.RPCVersion
+	local, remote naming.Endpoint
+	remoteAddr    net.Addr
+	closed        chan struct{}
+	lameDucked    chan struct{}
+	blessingsFlow *blessingsFlow
+	loopWG        sync.WaitGroup
+	unopenedFlows sync.WaitGroup
+	cancel        context.CancelFunc
+	handler       FlowHandler
+	mtu           uint64
 
 	mu sync.Mutex // All the variables below here are protected by mu.
 
@@ -656,7 +656,7 @@ func (c *Conn) RemoteDischarges() map[string]security.Discharge {
 }
 
 // CommonVersion returns the RPCVersion negotiated between the local and remote endpoints.
-func (c *Conn) CommonVersion() version.RPCVersion { return c.common_version }
+func (c *Conn) CommonVersion() version.RPCVersion { return c.version }
 
 // LastUsed returns the time at which the Conn had bytes read or written on it.
 func (c *Conn) LastUsed() time.Time {
@@ -1217,7 +1217,7 @@ LastUsed:    %v
 		c.rPublicKey,
 		c.local,
 		c.localBlessings,
-		c.common_version,
+		c.version,
 		c.mtu,
 		c.lastUsedTime,
 		len(c.flows))

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -167,7 +167,7 @@ var _ flow.ManagedConn = &Conn{}
 // even if the context is canceled. The behaviour is different for a proxy
 // connection, in which case a cancelation is immediate and no attempt is made
 // to establish the connection.
-func NewDialed(
+func NewDialed( //nolint:gocyclo
 	ctx *context.T,
 	conn flow.MsgReadWriteCloser,
 	local, remote naming.Endpoint,
@@ -176,7 +176,7 @@ func NewDialed(
 	proxy bool,
 	handshakeTimeout time.Duration,
 	channelTimeout time.Duration,
-	handler FlowHandler) (c *Conn, names []string, rejected []security.RejectedBlessing, err error) { //nolint:gocyclo
+	handler FlowHandler) (c *Conn, names []string, rejected []security.RejectedBlessing, err error) {
 
 	if _, err = version.CommonVersion(ctx, rpcversion.Supported, versions); err != nil {
 		return

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -176,7 +176,7 @@ func NewDialed(
 	proxy bool,
 	handshakeTimeout time.Duration,
 	channelTimeout time.Duration,
-	handler FlowHandler) (c *Conn, names []string, rejected []security.RejectedBlessing, err error) {
+	handler FlowHandler) (c *Conn, names []string, rejected []security.RejectedBlessing, err error) { //nolint:gocyclo
 
 	if _, err = version.CommonVersion(ctx, rpcversion.Supported, versions); err != nil {
 		return

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -91,19 +91,18 @@ type healthCheckState struct {
 type Conn struct {
 	// All the variables here are set before the constructor returns
 	// and never changed after that.
-	mp              *messagePipe
-	common_version  version.RPCVersion
-	remote_versions version.RPCVersionRange
-	local, remote   naming.Endpoint
-	remoteAddr      net.Addr
-	closed          chan struct{}
-	lameDucked      chan struct{}
-	blessingsFlow   *blessingsFlow
-	loopWG          sync.WaitGroup
-	unopenedFlows   sync.WaitGroup
-	cancel          context.CancelFunc
-	handler         FlowHandler
-	mtu             uint64
+	mp             *messagePipe
+	common_version version.RPCVersion
+	local, remote  naming.Endpoint
+	remoteAddr     net.Addr
+	closed         chan struct{}
+	lameDucked     chan struct{}
+	blessingsFlow  *blessingsFlow
+	loopWG         sync.WaitGroup
+	unopenedFlows  sync.WaitGroup
+	cancel         context.CancelFunc
+	handler        FlowHandler
+	mtu            uint64
 
 	mu sync.Mutex // All the variables below here are protected by mu.
 
@@ -1205,7 +1204,6 @@ Remote:
   Endpoint   %v
   Blessings: %v (claimed)
   PublicKey: %v
-  Version:   %v
 Local:
   Endpoint:  %v
   Blessings: %v
@@ -1217,7 +1215,6 @@ LastUsed:    %v
 		c.remote,
 		c.remoteBlessings,
 		c.rPublicKey,
-		c.remote_versions.Max,
 		c.local,
 		c.localBlessings,
 		c.common_version,

--- a/x/ref/runtime/internal/flow/conn/conn_test.go
+++ b/x/ref/runtime/internal/flow/conn/conn_test.go
@@ -202,11 +202,11 @@ func TestHandshakeDespiteCancel(t *testing.T) {
 	dcancel()
 	dc, ac, derr, aerr := setupConnsWithTimeout(t, "local", "", dctx, ctx, dflows, aflows, nil, nil, 1*time.Second, 4*time.Second, time.Second)
 	if aerr != nil {
-		t.Errorf("accept unexpectedly failed: %v", aerr)
+		t.Fatalf("setupConnsWithTimeout: unexpectedly failed: %v, %v", derr, aerr)
 	}
 	if got, want := verror.ErrorID(derr), verror.ErrCanceled.ID; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
-	defer dc.Close(ctx, nil)
-	defer ac.Close(ctx, nil)
+	dc.Close(ctx, nil)
+	ac.Close(ctx, nil)
 }

--- a/x/ref/runtime/internal/flow/conn/util_test.go
+++ b/x/ref/runtime/internal/flow/conn/util_test.go
@@ -14,10 +14,10 @@ import (
 	"v.io/v23/context"
 	"v.io/v23/flow"
 	"v.io/v23/naming"
-	"v.io/v23/rpc/version"
 	"v.io/v23/security"
 	securitylib "v.io/x/ref/lib/security"
 	"v.io/x/ref/runtime/internal/flow/flowtest"
+	"v.io/x/ref/runtime/internal/rpc/version"
 )
 
 type fh chan<- flow.Flow
@@ -47,7 +47,13 @@ func setupConnsWithTimeout(t *testing.T,
 	handshakeTimeout time.Duration,
 	channelTimeout time.Duration) (dialed, accepted *Conn, derr, aerr error) {
 	dmrw, amrw := flowtest.Pipe(t, actx, network, address)
-	versions := version.RPCVersionRange{Min: 3, Max: 5}
+	versions := version.Supported
+	if len(address) == 0 {
+		// Ensure that we consistently use :0 to refer to 'any' port rather than
+		// "" so that message.rSetup and lSetup have the same values in our tests
+		// otherwise the RPC14 binding signature will not match.
+		address = ":0"
+	}
 	ridep := naming.Endpoint{Protocol: network, Address: address, RoutingID: naming.FixedRoutingID(191341)}
 	ep := naming.Endpoint{Protocol: network, Address: address}
 	dch := make(chan *Conn)

--- a/x/ref/runtime/internal/flow/manager/conncache_test.go
+++ b/x/ref/runtime/internal/flow/manager/conncache_test.go
@@ -15,10 +15,10 @@ import (
 	"v.io/v23/context"
 	"v.io/v23/flow"
 	"v.io/v23/naming"
-	"v.io/v23/rpc/version"
 	"v.io/v23/security"
 	connpackage "v.io/x/ref/runtime/internal/flow/conn"
 	"v.io/x/ref/runtime/internal/flow/flowtest"
+	"v.io/x/ref/runtime/internal/rpc/version"
 	_ "v.io/x/ref/runtime/protocols/local"
 	"v.io/x/ref/test"
 	"v.io/x/ref/test/goroutines"
@@ -606,7 +606,7 @@ func makeConnAndFlow(t *testing.T, ctx *context.T, ep naming.Endpoint) connAndFl
 	errCh := make(chan error, 2)
 	go func() {
 		d, _, _, err := connpackage.NewDialed(ctx, dmrw, ep, ep,
-			version.RPCVersionRange{Min: 1, Max: 5},
+			version.Supported,
 			flowtest.AllowAllPeersAuthorizer{},
 			false,
 			time.Minute, 0, nil)
@@ -619,7 +619,7 @@ func makeConnAndFlow(t *testing.T, ctx *context.T, ep naming.Endpoint) connAndFl
 	fh := fh{t, make(chan struct{})}
 	go func() {
 		a, err := connpackage.NewAccepted(ctx, nil, amrw, ep,
-			version.RPCVersionRange{Min: 1, Max: 5}, time.Minute, 0, fh)
+			version.Supported, time.Minute, 0, fh)
 		if err != nil {
 			err = fmt.Errorf("Unexpected error: %v", err)
 		}

--- a/x/ref/runtime/protocols/local/init.go
+++ b/x/ref/runtime/protocols/local/init.go
@@ -152,7 +152,7 @@ func (l *local) Listen(ctx *context.T, network, address string) (flow.Listener, 
 	defer l.mu.Unlock()
 	l.mu.Lock()
 	a := addr(address)
-	if a == "" {
+	if a == "" || a == ":0" {
 		a = l.nextAddrLocked()
 	}
 	if _, ok := l.listeners[a]; ok {


### PR DESCRIPTION
This PR cleans up version number error checking and in tests in preparation for using a new version in the (not so distant) future.