### PR TITLE
v23/flow: add ReadMsg2 to flow.MsgReader api

### DIFF
--- a/v23/flow/model.go
+++ b/v23/flow/model.go
@@ -213,6 +213,15 @@ type MsgReader interface {
 	// ReadMsg is like read, but it reads bytes in chunks.  Depending on the
 	// implementation the batch boundaries might or might not be significant.
 	ReadMsg() ([]byte, error)
+
+	// ReadMsg2 is like ReadMsg except that it can optionally use the supplied
+	// buffer to store the read message rather than always allocating
+	// a new one. The use of the supplied buffer is optional and different
+	// implementations may make different decisions as to whether to use
+	// it (assuming it is large enough). Consequently the caller should always
+	// use the returned buffer. Calling ReadMsg2 with a nil buffer is the same
+	// as calling ReadMsg.
+	ReadMsg2([]byte) ([]byte, error)
 }
 
 // MsgReadWriteCloser combines the MsgReader and MsgWriter interfaces and

--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -156,6 +156,13 @@ func (f *flw) ReadMsg() (buf []byte, err error) {
 	return
 }
 
+// ReadMsg2 is like ReadMsg. In this implementation it does not use the
+// supplied buffer since doing so would force an extraneous allocation and
+// copy.
+func (f *flw) ReadMsg2(_ []byte) (buf []byte, err error) {
+	return f.ReadMsg()
+}
+
 // Implement io.Writer.
 // Write, WriteMsg, and WriteMsgAndClose should not be called concurrently
 // with themselves or each other.

