### PR TITLE
x/ref/runtime/internal/flow/conn: relocate flow control token calculations

### DIFF
--- a/x/ref/runtime/internal/flow/conn/flowcontrol.go
+++ b/x/ref/runtime/internal/flow/conn/flowcontrol.go
@@ -189,6 +189,8 @@ func (fs *flowControlFlowStats) tokens(ctx *context.T, encapsulated bool) (int, 
 			max = fs.lshared
 		}
 		return int(max), func(used int) {
+			fs.lock()
+			defer fs.unlock()
 			fs.lshared -= uint64(used)
 			fs.borrowed += uint64(used)
 			if ctx.V(2) {
@@ -200,6 +202,8 @@ func (fs *flowControlFlowStats) tokens(ctx *context.T, encapsulated bool) (int, 
 		max = fs.released
 	}
 	return int(max), func(used int) {
+		fs.lock()
+		defer fs.unlock()
 		fs.released -= uint64(used)
 		if ctx.V(2) {
 			ctx.Infof("flow %d deducting %d tokens, %d left", fs.id, used, fs.released)

--- a/x/ref/runtime/internal/flow/conn/flowcontrol.go
+++ b/x/ref/runtime/internal/flow/conn/flowcontrol.go
@@ -4,7 +4,11 @@
 
 package conn
 
-import "sync"
+import (
+	"sync"
+
+	"v.io/v23/context"
+)
 
 // flowControlConnStats represents the flow control counters for all flows
 // supported by the Conn hosting it. The MTU and lshared are only known
@@ -58,6 +62,8 @@ type flowControlConnStats struct {
 // must be guarded by the mutex in flowControlConnStats.
 type flowControlFlowStats struct {
 	*flowControlConnStats
+
+	id uint64
 
 	// released counts tokens already released by the remote end, that is, the number
 	// of tokens we are allowed to send.
@@ -161,4 +167,57 @@ func (fs *flowControlConnStats) clearCountersLocked(fid uint64) {
 	// any/all short lived connections). A much better approach would be
 	// to use a 'special' flow ID (e.g use the invalidFlowID) to use
 	// for referring to all borrowed tokens for closed flows.
+}
+
+// tokens returns the number of tokens this flow can send right now.
+// It is bounded by the channel mtu, the released counters, and possibly
+// the number of shared counters for the conn if we are sending on a just
+// dialed flow.
+func (fs *flowControlFlowStats) tokens(ctx *context.T, encapsulated bool) (int, func(int)) {
+	fs.lock()
+	defer fs.unlock()
+	max := fs.mtu
+	// When	our flow is proxied (i.e. encapsulated), the proxy has added overhead
+	// when forwarding the message. This means we must reduce our mtu to ensure
+	// that dialer framing reaches the acceptor without being truncated by the
+	// proxy.
+	if encapsulated {
+		max -= proxyOverhead
+	}
+	if fs.borrowing {
+		if fs.lshared < max {
+			max = fs.lshared
+		}
+		return int(max), func(used int) {
+			fs.lshared -= uint64(used)
+			fs.borrowed += uint64(used)
+			if ctx.V(2) {
+				ctx.Infof("deducting %d borrowed tokens on flow %d, total: %d left: %d", used, fs.id, fs.borrowed, fs.lshared)
+			}
+		}
+	}
+	if fs.released < max {
+		max = fs.released
+	}
+	return int(max), func(used int) {
+		fs.released -= uint64(used)
+		if ctx.V(2) {
+			ctx.Infof("flow %d deducting %d tokens, %d left", fs.id, used, fs.released)
+		}
+	}
+}
+
+func (fs *flowControlFlowStats) handleFlowClose(closedRemotely, notConnClosing bool) {
+	fs.lock()
+	defer fs.unlock()
+	if closedRemotely {
+		// When the other side closes a flow, it implicitly releases all the
+		// counters used by that flow.  That means we should release the shared
+		// counter to be used on other new flows.
+		fs.lshared += fs.borrowed
+		fs.borrowed = 0
+	} else if fs.borrowed > 0 && notConnClosing {
+		fs.outstandingBorrowed[fs.id] = fs.borrowed
+	}
+	fs.clearCountersLocked(fs.id)
 }


### PR DESCRIPTION
This PR continues to tidy up how flow control is implemented and moves the calculates for the available tokens out of the flw object and into the flowControlFlowStats object instead. Similarly the token adjustments when a flow is closed are moved into flowControlFlowStats.