### PR TITLE
v23/naming,v23/flow/message: reduce mem allocations of using Endpoints

### DIFF
--- a/v23/naming/endpoint_test.go
+++ b/v23/naming/endpoint_test.go
@@ -231,3 +231,19 @@ func BenchmarkEndpointParsingBytes(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkEndpointString(b *testing.B) {
+	b.ReportAllocs()
+	eps := "@6@tcp@batman.com:2345@1@0000000000000000000000000000ba77@m@dev.v.io:foo@bar.com,dev.v.io:bar@bar.com:delegate@@"
+	ep, err := ParseEndpoint(eps)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s := ep.String()
+		if s != eps {
+			b.Fatalf("got %v, want %v", s, eps)
+		}
+	}
+}


### PR DESCRIPTION
This PR uses strings.Builder to implement naming.Endpoint.String() to reduce the number of allocations required and to improve its performance. Similarly the implementation of the flow/message is improved to avoid unnecessary copies when serializing and parsing endpoints. Appending a setup message now requires 11 allocations vs 31 before this PR.