--- a/x/ref/runtime/protocols/debug/debug.go
+++ b/x/ref/runtime/protocols/debug/debug.go
@@ -70,6 +70,7 @@ type conn struct {
 func (c *conn) LocalAddr() net.Addr                  { return c.addr }
 func (c *conn) RemoteAddr() net.Addr                 { return c.base.RemoteAddr() }
 func (c *conn) ReadMsg() ([]byte, error)             { return c.base.ReadMsg() }
+func (c *conn) ReadMsg2(buf []byte) ([]byte, error)  { return c.base.ReadMsg2(buf) }
 func (c *conn) WriteMsg(data ...[]byte) (int, error) { return c.base.WriteMsg(data...) }
 func (c *conn) Close() error                         { return c.base.Close() }
 func (c *conn) UnsafeDisableEncryption() bool        { return true }

--- a/x/ref/runtime/protocols/lib/framer/framer_test.go
+++ b/x/ref/runtime/protocols/lib/framer/framer_test.go
@@ -19,53 +19,52 @@ func (*readWriteCloser) Close() error {
 
 func TestFramer(t *testing.T) {
 	f := &framer{ReadWriteCloser: &readWriteCloser{}}
+
+	writeAndRead := func(want []byte, bufs [][]byte) {
+		l := len(want)
+		if n, err := f.WriteMsg(bufs...); err != nil || n != l {
+			t.Fatalf("got %v, %v, want %v, nil", n, err, l)
+		}
+		if got, err := f.ReadMsg(); err != nil || !bytes.Equal(got, want) {
+			t.Errorf("got %v, %v, want %v, nil", got, err, want)
+		}
+
+		if n, err := f.WriteMsg(bufs...); err != nil || n != l {
+			t.Fatalf("got %v, %v, want %v, nil", n, err, l)
+		}
+
+		rbuf := make([]byte, len(want)*2)
+		got, err := f.ReadMsg2(rbuf)
+		if err != nil || !bytes.Equal(got, want) {
+			t.Errorf("got %v, %v, want %v, nil", got, err, want)
+		}
+		rbuf[0] = 0xff
+		if bytes.Equal(got, want) {
+			t.Errorf("looks like ReadMsg2 did not use the supplied buffer")
+		}
+	}
+
 	bufs := [][]byte{[]byte("read "), []byte("this "), []byte("please.")}
 	want := []byte("read this please.")
-	l := len(want)
-	if n, err := f.WriteMsg(bufs...); err != nil || n != l {
-		t.Fatalf("got %v, %v, want %v, nil", n, err, l)
-	}
-	if got, err := f.ReadMsg(); err != nil || !bytes.Equal(got, want) {
-		t.Errorf("got %v, %v, want %v, nil", got, err, want)
-	}
+
+	writeAndRead(want, bufs)
+
 	// Framing a smaller message afterwards should reuse the internal buffer
 	// from the first sent message.
+	oldBufferLen := len(want) + 3
 	bufs = [][]byte{[]byte("read "), []byte("this "), []byte("too.")}
 	want = []byte("read this too.")
-	oldBufferLen := l + 3
-	l = len(want)
-	if n, err := f.WriteMsg(bufs...); err != nil || n != l {
-		t.Fatalf("got %v, %v, want %v, nil", n, err, l)
-	}
-	if got, err := f.ReadMsg(); err != nil || !bytes.Equal(got, want) {
-		t.Errorf("got %v, %v, want %v, nil", got, err, want)
-	}
+
+	writeAndRead(want, bufs)
+
 	if len(f.buf) != oldBufferLen {
 		t.Errorf("framer internal buffer should have been reused")
 	}
 	// Sending larger message afterwards should work as well.
 	bufs = [][]byte{[]byte("read "), []byte("this "), []byte("way bigger message.")}
 	want = []byte("read this way bigger message.")
-	l = len(want)
-	if n, err := f.WriteMsg(bufs...); err != nil || n != l {
-		t.Fatalf("got %v, %v, want %v, nil", n, err, l)
-	}
-	if got, err := f.ReadMsg(); err != nil || !bytes.Equal(got, want) {
-		t.Errorf("got %v, %v, want %v, nil", got, err, want)
-	}
 
-	if n, err := f.WriteMsg(bufs...); err != nil || n != l {
-		t.Fatalf("got %v, %v, want %v, nil", n, err, l)
-	}
-	rbuf := make([]byte, len(want)*2)
-	got, err := f.ReadMsg2(rbuf)
-	if err != nil || !bytes.Equal(got, want) {
-		t.Errorf("got %v, %v, want %v, nil", got, err, want)
-	}
-	rbuf[0] = 0xff
-	if bytes.Equal(got, want) {
-		t.Errorf("looks like ReadMsg2 did not use the supplied buffer")
-	}
+	writeAndRead(want, bufs)
 
 }
 

--- a/x/ref/runtime/protocols/lib/framer/framer_test.go
+++ b/x/ref/runtime/protocols/lib/framer/framer_test.go
@@ -53,6 +53,20 @@ func TestFramer(t *testing.T) {
 	if got, err := f.ReadMsg(); err != nil || !bytes.Equal(got, want) {
 		t.Errorf("got %v, %v, want %v, nil", got, err, want)
 	}
+
+	if n, err := f.WriteMsg(bufs...); err != nil || n != l {
+		t.Fatalf("got %v, %v, want %v, nil", n, err, l)
+	}
+	rbuf := make([]byte, len(want)*2)
+	got, err := f.ReadMsg2(rbuf)
+	if err != nil || !bytes.Equal(got, want) {
+		t.Errorf("got %v, %v, want %v, nil", got, err, want)
+	}
+	rbuf[0] = 0xff
+	if bytes.Equal(got, want) {
+		t.Errorf("looks like ReadMsg2 did not use the supplied buffer")
+	}
+
 }
 
 func Test3ByteUint(t *testing.T) {

--- a/x/ref/runtime/protocols/lib/websocket/conn.go
+++ b/x/ref/runtime/protocols/lib/websocket/conn.go
@@ -57,6 +57,10 @@ func (c *wrappedConn) ReadMsg() ([]byte, error) {
 	return b, nil
 }
 
+func (c *wrappedConn) ReadMsg2([]byte) ([]byte, error) {
+	return c.ReadMsg()
+}
+
 func (c *wrappedConn) WriteMsg(bufs ...[]byte) (int, error) {
 	c.writeLock.Lock()
 	defer c.writeLock.Unlock()

--- a/x/ref/runtime/protocols/local/init.go
+++ b/x/ref/runtime/protocols/local/init.go
@@ -34,6 +34,7 @@ type conn struct {
 
 func (c *conn) LocalAddr() net.Addr  { return c.addr }
 func (c *conn) RemoteAddr() net.Addr { return c.peer.addr }
+
 func (c *conn) ReadMsg() ([]byte, error) {
 	select {
 	case msg := <-c.incoming:
@@ -42,6 +43,11 @@ func (c *conn) ReadMsg() ([]byte, error) {
 		return nil, io.EOF
 	}
 }
+
+func (c *conn) ReadMsg2([]byte) ([]byte, error) {
+	return c.ReadMsg()
+}
+
 func (c *conn) WriteMsg(data ...[]byte) (int, error) {
 	l := 0
 	for _, b := range data {

--- a/x/ref/runtime/protocols/vine/vine.go
+++ b/x/ref/runtime/protocols/vine/vine.go
@@ -271,6 +271,10 @@ func (c *conn) ReadMsg() ([]byte, error) {
 	return c.base.ReadMsg()
 }
 
+func (c *conn) ReadMsg2(buf []byte) ([]byte, error) {
+	return c.base.ReadMsg2(buf)
+}
+
 func (c *conn) Close() error {
 	c.vine.removeConn(c)
 	return c.base.Close()


### PR DESCRIPTION
ReadMsg2 allows for the caller to supply a buffer to be (optionally) used instead of always allocating a new buffer for each new message. This is intended to support reducing memory allocations and copies in the RPC stack.