### PR TITLE
v23/vom: make errors more specific and informative

### DIFF
--- a/v23/vom/decoder.go
+++ b/v23/vom/decoder.go
@@ -453,7 +453,7 @@ func (d *decoder81) NextField() (int, error) { //nolint:gocyclo
 		case err != nil:
 			return -1, err
 		case index >= uint64(top.Type.NumField()):
-			return -1, errIndexOutOfRange
+			return -1, fmt.Errorf("vom: NextField: union field index out of range: %v >= %v", index, top.Type.NumField())
 		default:
 			// Set LenHint=Index+1 so that we'll know we're done next time around.
 			field = int(index)
@@ -475,7 +475,7 @@ func (d *decoder81) NextField() (int, error) { //nolint:gocyclo
 		case err != nil:
 			return -1, err
 		case index >= uint64(top.Type.NumField()):
-			return -1, errIndexOutOfRange
+			return -1, fmt.Errorf("vom: NextField: struct field index out of range: %v >= %v", index, top.Type.NumField())
 		default:
 			field = int(index)
 			top.Index = field

--- a/v23/vom/decoder_util.go
+++ b/v23/vom/decoder_util.go
@@ -12,7 +12,6 @@ import (
 )
 
 var (
-	errIndexOutOfRange  = errors.New("vom: index out of range")
 	errDecodeZeroTypeID = errors.New("vom: zero type id")
 )
 
@@ -167,7 +166,7 @@ func (d *decoder81) skipValue(tt *vdl.Type) error { //nolint:gocyclo
 			case err != nil:
 				return err
 			case index >= uint64(tt.NumField()):
-				return errIndexOutOfRange
+				return fmt.Errorf("vom: skipValue: struct field index out of range: %v >= %v", index, tt.NumField())
 			default:
 				ttfield := tt.Field(int(index))
 				if err := d.skipValue(ttfield.Type); err != nil {
@@ -180,7 +179,7 @@ func (d *decoder81) skipValue(tt *vdl.Type) error { //nolint:gocyclo
 		case err != nil:
 			return err
 		case index >= uint64(tt.NumField()):
-			return errIndexOutOfRange
+			return fmt.Errorf("vom: skipValue: union field index out of range: %v >= %v", index, tt.NumField())
 		default:
 			ttfield := tt.Field(int(index))
 			return d.skipValue(ttfield.Type)

--- a/v23/vom/dump.go
+++ b/v23/vom/dump.go
@@ -653,7 +653,7 @@ func (d *dumpWorker) decodeValue(tt *vdl.Type) error { //nolint:gocyclo
 		}
 		if index >= uint64(tt.NumEnumLabel()) {
 			d.writeAtom(DumpKindIndex, PrimitivePUint{index}, "out of range for %v", tt)
-			return errIndexOutOfRange
+			return fmt.Errorf("vom: Dump: enum field index out of range: %v >= %v", index, tt.NumField())
 		}
 		label := tt.EnumLabel(int(index))
 		d.writeAtom(DumpKindIndex, PrimitivePUint{index}, "%v.%v", tt.Name(), label)
@@ -739,7 +739,7 @@ func (d *dumpWorker) decodeValue(tt *vdl.Type) error { //nolint:gocyclo
 				return err
 			case index >= uint64(tt.NumField()):
 				d.writeAtom(DumpKindIndex, PrimitivePUint{index}, "out of range for %v", tt)
-				return errIndexOutOfRange
+				return fmt.Errorf("vom: Dump: struct field index out of range: %v >= %v", index, tt.NumField())
 			}
 			ttfield := tt.Field(int(index))
 			d.writeAtom(DumpKindIndex, PrimitivePUint{index}, "%v.%v", tt.Name(), ttfield.Name)
@@ -755,7 +755,7 @@ func (d *dumpWorker) decodeValue(tt *vdl.Type) error { //nolint:gocyclo
 			return err
 		case index >= uint64(tt.NumField()):
 			d.writeAtom(DumpKindIndex, PrimitivePUint{index}, "out of range for %v", tt)
-			return errIndexOutOfRange
+			return fmt.Errorf("vom: Dump: union field index out of range: %v >= %v", index, tt.NumField())
 		}
 		ttfield := tt.Field(int(index))
 		if tt == wireTypeType {

--- a/v23/vom/single_shot.go
+++ b/v23/vom/single_shot.go
@@ -6,6 +6,7 @@ package vom
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"sync"
 	"unsafe"
@@ -186,7 +187,7 @@ func computeTypeDecoderCacheKey(b *decbuf) ([]byte, error) {
 	// Walk through bytes until we get to a value message.
 	for {
 		if b.end < b.beg {
-			return nil, errIndexOutOfRange
+			return nil, fmt.Errorf("vom: failed to compute type decoder cache key: %v < %v", b.end, b.beg)
 		}
 		// Handle incomplete types.
 		switch ok, err := binaryDecodeControlOnly(b, WireCtrlTypeIncomplete); {


### PR DESCRIPTION
This PR makes error reporting more specific to help track down a flaky test failure of rpc/test/cancel_test:TestCancel.