### PR TITLE
x/ref/runtime/internal/{flow/conn,rpc/test}: attempt to fix flaky test

### DIFF
--- a/v23/verror/compat.go
+++ b/v23/verror/compat.go
@@ -6,6 +6,7 @@ package verror
 
 import (
 	"errors"
+	"fmt"
 )
 
 // Error implements error.
@@ -72,6 +73,7 @@ func (se subErrChain) Unwrap() error {
 // verror.SubErrors followed by any error recorded with %w for Errorf or the
 // last argument to Message, New or ExplicitNew.
 func (e E) Unwrap() error {
+	fmt.Printf("unwrap...\n")
 	r := []error{}
 	for _, p := range e.ParamList {
 		switch se := p.(type) {

--- a/v23/verror/compat.go
+++ b/v23/verror/compat.go
@@ -6,7 +6,6 @@ package verror
 
 import (
 	"errors"
-	"fmt"
 )
 
 // Error implements error.
@@ -73,7 +72,6 @@ func (se subErrChain) Unwrap() error {
 // verror.SubErrors followed by any error recorded with %w for Errorf or the
 // last argument to Message, New or ExplicitNew.
 func (e E) Unwrap() error {
-	fmt.Printf("unwrap...\n")
 	r := []error{}
 	for _, p := range e.ParamList {
 		switch se := p.(type) {

--- a/v23/vom/binary_util.go
+++ b/v23/vom/binary_util.go
@@ -19,7 +19,7 @@ import (
 var errInvalid = errors.New("vom: invalid encoding")
 
 func errEndedBeforeVersionByte(err error) error {
-	return fmt.Errorf("ended before version byte received: %v", err)
+	return fmt.Errorf("ended before version byte received: %w", err)
 }
 
 func errBadVersionByte(v Version) error {

--- a/x/ref/runtime/internal/flow/conn/readq.go
+++ b/x/ref/runtime/internal/flow/conn/readq.go
@@ -163,6 +163,9 @@ func (r *readq) waitLocked(ctx *context.T) (err error) {
 			}
 		case <-ctx.Done():
 			err = io.EOF
+			if ctx.Err() == context.DeadlineExceeded {
+				err = context.DeadlineExceeded
+			}
 		}
 		r.mu.Lock()
 	}

--- a/x/ref/runtime/internal/rpc/client.go
+++ b/x/ref/runtime/internal/rpc/client.go
@@ -1069,6 +1069,9 @@ func decodingResponseError(ctx *context.T, err error, detail string) error {
 // as its retrun value. This allows for the stack trace of the original
 // error to be chained to that of any verror created with it as a first parameter.
 func decodeNetError(ctx *context.T, err error) (verror.IDAction, error) {
+	if errors.Unwrap(err) == context.DeadlineExceeded {
+		return verror.ErrTimeout, err
+	}
 	if neterr, ok := err.(net.Error); ok {
 		if neterr.Timeout() {
 			// If a read is canceled in the lower levels we see

--- a/x/ref/runtime/internal/rpc/test/client_test.go
+++ b/x/ref/runtime/internal/rpc/test/client_test.go
@@ -502,7 +502,7 @@ func TestTimeoutResponse(t *testing.T) {
 		err := v23.GetClient(ctx).Call(ctx, name, "Sleep", nil, nil)
 		if got, want := verror.ErrorID(err), verror.ErrTimeout.ID; got != want {
 			record := vtrace.GetStore(ctx).TraceRecord(span.Trace())
-			return fmt.Errorf("got %v, want %v: debugString %v\n%v\n", verror.ErrorID(err), want, verror.DebugString(err), record)
+			return fmt.Errorf("got %v, want %v: debugString %v\n%v", verror.ErrorID(err), want, verror.DebugString(err), record)
 		}
 		return nil
 	}
@@ -668,14 +668,14 @@ func TestStreamTimeout(t *testing.T) {
 			}
 			if got, want := verror.ErrorID(err), verror.ErrTimeout.ID; got != want {
 				record := vtrace.GetStore(ctx).TraceRecord(span.Trace())
-				return fmt.Errorf("got %v, want %v\n%v\n", got, want, record)
+				return fmt.Errorf("got %v, want %v\n%v", got, want, record)
 			}
 			break
 		}
 		err = call.Finish()
 		if got, want := verror.ErrorID(err), verror.ErrTimeout.ID; got != want {
 			record := vtrace.GetStore(ctx).TraceRecord(span.Trace())
-			return fmt.Errorf("got %v, want %v:\n%v\n", got, want, record)
+			return fmt.Errorf("got %v, want %v:\n%v", got, want, record)
 		}
 		return nil
 	}


### PR DESCRIPTION
This PR attempts to fix the flaky RPC tests TestTimeoutResponse and TestStreamTimeout which sometimes fail with an EOF rather a timeout error. The attempted fix is in conn.readq.waitLocked which will now return a context.DeadlineExceeded error when the context contains that error rather than converting all context errors to EOF. Additional changes are required to unwrap the timeout error and act accordingly. In addition, the tests themselves are run with different timeouts and additional vtrace output to further diagnose the problem if it persists. 