### PR TITLE
v23/context: de-flake TestRootCancelGoroutineLeak

### DIFF
--- a/v23/context/context_test.go
+++ b/v23/context/context_test.go
@@ -347,7 +347,7 @@ func TestRootCancelGoroutineLeak(t *testing.T) {
 		}
 	}
 	if count != 0 {
-		t.Errorf("expected 0 but got %d: goroutine leaking in WithRootCancel", count)
+		t.Errorf("expected 0 but got %d: goroutine leaking in WithRootCancel: %s", count, buf)
 	}
 	rootcancel()
 }

--- a/v23/context/context_test.go
+++ b/v23/context/context_test.go
@@ -323,6 +323,22 @@ func TestRootCancelChain(t *testing.T) {
 }
 
 func TestRootCancelGoroutineLeak(t *testing.T) {
+	// Arbitrary threshold to wait for the goroutines in the created contexts
+	// above to exit. This threshold was arbitrarily created after running
+	// `go test -count=10000 -run TestRootCancelGoroutineLeak$` and verifying
+	// that the tests did not fail flakily.
+	const waitThreshold = 8 * time.Millisecond
+	if err := testRootCancelGoroutineLeak(waitThreshold); err == nil {
+		return
+	}
+	// Try again, for the very rare case that the above fails due to
+	// being run on a very slow machine.
+	if err := testRootCancelGoroutineLeak(waitThreshold * 2); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testRootCancelGoroutineLeak(waitThreshold time.Duration) error {
 	rootCtx, rootcancel := context.RootContext()
 	const iterations = 1024
 	for i := 0; i != iterations; i++ {
@@ -330,11 +346,6 @@ func TestRootCancelGoroutineLeak(t *testing.T) {
 		cancel()
 	}
 
-	// Arbitrary threshold to wait for the goroutines in the created contexts
-	// above to exit. This threshold was arbitrarily created after running
-	// `go test -count=10000 -run TestRootCancelGoroutineLeak$` and verifying
-	// that the tests did not fail flakily.
-	const waitThreshold = 8 * time.Millisecond
 	time.Sleep(waitThreshold)
 
 	// Verify that goroutines no longer exist in the runtime stack.
@@ -347,9 +358,10 @@ func TestRootCancelGoroutineLeak(t *testing.T) {
 		}
 	}
 	if count != 0 {
-		t.Errorf("expected 0 but got %d: goroutine leaking in WithRootCancel: %s", count, buf)
+		return fmt.Errorf("expected 0 but got %d: goroutine leaking in WithRootCancel: %s", count, buf)
 	}
 	rootcancel()
+	return nil
 }
 
 func TestRootCancel_GoContext(t *testing.T) {

--- a/x/ref/test/goroutines/goroutines.go
+++ b/x/ref/test/goroutines/goroutines.go
@@ -244,7 +244,7 @@ func NoLeaks(t ErrorReporter, wait time.Duration) func() {
 				return
 			}
 			if time.Now().After(until) {
-				t.Errorf("%d extra Goroutines outstanding after %s:\n %s",
+				t.Errorf("%d extra Goroutines outstanding after %v:\n %s",
 					len(left), wait, string(Format(left...)))
 				return
 			}

--- a/x/ref/test/goroutines/goroutines.go
+++ b/x/ref/test/goroutines/goroutines.go
@@ -206,7 +206,8 @@ type ErrorReporter interface {
 func NoLeaks(t ErrorReporter, wait time.Duration) func() {
 	gs, err := Get()
 	if err != nil {
-		return func() {} // If we can't parse correctly we let the test pass.
+		t.Errorf("NoLeaks: failed to parse goroutine output %v", err)
+		return func() {}
 	}
 	bycreator := map[string]int{}
 	for _, g := range gs {
@@ -218,13 +219,14 @@ func NoLeaks(t ErrorReporter, wait time.Duration) func() {
 	}
 	return func() {
 		var left []*Goroutine
-		backoff := 10 * time.Millisecond
+		backoff := 100 * time.Millisecond
 		start := time.Now()
 		until := start.Add(wait)
 		for {
 			cgs, err := Get()
 			if err != nil {
-				return // If we can't parse correctly we let the test pass.
+				t.Errorf("NoLeaks: failed to parse goroutine output %v", err)
+				return
 			}
 			left = left[:0]
 			cbycreator := map[string]int{}
@@ -242,8 +244,8 @@ func NoLeaks(t ErrorReporter, wait time.Duration) func() {
 				return
 			}
 			if time.Now().After(until) {
-				t.Errorf("%d extra Goroutines outstanding:\n %s", len(left),
-					string(Format(left...)))
+				t.Errorf("%d extra Goroutines outstanding after %s:\n %s",
+					len(left), wait, string(Format(left...)))
 				return
 			}
 			time.Sleep(backoff)

--- a/x/ref/test/goroutines/goroutines_test.go
+++ b/x/ref/test/goroutines/goroutines_test.go
@@ -6,6 +6,7 @@ package goroutines
 
 import (
 	"bytes"
+	"fmt"
 	"runtime"
 	"strings"
 	"sync"
@@ -132,7 +133,8 @@ type fakeErrorReporter struct {
 func (f *fakeErrorReporter) Errorf(format string, args ...interface{}) {
 	f.calls++
 	f.extra = args[0].(int)
-	f.formatted = args[1].(string)
+	// ignore the 'wait' parameter.
+	f.formatted = fmt.Sprintf("%v", args[2])
 }
 
 func TestNoLeaks(t *testing.T) {


### PR DESCRIPTION
This PR attempts to de-flake TestRootCancelGoroutineLeak and makes some minor changes to the leak detection code (NoLeaks) to display the timeout and fail if it fails to parse the goroutine state output.