### PR TITLE
x/ref/lib/discovery/plugins/ble: stop the discovery Trigger.

### DIFF
--- a/x/ref/lib/discovery/plugins/ble/ble.go
+++ b/x/ref/lib/discovery/plugins/ble/ble.go
@@ -106,6 +106,7 @@ func (p *plugin) Scan(ctx *context.T, interfaceName string, callback func(*idisc
 }
 
 func (p *plugin) Close() {
+	p.adStopper.Stop()
 	p.scanner.shutdown()
 }
 

--- a/x/ref/lib/discovery/plugins/testutil/util.go
+++ b/x/ref/lib/discovery/plugins/testutil/util.go
@@ -79,21 +79,22 @@ func doScan(ctx *context.T, p idiscovery.Plugin, interfaceName string, expectedA
 	defer stop()
 
 	adinfos := make([]idiscovery.AdInfo, 0, expectedAdInfos)
-	fmt.Printf("doScan: waiting for %v events\n", expectedAdInfos)
+	start := time.Now()
+	fmt.Printf("%v: doScan: waiting for %v events\n", start, expectedAdInfos)
 	for {
 		var timer <-chan time.Time
 		// On the first iteration, wait on scanCh with no timeout.
 		if len(adinfos) >= expectedAdInfos {
-			fmt.Printf("doScan: bumping timer: have %v expecting %v\n", len(adinfos), expectedAdInfos)
+			fmt.Printf("%v: doScan: bumping timer: have %v expecting %v\n", time.Since(start), len(adinfos), expectedAdInfos)
 			timer = time.After(5 * time.Millisecond)
 		}
 
 		select {
 		case adinfo := <-scanCh:
 			adinfos = append(adinfos, *adinfo)
-			fmt.Printf("doScan: new: %v %v -> %v\n", adinfo, len(adinfos), expectedAdInfos)
+			fmt.Printf("%v: doScan: new: %v %v -> %v\n", time.Since(start), adinfo, len(adinfos), expectedAdInfos)
 		case <-timer:
-			fmt.Printf("doScan: timer returning %v\n", len(adinfos))
+			fmt.Printf("%v: doScan: timer returning %v\n", time.Since(start), len(adinfos))
 			return adinfos, nil
 		}
 	}

--- a/x/ref/lib/discovery/plugins/testutil/util.go
+++ b/x/ref/lib/discovery/plugins/testutil/util.go
@@ -6,7 +6,9 @@ package testutil
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"sync"
 	"time"
 
@@ -80,21 +82,23 @@ func doScan(ctx *context.T, p idiscovery.Plugin, interfaceName string, expectedA
 
 	adinfos := make([]idiscovery.AdInfo, 0, expectedAdInfos)
 	start := time.Now()
-	fmt.Printf("%v: doScan: waiting for %v events\n", start, expectedAdInfos)
+	_, file, line, _ := runtime.Caller(2)
+	file = filepath.Base(file)
+	fmt.Printf("%v:%v: %v: doScan: waiting for %v events\n", file, line, start, expectedAdInfos)
 	for {
 		var timer <-chan time.Time
 		// On the first iteration, wait on scanCh with no timeout.
 		if len(adinfos) >= expectedAdInfos {
-			fmt.Printf("%v: doScan: bumping timer: have %v expecting %v\n", time.Since(start), len(adinfos), expectedAdInfos)
+			fmt.Printf("%v:%v: %v: doScan: bumping timer: have %v expecting %v\n", file, line, time.Since(start), len(adinfos), expectedAdInfos)
 			timer = time.After(5 * time.Millisecond)
 		}
 
 		select {
 		case adinfo := <-scanCh:
 			adinfos = append(adinfos, *adinfo)
-			fmt.Printf("%v: doScan: new: %v %v -> %v\n", time.Since(start), adinfo, len(adinfos), expectedAdInfos)
+			fmt.Printf("%v:%v: %v: doScan: new: %v %v -> %v\n", file, line, time.Since(start), adinfo, len(adinfos), expectedAdInfos)
 		case <-timer:
-			fmt.Printf("%v: doScan: timer returning %v\n", time.Since(start), len(adinfos))
+			fmt.Printf("%v:%v: %v: doScan: timer returning %v\n", file, line, time.Since(start), len(adinfos))
 			return adinfos, nil
 		}
 	}

--- a/x/ref/lib/discovery/trigger.go
+++ b/x/ref/lib/discovery/trigger.go
@@ -4,9 +4,7 @@
 
 package discovery
 
-import (
-	"reflect"
-)
+import "reflect"
 
 // A Trigger is a simple multi-channel receiver. It triggers callbacks
 // when it receives signals from the corresponding channels.

--- a/x/ref/lib/discovery/trigger.go
+++ b/x/ref/lib/discovery/trigger.go
@@ -4,7 +4,9 @@
 
 package discovery
 
-import "reflect"
+import (
+	"reflect"
+)
 
 // A Trigger is a simple multi-channel receiver. It triggers callbacks
 // when it receives signals from the corresponding channels.


### PR DESCRIPTION
This PR stops the discovery Trigger when the ble plugin is stopped. This bug was noticed while debugging the flaky failures of the ble tests. This fix should reduce the number of outstanding goroutines when the tests do fail. Additional logging is added to help track down the cause of the failures which take the form of the tests running for longer than 10 minutes which suggests some kind of deadlock in the tests or the ble code since the tests generally run in .1 or .2s.