### PR TITLE
v23/naming: reduce the number of memory allocations required for parsing endpoints

### DIFF
--- a/v23/naming/endpoint.go
+++ b/v23/naming/endpoint.go
@@ -143,7 +143,6 @@ func parseV6(input string) (ep Endpoint, err error) {
 
 	input = input[idx+1:]
 	idx = strings.IndexRune(input, separatorRune)
-
 	if idx < 0 {
 		return
 	}

--- a/v23/naming/endpoint.go
+++ b/v23/naming/endpoint.go
@@ -116,6 +116,20 @@ func parseHostPort(blessing, hostport string) (Endpoint, error) {
 	return ep, nil
 }
 
+func parseRoutes(input string) ([]string, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+	routes := strings.Split(input, routeSeparator)
+	var ok bool
+	for i := range routes {
+		if routes[i], ok = Unescape(routes[i]); !ok {
+			return nil, fmt.Errorf("invalid route: bad escape %s", routes[i])
+		}
+	}
+	return routes, nil
+}
+
 func parseV6(input string) (ep Endpoint, err error) {
 	err = errInvalidEndpointString
 
@@ -146,13 +160,9 @@ func parseV6(input string) (ep Endpoint, err error) {
 	if idx < 0 {
 		return
 	}
-	if routes := input[:idx]; len(routes) > 0 {
-		ep.routes = strings.Split(routes, routeSeparator)
-		for i := range ep.routes {
-			if ep.routes[i], ok = Unescape(ep.routes[i]); !ok {
-				return ep, fmt.Errorf("invalid route: bad escape %s", ep.routes[i])
-			}
-		}
+	ep.routes, err = parseRoutes(input[:idx])
+	if err != nil {
+		return
 	}
 
 	input = input[idx+1:]

--- a/v23/naming/endpoint_test.go
+++ b/v23/naming/endpoint_test.go
@@ -209,3 +209,25 @@ func TestEscapeEndpoint(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkEndpointParsing(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseEndpoint(
+			"@6@tcp@batman.com:2345@1@0000000000000000000000000000ba77@m@dev.v.io:foo@bar.com,dev.v.io:bar@bar.com:delegate@@")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEndpointParsingBytes(b *testing.B) {
+	ep := []byte("@6@tcp@batman.com:2345@1@0000000000000000000000000000ba77@m@dev.v.io:foo@bar.com,dev.v.io:bar@bar.com:delegate@@")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseEndpointBytes(ep)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/v23/naming/parse_test.go
+++ b/v23/naming/parse_test.go
@@ -61,6 +61,7 @@ func TestSplitAddressName(t *testing.T) {
 }
 
 func BenchmarkSplitAddressName(b *testing.B) {
+	b.ReportAllocs()
 	tests := []string{
 		"/user@domain.com@host:1234/foo/bar",
 		"/(dev.v.io/services/mounttabled)@host:1234/foo/bar",


### PR DESCRIPTION
This PR reduces the number of memory allocations required for parsing endpoints in two ways:
1. providing a ParseEndpointBytes functions which avoids the caller having to convert a []byte to
   a string prior to calling ParseEndpoint as happens within the rpc runtime in many places.
2. avoid splitting on the @ separator in parse6 and rejoining/splitting again.