### PR TITLE
x/ref/runtime/protocols/lib/framer: bound memory usage

### DIFF
--- a/x/ref/runtime/internal/rpc/benchmark/summary/summary_test.go
+++ b/x/ref/runtime/internal/rpc/benchmark/summary/summary_test.go
@@ -43,6 +43,8 @@ func Benchmark_______ConnectionSetup(b *testing.B) { runConnections(b) }
 func Benchmark__Echo_____________1KB(b *testing.B) { runEcho(b, 1000, false) }
 func Benchmark__Echo____________10KB(b *testing.B) { runEcho(b, 10000, false) }
 func Benchmark__Echo_____________1MB(b *testing.B) { runEcho(b, 1000000, false) }
+func Benchmark__Echo____________10MB(b *testing.B) { runEcho(b, 10000000, false) }
+
 func Benchmark__Echo________Rnd_10KB(b *testing.B) { runEcho(b, 10000, true) }
 func Benchmark__Echo_Stream_____10KB(b *testing.B) { runEchoStream(b, 10, 10000, false) }
 func Benchmark__Echo_Stream____500KB(b *testing.B) { runEchoStream(b, 10, 500000, false) }

--- a/x/ref/runtime/internal/rpc/benchmark/summary/summary_test.go
+++ b/x/ref/runtime/internal/rpc/benchmark/summary/summary_test.go
@@ -40,7 +40,9 @@ func runEchoStream(b *testing.B, chunkCnt, payloadSize int, random bool) {
 }
 
 func Benchmark_______ConnectionSetup(b *testing.B) { runConnections(b) }
+func Benchmark__Echo_____________1KB(b *testing.B) { runEcho(b, 1000, false) }
 func Benchmark__Echo____________10KB(b *testing.B) { runEcho(b, 10000, false) }
+func Benchmark__Echo_____________1MB(b *testing.B) { runEcho(b, 1000000, false) }
 func Benchmark__Echo________Rnd_10KB(b *testing.B) { runEcho(b, 10000, true) }
 func Benchmark__Echo_Stream_____10KB(b *testing.B) { runEchoStream(b, 10, 10000, false) }
 func Benchmark__Echo_Stream____500KB(b *testing.B) { runEchoStream(b, 10, 500000, false) }

--- a/x/ref/runtime/protocols/lib/framer/framer_test.go
+++ b/x/ref/runtime/protocols/lib/framer/framer_test.go
@@ -18,7 +18,7 @@ func (*readWriteCloser) Close() error {
 }
 
 func TestFramer(t *testing.T) {
-	f := &framer{ReadWriteCloser: &readWriteCloser{}}
+	f := New(&readWriteCloser{})
 
 	writeAndRead := func(want []byte, bufs [][]byte) {
 		l := len(want)
@@ -49,30 +49,11 @@ func TestFramer(t *testing.T) {
 
 	writeAndRead(want, bufs)
 
-	// Framing a smaller message afterwards should reuse the internal buffer
-	// from the first sent message.
-	oldBufferLen := len(want) + 3
-	bufs = [][]byte{[]byte("read "), []byte("this "), []byte("too.")}
-	want = []byte("read this too.")
-
-	writeAndRead(want, bufs)
-
-	if len(f.buf) != oldBufferLen {
-		t.Errorf("framer internal buffer should have been reused")
-	}
-	// Sending larger message afterwards should work as well.
-	bufs = [][]byte{[]byte("read "), []byte("this "), []byte("way bigger message.")}
-	want = []byte("read this way bigger message.")
-
-	writeAndRead(want, bufs)
-
 }
 
 func Test3ByteUint(t *testing.T) {
 	var b [3]byte
-	if err := write3ByteUint(b[:], 65555); err != nil {
-		t.Error(err)
-	}
+	write3ByteUint(b[:], 65555)
 	if got := read3ByteUint(b); got != 65555 {
 		t.Errorf("got %v, want %v", got, 65555)
 	}

--- a/x/ref/runtime/protocols/lib/framer/framer_test.go
+++ b/x/ref/runtime/protocols/lib/framer/framer_test.go
@@ -17,7 +17,7 @@ type readWriteCloser struct {
 }
 
 func (rwc *readWriteCloser) Write(data []byte) (int, error) {
-	rwc.wrops += 1
+	rwc.wrops++
 	return rwc.rw.Write(data)
 }
 func (rwc *readWriteCloser) Read(buf []byte) (int, error) {

--- a/x/ref/runtime/protocols/lib/tcputil/tcputil.go
+++ b/x/ref/runtime/protocols/lib/tcputil/tcputil.go
@@ -95,7 +95,7 @@ func (ln *tcpListener) Close() error {
 
 func NewTCPConn(c net.Conn) flow.Conn {
 	return tcpConn{
-		framer.New(c, 8192),
+		framer.New(c),
 		c.LocalAddr(),
 		c.RemoteAddr(),
 	}

--- a/x/ref/runtime/protocols/lib/tcputil/tcputil.go
+++ b/x/ref/runtime/protocols/lib/tcputil/tcputil.go
@@ -95,7 +95,7 @@ func (ln *tcpListener) Close() error {
 
 func NewTCPConn(c net.Conn) flow.Conn {
 	return tcpConn{
-		framer.New(c, 1300),
+		framer.New(c, 8192),
 		c.LocalAddr(),
 		c.RemoteAddr(),
 	}

--- a/x/ref/runtime/protocols/lib/tcputil/tcputil.go
+++ b/x/ref/runtime/protocols/lib/tcputil/tcputil.go
@@ -95,7 +95,7 @@ func (ln *tcpListener) Close() error {
 
 func NewTCPConn(c net.Conn) flow.Conn {
 	return tcpConn{
-		framer.New(c),
+		framer.New(c, 1300),
 		c.LocalAddr(),
 		c.RemoteAddr(),
 	}


### PR DESCRIPTION
This PR ensures that the framer implementation will never use more than a fixed amount of memory. The previous implementation would always copy the supplied data to a newly allocated buffer in order to prepend the frame size before issuing a single system call to write the data. The new implementation instead will only do this for small payloads, for larger ones it will issue multiple system calls, one for the message size and then one per payload argument. This also reduces the amount of data copying which should be beneficial for large payloads.