### PR TITLE
x/ref/runtime/internal/flow/conn: refactor the blessingsFlow caches to be slices rather than maps

### DIFF
--- a/x/ref/runtime/internal/flow/conn/auth.go
+++ b/x/ref/runtime/internal/flow/conn/auth.go
@@ -36,19 +36,7 @@ func (c *Conn) dialHandshake(
 	}
 	dialedEP := c.remote
 	c.remote.RoutingID = remoteEndpoint.RoutingID
-	bflow := c.newFlowLocked(
-		ctx,
-		blessingsFlowID,
-		security.Blessings{},
-		security.Blessings{},
-		nil,
-		nil,
-		naming.Endpoint{},
-		true,
-		true,
-		0,
-		true)
-	bflow.releaseLocked(DefaultBytesBufferedPerFlow)
+	bflow := c.newFlowForBlessingsLocked(ctx)
 	c.blessingsFlow = newBlessingsFlow(bflow)
 
 	rttend, err := c.readRemoteAuth(ctx, binding, true)
@@ -112,18 +100,7 @@ func (c *Conn) acceptHandshake(
 		return rtt, err
 	}
 	c.remote = remoteEndpoint
-	bflow := c.newFlowLocked(
-		ctx,
-		blessingsFlowID,
-		security.Blessings{},
-		security.Blessings{},
-		nil,
-		nil,
-		naming.Endpoint{},
-		true,
-		true,
-		0,
-		true)
+	bflow := c.newFlowForBlessingsLocked(ctx)
 	c.blessingsFlow = newBlessingsFlow(bflow)
 	signedBinding, err := v23.GetPrincipal(ctx).Sign(append(authAcceptorTag, binding...))
 	if err != nil {

--- a/x/ref/runtime/internal/flow/conn/blessings_caches.go
+++ b/x/ref/runtime/internal/flow/conn/blessings_caches.go
@@ -1,0 +1,154 @@
+// Copyright 2022 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package conn
+
+import (
+	"v.io/v23/security"
+)
+
+// inCache keeps track of incoming blessings, discharges, and keys.
+type inCache struct {
+	blessings  blessingsCache // indexed by bkey-1
+	discharges dischargeCache // indexed by dkey-1
+	dkeys      keyCache       // dkey of the latest discharges, indexed by bkey-1.
+}
+
+type keyCache []uint64
+
+func (c keyCache) extend(key uint64) keyCache {
+	if needed := int(key); needed > len(c) {
+		tmp := make([]uint64, needed)
+		copy(tmp, c)
+		return tmp
+	}
+	return c
+}
+
+func (c keyCache) has(key uint64) (uint64, bool) {
+	if int(key) < len(c) {
+		b := c[key]
+		return b, b != 0
+	}
+	return 0, false
+}
+
+type blessingsCache []security.Blessings
+
+func (c blessingsCache) extend(key uint64) blessingsCache {
+	if needed := int(key); needed > len(c) {
+		tmp := make([]security.Blessings, needed)
+		copy(tmp, c)
+		return tmp
+	}
+	return c
+}
+
+func (c blessingsCache) has(key uint64) (security.Blessings, bool) {
+	if int(key) < len(c) {
+		b := c[key]
+		return b, !b.IsZero()
+	}
+	return security.Blessings{}, false
+}
+
+type dischargeCache [][]security.Discharge
+
+func (c dischargeCache) extend(key uint64) dischargeCache {
+	if needed := int(key); needed > len(c) {
+		tmp := make([][]security.Discharge, needed)
+		copy(tmp, c)
+		return tmp
+	}
+	return c
+}
+
+func (c dischargeCache) has(key uint64) ([]security.Discharge, bool) {
+	if int(key) < len(c) {
+		b := c[key]
+		return b, b != nil
+	}
+	return nil, false
+}
+
+func (c *inCache) addBlessings(bkey uint64, blessings security.Blessings) {
+	c.blessings = c.blessings.extend(bkey)
+	c.blessings[bkey-1] = blessings
+}
+
+func (c *inCache) hasBlessings(bkey uint64) (security.Blessings, bool) {
+	return c.blessings.has(bkey)
+}
+
+func (c *inCache) addDischarges(bkey, dkey uint64, discharges []security.Discharge) {
+	c.discharges = c.discharges.extend(dkey)
+	c.discharges[dkey-1] = discharges
+	c.dkeys = c.dkeys.extend(bkey)
+	c.dkeys[bkey-1] = dkey
+}
+
+func (c *inCache) hasDischarges(dkey uint64) ([]security.Discharge, bool) {
+	return c.discharges.has(dkey)
+}
+
+// outCache keeps track of outgoing blessings, discharges, and keys.
+type outCache struct {
+	bkeys uidCache // blessings uid -> bkey
+	dkeys keyCache // blessings bkey -> dkey of latest discharges
+
+	blessings  blessingsCache // indexed by bkey
+	discharges dischargeCache // indexed by dkey
+
+	/*bkeys map[string]uint64 // blessings uid -> bkey
+	dkeys      map[uint64]uint64      // blessings bkey -> dkey of latest discharges
+	blessings  []security.Blessings   // keyed by bkey
+	discharges [][]security.Discharge // keyed by dkey*/
+}
+
+type uidCache []string
+
+func (c uidCache) extend(key string) uidCache {
+	if needed := int(key); needed > len(c) {
+		tmp := make([]string, needed)
+		copy(tmp, c)
+		return tmp
+	}
+	return c
+}
+
+func (c uidCache) has(key uint64) (uint64, bool) {
+	if int(key) < len(c) {
+		b := c[key]
+		return b, b != 0
+	}
+	return 0, false
+}
+
+func (c *outCache) addBlessings(buid string, bkey uint64) {
+	if needed := int(bkey) + 1; needed > len(c.bkeys) {
+		tmp := make([]string, needed)
+		copy(tmp, c)
+		return tmp
+	}
+
+}
+
+func (c *outCache) hasBlessings(buid string) (uint64, bool) {
+	for i, v := range c.bkeys {
+		if v == buid {
+			return uint64(i), true
+		}
+	}
+	return 0, false
+}
+
+/*
+func newOutCache() *outCache {
+	return &outCache{
+		bkeys:      make(map[string]uint64),
+		dkeys:      make(map[uint64]uint64),
+		blessings:  make(map[uint64]security.Blessings),
+		discharges: make(map[uint64][]security.Discharge),
+	}
+}*/

--- a/x/ref/runtime/internal/flow/conn/blessings_caches_test.go
+++ b/x/ref/runtime/internal/flow/conn/blessings_caches_test.go
@@ -54,7 +54,6 @@ func TestBlessingsIncomingCache(t *testing.T) {
 	if got, want := len(ic.discharges), 2; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
-
 }
 
 func TestBlessingsOutgoingCache(t *testing.T) {

--- a/x/ref/runtime/internal/flow/conn/blessings_caches_test.go
+++ b/x/ref/runtime/internal/flow/conn/blessings_caches_test.go
@@ -1,0 +1,102 @@
+// Copyright 2022 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package conn
+
+import (
+	"testing"
+
+	"v.io/v23/security"
+)
+
+func TestBlessingsIncomingCache(t *testing.T) {
+	var ic inCache
+
+	testHasBlessings := func(bkey uint64, present bool) {
+		_, o := ic.hasBlessings(bkey)
+		if got, want := o, present; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	}
+
+	testHasDischarges := func(bkey, dkey uint64, present bool) {
+		d, dk, o := ic.hasDischarges(bkey)
+		if got, want := o, present; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if got, want := dk, dkey; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if present && d == nil {
+			t.Errorf("should not be nil")
+		}
+		if !present && d != nil {
+			t.Errorf("should be nil")
+		}
+	}
+
+	testHasBlessings(0, false)
+	ic.addBlessings(2, security.Blessings{})
+	testHasBlessings(1, false)
+	testHasBlessings(2, true)
+
+	if got, want := len(ic.blessings), 1; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	testHasDischarges(0, 0, false)
+	ic.addDischarges(2, 1, []security.Discharge{})
+	testHasDischarges(1, 2, true)
+
+	ic.addDischarges(3, 2, []security.Discharge{})
+
+	if got, want := len(ic.discharges), 2; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+}
+
+func TestBlessingsOutgoingCache(t *testing.T) {
+	var oc outCache
+
+	testHasBlessings := func(uid string, bkey uint64, present bool) {
+		k, o := oc.hasBlessings(uid)
+		if got, want := o, present; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if got, want := k, bkey; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	}
+
+	testHasDischarges := func(bkey, dkey uint64, present bool) {
+		d, dk, o := oc.hasDischarges(bkey)
+		if got, want := o, present; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if got, want := dk, dkey; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if present && d == nil {
+			t.Errorf("should not be nil")
+		}
+		if !present && d != nil {
+			t.Errorf("should be nil")
+		}
+	}
+
+	testHasBlessings("x", 0, false)
+	oc.addBlessings("yy", 1, security.Blessings{})
+	testHasBlessings("yy", 1, true)
+	if got, want := len(oc.blessings), 1; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	testHasDischarges(1, 0, false)
+	oc.addDischarges(1, 2, []security.Discharge{})
+	testHasDischarges(1, 2, true)
+	testHasDischarges(3, 0, false)
+	if got, want := len(oc.discharges), 1; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/x/ref/runtime/internal/flow/conn/blessings_flow.go
+++ b/x/ref/runtime/internal/flow/conn/blessings_flow.go
@@ -14,8 +14,6 @@ import (
 	iflow "v.io/x/ref/runtime/internal/flow"
 )
 
-// create simplified flow for blessings.
-
 func (c *Conn) newFlowForBlessingsLocked(ctx *context.T) *flw {
 	f := &flw{
 		id:          blessingsFlowID,

--- a/x/ref/runtime/internal/flow/conn/blessings_flow.go
+++ b/x/ref/runtime/internal/flow/conn/blessings_flow.go
@@ -15,6 +15,14 @@ import (
 )
 
 func (c *Conn) newFlowForBlessingsLocked(ctx *context.T) *flw {
+	// TODO(cnicolaou): create a simplified flow implementation for
+	// blessings as follows:
+	//   - flow control is essentially disabled for these flows, so
+	//     there's no need for a readq
+	//   - there is only ever one writer so there's no need for the
+	//     writerq/writech.
+	//   - the flow's are always pre-opened and never closed so no
+	//     need for state to track that.
 	f := &flw{
 		id:          blessingsFlowID,
 		conn:        c,


### PR DESCRIPTION
This PR replaces the use of maps with slices for the caches used by the blessingsFlow implementation since in practice the number of elements stored is very small (typically 2) so using maps is expensive by comparison to small slices. Memory allocation is accordingly reduced.

The creation of blessingsFlows is also simplified.