### PR TITLE
x/ref/runtime/internal/flow/conn: move flow control token calculations.

### DIFF
--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -157,26 +157,9 @@ func (f *flw) Write(p []byte) (n int, err error) {
 // releaseCounters releases some counters from a remote reader to the local
 // writer.  This allows the writer to then write more data to the wire.
 func (f *flw) releaseCounters(tokens uint64) {
-	debug := f.ctx.V(2)
-	f.flowControl.lock()
-	defer f.flowControl.unlock()
-	f.flowControl.borrowing = false
-	if f.flowControl.borrowed > 0 {
-		n := tokens
-		if f.flowControl.borrowed < tokens {
-			n = f.flowControl.borrowed
-		}
-		if debug {
-			f.ctx.Infof("Returning %d/%d tokens borrowed by %d(%p) shared: %d", n, tokens, f.id, f, f.flowControl.lshared)
-		}
-		tokens -= n
-		f.flowControl.borrowed -= n
-		f.flowControl.lshared += n
-	}
-	f.flowControl.released += tokens
-	if debug {
-		f.ctx.Infof("Tokens release to %d(%p): %d => %d", f.id, f, tokens, f.flowControl.released)
-	}
+	ctx := f.ctx
+	debug := ctx.V(2)
+	f.flowControl.releaseCounters(ctx, tokens)
 	if f.writing {
 		if debug {
 			f.ctx.Infof("Activating writing flow %d(%p) now that we have tokens.", f.id, f)


### PR DESCRIPTION
This PR moves the flow control calculations for when tokens are released out of the flw object and into flowControlFlowStats.