### PR TITLE
v23/vom: use slice instead of small maps for better performance and less memory overhead.

### DIFF
--- a/v23/vdl/reflect_type_test.go
+++ b/v23/vdl/reflect_type_test.go
@@ -471,24 +471,45 @@ func BenchmarkStructMap(b *testing.B) {
 	}
 }
 
-func BenchmarkSlice(b *testing.B) {
-	has := func(s []*Type, t *Type) bool {
-		for i := 0; i < len(s); i++ {
-			if s[i] == t {
-				return true
-			}
+func has(s []*Type, t *Type) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == t {
+			return true
 		}
-		return false
 	}
+	return false
+}
+
+func BenchmarkSlice___16(b *testing.B) {
+	benchmarkSlice(b, 16)
+}
+
+func BenchmarkSlice___32(b *testing.B) {
+	benchmarkSlice(b, 32)
+}
+
+func BenchmarkSlice___48(b *testing.B) {
+	benchmarkSlice(b, 48)
+}
+
+func BenchmarkSlice___64(b *testing.B) {
+	benchmarkSlice(b, 64)
+}
+
+func BenchmarkSlice__128(b *testing.B) {
+	benchmarkSlice(b, 128)
+}
+
+func benchmarkSlice(b *testing.B, ntypes int) {
 	b.ReportAllocs()
-	ntypes := 24
 	typs := createTypes(ntypes)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ss := [64]*Type{}
+		ss := [128]*Type{}
 		m := ss[:0]
 		for j := 0; j < ntypes; j++ {
 			m = append(m, typs[j])
+			// worst case when the desired type is the most recent one
 			has(m, typs[j])
 		}
 	}

--- a/v23/vdl/type.go
+++ b/v23/vdl/type.go
@@ -478,7 +478,8 @@ func (t *Type) ContainsType(mode WalkMode, types ...*Type) bool {
 // terminated early, and false is returned by Walk.  The mode controls which
 // types in the type graph we will visit.
 func (t *Type) Walk(mode WalkMode, fn func(*Type) bool) bool {
-	return typeWalk(mode, t, fn, make(map[*Type]bool))
+	var seen [cycleArraySize]*Type
+	return typeWalk(mode, t, fn, seen[:0])
 }
 
 // WalkMode is the mode to perform a Walk through the type graph.
@@ -503,11 +504,11 @@ func (t *Type) subTypesInline() bool {
 	return false
 }
 
-func typeWalk(mode WalkMode, t *Type, fn func(*Type) bool, seen map[*Type]bool) bool {
-	if seen[t] {
+func typeWalk(mode WalkMode, t *Type, fn func(*Type) bool, seen []*Type) bool {
+	if hasType(seen, t) {
 		return true
 	}
-	seen[t] = true
+	seen = append(seen, t)
 	if !fn(t) {
 		return false
 	}

--- a/v23/vdl/type_builder.go
+++ b/v23/vdl/type_builder.go
@@ -761,7 +761,7 @@ func typeConsLookup(t *Type) *Type {
 	// buf is allocated on the stack so long as uniqueTypeStr does
 	// 'call up the stack', that is, it's ok for uniqueTypeStr to call itself
 	// recursively, but not for it to call a sub-function when then calls itself.
-	// This is a very large impact on the # of memory allocations and overall
+	// This has a large impact on the # of memory allocations and overall
 	// performance of typeConsLookup and consequently all vom decoding.
 	var buf [2048]byte
 	unique := t.unique


### PR DESCRIPTION
This PR is similar to #316. Additional benchmarks show that on a M1 Macbook Pro slices with fewer than 32 entries easily outperform a map.