### PR TITLE
x/ref/runtime/internal/flow/conn: tidy up tracking of unopened to opened states for flows.

### DIFF
--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -551,7 +551,6 @@ func (c *Conn) Dial(ctx *context.T, blessings security.Blessings, discharges map
 		c.remoteDischarges,
 		remote,
 		true,
-		false,
 		channelTimeout,
 		sideChannel)
 	return flw, nil

--- a/x/ref/runtime/internal/flow/conn/handle_message.go
+++ b/x/ref/runtime/internal/flow/conn/handle_message.go
@@ -103,7 +103,6 @@ func (c *Conn) handleOpenFlow(ctx *context.T, msg *message.OpenFlow) error {
 		remoteDischarges,
 		c.remote,
 		false,
-		true,
 		c.acceptChannelTimeout,
 		sideChannel)
 	f.releaseCounters(msg.InitialCounters)


### PR DESCRIPTION
Flows may be created implicitly when accepted, or explicitly when dialed. A dialed flow must send an OpenFlow message to its peer, whereas an accepted flow is created in response to receiving an OpenFlow message. This PR consolidates the handling of these two cases and in particular the communication to the underlying Conn object's waitgroup that an explicitly created, dialed, flow has sent its OpenFlow message.