### PR TITLE
v23/flow/message,v23/naming: add message.CopyBuffers and remove naming.ParseEndpointBytes

### DIFF
--- a/v23/flow/message/message_test.go
+++ b/v23/flow/message/message_test.go
@@ -39,6 +39,13 @@ func testMessagesWithResults(t *testing.T, ctx *context.T, cases []message.Messa
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got: %#v, want %#v", got, want)
 		}
+		message.CopyBuffers(got)
+		for i := range encoded {
+			encoded[i] = 0xff
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got: %#v, want %#v", got, want)
+		}
 	}
 }
 

--- a/v23/naming/endpoint.go
+++ b/v23/naming/endpoint.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"regexp"
 	"strings"
-	"unsafe"
 )
 
 const (
@@ -86,14 +85,6 @@ func ParseEndpoint(input string) (Endpoint, error) {
 	default:
 		return Endpoint{}, errInvalidEndpointString
 	}
-}
-
-// ParseEndpointBytes is line ParseEndpoint but avoids the
-// need for converting a []byte to a string. The caller must
-// ensure that input is not changed whilst ParseEndpointBytes is
-// executing.
-func ParseEndpointBytes(input []byte) (Endpoint, error) {
-	return ParseEndpoint(*(*string)(unsafe.Pointer(&input)))
 }
 
 func parseHostPort(blessing, hostport string) (Endpoint, error) {

--- a/v23/naming/endpoint_test.go
+++ b/v23/naming/endpoint_test.go
@@ -225,7 +225,7 @@ func BenchmarkEndpointParsingBytes(b *testing.B) {
 	ep := []byte("@6@tcp@batman.com:2345@1@0000000000000000000000000000ba77@m@dev.v.io:foo@bar.com,dev.v.io:bar@bar.com:delegate@@")
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_, err := ParseEndpointBytes(ep)
+		_, err := ParseEndpoint(string(ep))
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
This PR adds message.CopyBuffers in anticipation of experimenting with using shared buffers for network input. CopyBuffers would be called to make copies of any internally use buffers that refer to the original buffer that the message
was read from. ParseEndpointBytes is also removed since it proved too hard to manage the lifecycle of endpoints. Finally, the order in the switch statement in message.Read is modified to have more commonly used messages first.