### PR TITLE
x/ref/runtime/internal/flow/conn: minor changes and comments for the readq implementation

### DIFF
--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -72,7 +72,6 @@ func (c *Conn) newFlowLocked(
 	f := &flw{
 		id:               id,
 		conn:             c,
-		q:                newReadQ(c, id),
 		localBlessings:   localBlessings,
 		localDischarges:  localDischarges,
 		remoteBlessings:  remoteBlessings,
@@ -87,6 +86,8 @@ func (c *Conn) newFlowLocked(
 		channelTimeout: channelTimeout,
 		sideChannel:    sideChannel,
 	}
+	f.q = newReadQ(f.release)
+
 	f.next, f.prev = f, f
 	f.ctx, f.cancel = context.WithCancel(ctx)
 	if !f.opened {
@@ -95,6 +96,10 @@ func (c *Conn) newFlowLocked(
 	c.flows[id] = f
 	c.healthCheckNewFlowLocked(ctx, channelTimeout)
 	return f
+}
+
+func (f *flw) release(ctx *context.T, n int) {
+	f.conn.release(ctx, f.id, uint64(n))
 }
 
 func (c *Conn) newFlowCountersLocked(id uint64) {

--- a/x/ref/runtime/internal/flow/conn/readq.go
+++ b/x/ref/runtime/internal/flow/conn/readq.go
@@ -5,7 +5,6 @@
 package conn
 
 import (
-	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -97,7 +96,6 @@ func (r *readq) put(ctx *context.T, bufs [][]byte) error {
 
 func (r *readq) reserveLocked(n int) {
 	if n < len(r.bufsBuiltin) && len(r.bufs) > len(r.bufsBuiltin) {
-		fmt.Printf("shrunk..")
 		r.moveqLocked(r.bufsBuiltin[:])
 		return
 	}

--- a/x/ref/runtime/internal/flow/conn/readq_test.go
+++ b/x/ref/runtime/internal/flow/conn/readq_test.go
@@ -28,7 +28,7 @@ type readqRelease struct {
 }
 
 func (rr *readqRelease) release(ctx *context.T, n int) {
-	rr.n = n
+	rr.n += n
 }
 
 func TestReadqRead(t *testing.T) {
@@ -131,7 +131,7 @@ func TestReadqMixed(t *testing.T) {
 		t.Errorf("expected EOF got %v", err)
 	}
 
-	if got, want := rr.n, 10; got != want {
+	if got, want := rr.n, 18; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
This PR tidies up and documents the implementation of the readq used to pass data from a flow's network receiver code to the flow's Read and ReadMsg methods used by higher level code. The current implementation assumes that buffers may be passed directly from the network to the readq and then on to the caller of GetMsg (called on a different goroutine) and this is now clearly documented/defined. 