### PR TITLE
x/ref/runtime/internal/flow/conn: refactor flow control stats

### DIFF
--- a/x/ref/runtime/internal/flow/conn/auth.go
+++ b/x/ref/runtime/internal/flow/conn/auth.go
@@ -172,10 +172,12 @@ func (c *Conn) setup(ctx *context.T, versions version.RPCVersionRange, dialer bo
 	} else {
 		c.mtu = defaultMtu
 	}
-	c.lshared = lSetup.SharedTokens
-	if rSetup.SharedTokens != 0 && rSetup.SharedTokens < c.lshared {
-		c.lshared = rSetup.SharedTokens
+	lshared := lSetup.SharedTokens
+	if rSetup.SharedTokens != 0 && rSetup.SharedTokens < lshared {
+		lshared = rSetup.SharedTokens
 	}
+	c.flowControl.configure(c.mtu, lshared)
+
 	if rSetup.PeerNaClPublicKey == nil {
 		return nil, naming.Endpoint{}, rttstart, ErrMissingSetupOption.Errorf(ctx, "conn.setup: missing required setup option: peerNaClPublicKey")
 	}

--- a/x/ref/runtime/internal/flow/conn/close_test.go
+++ b/x/ref/runtime/internal/flow/conn/close_test.go
@@ -341,10 +341,10 @@ func testCounters(t *testing.T, ctx *context.T, count int, dialClose, acceptClos
 	}
 
 	dc.mu.Lock()
-	dialRelease, dialBorrowed = len(dc.toRelease), len(dc.borrowing)
+	dialRelease, dialBorrowed = len(dc.flowControl.toRelease), len(dc.flowControl.borrowing)
 	dc.mu.Unlock()
 	ac.mu.Lock()
-	acceptRelease, acceptBorrowed = len(ac.toRelease), len(ac.borrowing)
+	acceptRelease, acceptBorrowed = len(ac.flowControl.toRelease), len(ac.flowControl.borrowing)
 	ac.mu.Unlock()
 	ac.Close(ctx, nil)
 	dc.Close(ctx, nil)

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -118,33 +118,7 @@ type Conn struct {
 	hcstate                           *healthCheckState
 	acceptChannelTimeout              time.Duration
 
-	// TODO(mattr): Integrate these maps back into the flows themselves as
-	// has been done with the sending counts.
-	// toRelease is a map from flowID to a number of tokens which are pending
-	// to be released.  We only send release messages when some flow has
-	// used up at least half it's buffer, and then we send the counters for
-	// every flow.  This reduces the number of release messages that are sent.
-	toRelease map[uint64]uint64
-	// borrowing is a map from flowID to a boolean indicating whether the remote
-	// dialer of the flow is using shared counters for his sends because we've not
-	// yet sent a release for this flow.
-	borrowing map[uint64]bool
-
-	// In our protocol new flows are opened by the dialer by immediately
-	// starting to write data for that flow (in an OpenFlow message).
-	// Since the other side doesn't yet know of the existence of this new
-	// flow, it couldn't have allocated us any counters via a Release message.
-	// In order to deal with this the conn maintains a pool of shared tokens
-	// which are used by dialers of new flows.
-	// lshared is the number of shared tokens available for new flows dialed
-	// locally.
-	lshared uint64
-	// outstandingBorrowed is a map from flowID to a number of borrowed tokens.
-	// This map is populated when a flow closes locally before it receives a remote close
-	// or a release message.  In this case we need to remember that we have already
-	// used these counters and return them to the shared pool when we get
-	// a close or release.
-	outstandingBorrowed map[uint64]uint64
+	flowControl flowControlConnStats
 
 	// activeWriters keeps track of all the flows that are currently
 	// trying to write, indexed by priority.  activeWriters[0] is a list
@@ -212,13 +186,11 @@ func NewDialed( //nolint:gocyclo
 		nextFid:              reservedFlows,
 		flows:                map[uint64]*flw{},
 		lastUsedTime:         time.Now(),
-		toRelease:            map[uint64]uint64{},
-		borrowing:            map[uint64]bool{},
 		cancel:               cancel,
-		outstandingBorrowed:  make(map[uint64]uint64),
 		activeWriters:        make([]writer, numPriorities),
 		acceptChannelTimeout: channelTimeout,
 	}
+	c.flowControl.init()
 	done := make(chan struct{})
 	var rtt time.Duration
 	c.loopWG.Add(1)
@@ -336,13 +308,11 @@ func NewAccepted(
 		nextFid:              reservedFlows + 1,
 		flows:                map[uint64]*flw{},
 		lastUsedTime:         time.Now(),
-		toRelease:            map[uint64]uint64{},
-		borrowing:            map[uint64]bool{},
 		cancel:               cancel,
-		outstandingBorrowed:  make(map[uint64]uint64),
 		activeWriters:        make([]writer, numPriorities),
 		acceptChannelTimeout: channelTimeout,
 	}
+	c.flowControl.init()
 	done := make(chan struct{}, 1)
 	var rtt time.Duration
 	var err error
@@ -823,27 +793,15 @@ func (c *Conn) fragmentReleaseMessage(ctx *context.T, toRelease map[uint64]uint6
 	return nil
 }
 
-func (c *Conn) release(ctx *context.T, fid, count uint64) {
-	var toRelease map[uint64]uint64
-	var release bool
+func (c *Conn) sendRelease(ctx *context.T, fid, count uint64) {
 	c.mu.Lock()
 	if _, ok := c.flows[fid]; ok {
 		// Handle the case where the flow is already closed but a message
 		// is received for it, hence only bump the toRelease value for
 		// that flow if it is still active.
-		c.toRelease[fid] += count
+		c.flowControl.incrementToRelease(fid, count)
 	}
-	if c.borrowing[fid] {
-		c.toRelease[invalidFlowID] += count
-		release = c.toRelease[invalidFlowID] > DefaultBytesBufferedPerFlow/2
-	} else {
-		release = c.toRelease[fid] > DefaultBytesBufferedPerFlow/2
-	}
-	if release {
-		toRelease = c.toRelease
-		c.toRelease = make(map[uint64]uint64, len(c.toRelease))
-		c.borrowing = make(map[uint64]bool, len(c.borrowing))
-	}
+	toRelease := c.flowControl.createReleaseMessageContents(fid, count)
 	var err error
 	if toRelease != nil {
 		delete(toRelease, invalidFlowID)
@@ -852,22 +810,6 @@ func (c *Conn) release(ctx *context.T, fid, count uint64) {
 	c.mu.Unlock()
 	if err != nil {
 		c.Close(ctx, ErrSend.Errorf(ctx, "failure sending release message to %v: %v", c.remote.String(), err))
-	}
-}
-
-func (c *Conn) releaseOutstandingBorrowedLocked(fid, val uint64) {
-	borrowed := c.outstandingBorrowed[fid]
-	released := val
-	if borrowed == 0 {
-		return
-	} else if borrowed < released {
-		released = borrowed
-	}
-	c.lshared += released
-	if released == borrowed {
-		delete(c.outstandingBorrowed, fid)
-	} else {
-		c.outstandingBorrowed[fid] = borrowed - released
 	}
 }
 

--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -30,6 +30,11 @@ type flw struct {
 	channelTimeout                    time.Duration
 	sideChannel                       bool
 
+	// NOTE that lock in connFlowControl must be used to guard updates to
+	// flowControl also.
+	connFlowControl *flowControlConnStats
+	flowControl     flowControlFlowStats
+
 	// NOTE: The remaining variables are actually protected by conn.mu.
 
 	ctx    *context.T
@@ -41,16 +46,6 @@ type flw struct {
 	opened bool
 	// writing is true if we're in the middle of a write to this flow.
 	writing bool
-	// released counts tokens already released by the remote end, that is, the number
-	// of tokens we are allowed to send.
-	released uint64
-	// borrowed indicates the number of tokens we have borrowed from the shared pool for
-	// sending on newly dialed flows.
-	borrowed uint64
-	// borrowing indicates whether this flow is using borrowed counters for a newly
-	// dialed flow.  This will be set to false after we first receive a
-	// release from the remote end.  This is always false for accepted flows.
-	borrowing bool
 
 	closed bool
 
@@ -77,7 +72,7 @@ func (c *Conn) newFlowLocked(
 		remoteBlessings:  remoteBlessings,
 		remoteDischarges: remoteDischarges,
 		opened:           preopen,
-		borrowing:        dialed,
+		connFlowControl:  &c.flowControl,
 		// It's important that this channel has a non-zero buffer.  Sometimes this
 		// flow will be notifying itself, so if there's no buffer a deadlock will
 		// occur.
@@ -86,7 +81,8 @@ func (c *Conn) newFlowLocked(
 		channelTimeout: channelTimeout,
 		sideChannel:    sideChannel,
 	}
-	f.q = newReadQ(f.release)
+	f.flowControl.borrowing = dialed
+	f.q = newReadQ(f.sendRelease)
 
 	f.next, f.prev = f, f
 	f.ctx, f.cancel = context.WithCancel(ctx)
@@ -98,26 +94,8 @@ func (c *Conn) newFlowLocked(
 	return f
 }
 
-func (f *flw) release(ctx *context.T, n int) {
-	f.conn.release(ctx, f.id, uint64(n))
-}
-
-func (c *Conn) newFlowCountersLocked(id uint64) {
-	c.toRelease[id] = DefaultBytesBufferedPerFlow
-	c.borrowing[id] = true
-}
-
-func (c *Conn) clearFlowCountersLocked(id uint64) {
-	if !c.borrowing[id] {
-		delete(c.toRelease, id)
-		delete(c.borrowing, id)
-	}
-	// Need to keep borrowed counters around so that they can be sent
-	// to the dialer to allow for the shared counter to be incremented
-	// for all the past flows that borrowed counters (ie. pretty much
-	// any/all short lived connections). A much better approach would be
-	// to use a 'special' flow ID (e.g use the invalidFlowID) to use
-	// for referring to all borrowed tokens for closed flows.
+func (f *flw) sendRelease(ctx *context.T, n int) {
+	f.conn.sendRelease(ctx, f.id, uint64(n))
 }
 
 // Implement the writer interface.
@@ -181,9 +159,10 @@ func (f *flw) Write(p []byte) (n int, err error) {
 // It is bounded by the channel mtu, the released counters, and possibly
 // the number of shared counters for the conn if we are sending on a just
 // dialed flow.
-func (f *flw) tokensLocked() (int, func(int)) {
-
-	max := f.conn.mtu
+func (f *flw) tokens() (int, func(int)) {
+	f.connFlowControl.lock()
+	defer f.connFlowControl.unlock()
+	max := f.connFlowControl.mtu
 	// When	our flow is proxied (i.e. encapsulated), the proxy has added overhead
 	// when forwarding the message. This means we must reduce our mtu to ensure
 	// that dialer framing reaches the acceptor without being truncated by the
@@ -191,49 +170,51 @@ func (f *flw) tokensLocked() (int, func(int)) {
 	if f.conn.IsEncapsulated() {
 		max -= proxyOverhead
 	}
-	if f.borrowing {
-		if f.conn.lshared < max {
-			max = f.conn.lshared
+	if f.flowControl.borrowing {
+		if f.connFlowControl.lshared < max {
+			max = f.connFlowControl.lshared
 		}
 		return int(max), func(used int) {
-			f.conn.lshared -= uint64(used)
-			f.borrowed += uint64(used)
+			f.connFlowControl.lshared -= uint64(used)
+			f.flowControl.borrowed += uint64(used)
 			if f.ctx.V(2) {
-				f.ctx.Infof("deducting %d borrowed tokens on flow %d(%p), total: %d left: %d", used, f.id, f, f.borrowed, f.conn.lshared)
+				f.ctx.Infof("deducting %d borrowed tokens on flow %d(%p), total: %d left: %d", used, f.id, f, f.flowControl.borrowed, f.connFlowControl.lshared)
 			}
 		}
 	}
-	if f.released < max {
-		max = f.released
+	if f.flowControl.released < max {
+		max = f.flowControl.released
 	}
 	return int(max), func(used int) {
-		f.released -= uint64(used)
+		f.flowControl.released -= uint64(used)
 		if f.ctx.V(2) {
-			f.ctx.Infof("flow %d(%p) deducting %d tokens, %d left", f.id, f, used, f.released)
+			f.ctx.Infof("flow %d(%p) deducting %d tokens, %d left", f.id, f, used, f.flowControl.released)
 		}
 	}
 }
 
-// releaseLocked releases some counters from a remote reader to the local
+// releaseCounters releases some counters from a remote reader to the local
 // writer.  This allows the writer to then write more data to the wire.
-func (f *flw) releaseLocked(tokens uint64) {
+func (f *flw) releaseCounters(tokens uint64) {
 	debug := f.ctx.V(2)
-	f.borrowing = false
-	if f.borrowed > 0 {
+	f.connFlowControl.lock()
+	defer f.connFlowControl.unlock()
+	f.flowControl.borrowing = false
+	if f.flowControl.borrowed > 0 {
 		n := tokens
-		if f.borrowed < tokens {
-			n = f.borrowed
+		if f.flowControl.borrowed < tokens {
+			n = f.flowControl.borrowed
 		}
 		if debug {
-			f.ctx.Infof("Returning %d/%d tokens borrowed by %d(%p) shared: %d", n, tokens, f.id, f, f.conn.lshared)
+			f.ctx.Infof("Returning %d/%d tokens borrowed by %d(%p) shared: %d", n, tokens, f.id, f, f.connFlowControl.lshared)
 		}
 		tokens -= n
-		f.borrowed -= n
-		f.conn.lshared += n
+		f.flowControl.borrowed -= n
+		f.connFlowControl.lshared += n
 	}
-	f.released += tokens
+	f.flowControl.released += tokens
 	if debug {
-		f.ctx.Infof("Tokens release to %d(%p): %d => %d", f.id, f, tokens, f.released)
+		f.ctx.Infof("Tokens release to %d(%p): %d => %d", f.id, f, tokens, f.flowControl.released)
 	}
 	if f.writing {
 		if debug {
@@ -299,7 +280,7 @@ func (f *flw) writeMsg(alsoClose bool, parts ...[]byte) (sent int, err error) { 
 			break
 		}
 		opened := f.opened
-		tokens, deduct := f.tokensLocked()
+		tokens, deduct := f.tokens()
 		if opened && (tokens == 0 || ((f.noEncrypt || f.noFragment) && (tokens < totalSize))) {
 			// Oops, we really don't have data to send, probably because we've exhausted
 			// the remote buffer.  deactivate ourselves but keep trying.
@@ -519,17 +500,19 @@ func (f *flw) close(ctx *context.T, closedRemotely bool, err error) {
 				Flags: message.CloseFlag,
 			})
 		}
+		f.connFlowControl.lock()
 		if closedRemotely {
 			// When the other side closes a flow, it implicitly releases all the
 			// counters used by that flow.  That means we should release the shared
 			// counter to be used on other new flows.
-			f.conn.lshared += f.borrowed
-			f.borrowed = 0
-		} else if f.borrowed > 0 && f.conn.status < Closing {
-			f.conn.outstandingBorrowed[f.id] = f.borrowed
+			f.connFlowControl.lshared += f.flowControl.borrowed
+			f.flowControl.borrowed = 0
+		} else if f.flowControl.borrowed > 0 && f.conn.status < Closing {
+			f.connFlowControl.outstandingBorrowed[f.id] = f.flowControl.borrowed
 		}
+		f.connFlowControl.clearCountersLocked(f.id)
+		f.connFlowControl.unlock()
 		delete(f.conn.flows, f.id)
-		f.conn.clearFlowCountersLocked(f.id)
 		f.conn.mu.Unlock()
 		if serr != nil {
 			ctx.VI(2).Infof("Could not send close flow message: %v", err)

--- a/x/ref/runtime/internal/flow/conn/flowcontrol.go
+++ b/x/ref/runtime/internal/flow/conn/flowcontrol.go
@@ -1,0 +1,138 @@
+// Copyright 2022 The Vanadium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package conn
+
+import "sync"
+
+type flowControlConnStats struct {
+	mu sync.Mutex
+
+	mtu uint64
+
+	// TODO(mattr): Integrate these maps back into the flows themselves as
+	// has been done with the sending counts.
+	// toRelease is a map from flowID to a number of tokens which are pending
+	// to be released.  We only send release messages when some flow has
+	// used up at least half it's buffer, and then we send the counters for
+	// every flow.  This reduces the number of release messages that are sent.
+	toRelease map[uint64]uint64
+
+	// borrowing is a map from flowID to a boolean indicating whether the remote
+	// dialer of the flow is using shared counters for his sends because we've not
+	// yet sent a release for this flow.
+	borrowing map[uint64]bool
+
+	// In our protocol new flows are opened by the dialer by immediately
+	// starting to write data for that flow (in an OpenFlow message).
+	// Since the other side doesn't yet know of the existence of this new
+	// flow, it couldn't have allocated us any counters via a Release message.
+	// In order to deal with this the conn maintains a pool of shared tokens
+	// which are used by dialers of new flows.
+	// lshared is the number of shared tokens available for new flows dialed
+	// locally.
+	lshared uint64
+
+	// outstandingBorrowed is a map from flowID to a number of borrowed tokens.
+	// This map is populated when a flow closes locally before it receives a remote close
+	// or a release message.  In this case we need to remember that we have already
+	// used these counters and return them to the shared pool when we get
+	// a close or release.
+	outstandingBorrowed map[uint64]uint64
+}
+
+func (fs *flowControlConnStats) init() {
+	fs.toRelease = map[uint64]uint64{}
+	fs.borrowing = map[uint64]bool{}
+	fs.lshared = 0
+	fs.outstandingBorrowed = make(map[uint64]uint64)
+}
+
+func (fs *flowControlConnStats) configure(mtu, shared uint64) {
+	fs.mtu, fs.lshared = mtu, shared
+}
+
+func (fs *flowControlConnStats) lock() {
+	fs.mu.Lock()
+}
+
+func (fs *flowControlConnStats) unlock() {
+	fs.mu.Unlock()
+}
+
+func (fs *flowControlConnStats) newCounters(fid uint64) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	fs.toRelease[fid] = DefaultBytesBufferedPerFlow
+	fs.borrowing[fid] = true
+}
+
+func (fs *flowControlConnStats) incrementToRelease(fid, count uint64) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	fs.toRelease[fid] += count
+}
+
+func (fs *flowControlConnStats) createReleaseMessageContents(fid, count uint64) map[uint64]uint64 {
+	var release bool
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.borrowing[fid] {
+		fs.toRelease[invalidFlowID] += count
+		release = fs.toRelease[invalidFlowID] > DefaultBytesBufferedPerFlow/2
+	} else {
+		release = fs.toRelease[fid] > DefaultBytesBufferedPerFlow/2
+	}
+	if !release {
+		return nil
+	}
+	toRelease := fs.toRelease
+	fs.toRelease = make(map[uint64]uint64, len(fs.toRelease))
+	fs.borrowing = make(map[uint64]bool, len(fs.borrowing))
+	return toRelease
+}
+
+func (fs *flowControlConnStats) releaseOutstandingBorrowed(fid, val uint64) {
+	fs.lock()
+	defer fs.unlock()
+	borrowed := fs.outstandingBorrowed[fid]
+	released := val
+	if borrowed == 0 {
+		return
+	} else if borrowed < released {
+		released = borrowed
+	}
+	fs.lshared += released
+	if released == borrowed {
+		delete(fs.outstandingBorrowed, fid)
+	} else {
+		fs.outstandingBorrowed[fid] = borrowed - released
+	}
+}
+
+func (fs *flowControlConnStats) clearCountersLocked(fid uint64) {
+	if !fs.borrowing[fid] {
+		delete(fs.toRelease, fid)
+		delete(fs.borrowing, fid)
+	}
+	// Need to keep borrowed counters around so that they can be sent
+	// to the dialer to allow for the shared counter to be incremented
+	// for all the past flows that borrowed counters (ie. pretty much
+	// any/all short lived connections). A much better approach would be
+	// to use a 'special' flow ID (e.g use the invalidFlowID) to use
+	// for referring to all borrowed tokens for closed flows.
+}
+
+type flowControlFlowStats struct {
+	// released counts tokens already released by the remote end, that is, the number
+	// of tokens we are allowed to send.
+	released uint64
+	// borrowed indicates the number of tokens we have borrowed from the shared pool for
+	// sending on newly dialed flows.
+	borrowed uint64
+	// borrowing indicates whether this flow is using borrowed counters for a newly
+	// dialed flow.  This will be set to false after we first receive a
+	// release from the remote end.  This is always false for accepted flows.
+	borrowing bool
+}

--- a/x/ref/runtime/internal/flow/conn/handle_message.go
+++ b/x/ref/runtime/internal/flow/conn/handle_message.go
@@ -61,7 +61,7 @@ func (c *Conn) handleData(ctx *context.T, msg *message.Data) error {
 	if f == nil {
 		// If the flow is closing then we assume the remote side releases
 		// all borrowed counters for that flow.
-		c.releaseOutstandingBorrowedLocked(msg.ID, math.MaxUint64)
+		c.flowControl.releaseOutstandingBorrowed(msg.ID, math.MaxUint64)
 		c.mu.Unlock()
 		return nil
 	}
@@ -106,8 +106,8 @@ func (c *Conn) handleOpenFlow(ctx *context.T, msg *message.OpenFlow) error {
 		true,
 		c.acceptChannelTimeout,
 		sideChannel)
-	f.releaseLocked(msg.InitialCounters)
-	c.newFlowCountersLocked(msg.ID)
+	f.releaseCounters(msg.InitialCounters)
+	c.flowControl.newCounters(msg.ID)
 	c.mu.Unlock()
 
 	c.handler.HandleFlow(f) //nolint:errcheck
@@ -193,9 +193,9 @@ func (c *Conn) handleRelease(ctx *context.T, msg *message.Release) error {
 	defer c.mu.Unlock()
 	for fid, val := range msg.Counters {
 		if f := c.flows[fid]; f != nil {
-			f.releaseLocked(val)
+			f.releaseCounters(val)
 		} else {
-			c.releaseOutstandingBorrowedLocked(fid, val)
+			c.flowControl.releaseOutstandingBorrowed(fid, val)
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR separates out the flow control counters from the core Conn and Flow structs, moving into their own data types with specific locking for the flow control stats. This is a step towards simplifying the current locking strategy which relies on a single lock on the Conn to guard both the Conn and Flow's core data structures. The only shared state between a Conn and Flow are the flow control counters and by breaking this out it will allow for the simplification of both the Conn and Flow's locking going forward.