### PR TITLE
x/ref/runtime/internal/flow/conn: tidy up locking and sync.Pools

### DIFF
--- a/x/ref/runtime/internal/flow/conn/buffer_pools.go
+++ b/x/ref/runtime/internal/flow/conn/buffer_pools.go
@@ -5,6 +5,7 @@
 package conn
 
 import (
+	"bytes"
 	"sync"
 )
 
@@ -28,7 +29,8 @@ var (
 	// The ciphertext buffer needs to allow for the cipher overhead also.
 	ciphertextBufferSize = plaintextBufferSize + maxCipherOverhead
 
-	// intermediate buffers used by the message pipe for compression/decompression.
+	// messagePipePool is used by messagePipe for the intermediate
+	// buffers used for compression/decompression.
 	messagePipePool = sync.Pool{
 		New: func() interface{} {
 			b := make([]byte, ciphertextBufferSize)
@@ -37,4 +39,7 @@ var (
 			return &b
 		},
 	}
+
+	// bufferPool is used by BufferingFlow.
+	bufferPool = sync.Pool{New: func() interface{} { return &bytes.Buffer{} }}
 )

--- a/x/ref/runtime/internal/flow/conn/bufferingflow.go
+++ b/x/ref/runtime/internal/flow/conn/bufferingflow.go
@@ -12,8 +12,6 @@ import (
 	"v.io/v23/flow"
 )
 
-var bufferPool = sync.Pool{New: func() interface{} { return &bytes.Buffer{} }}
-
 type MTUer interface {
 	MTU() uint64
 }

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -466,8 +466,8 @@ func (c *Conn) MTU() uint64 {
 // The RTT will be updated with the receipt of every healthCheckResponse, so
 // this overestimate doesn't remain for long when the channel timeout is low.
 func (c *Conn) RTT() time.Duration {
-	defer c.mu.Unlock()
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	rtt := c.hcstate.lastRTT
 	if !c.hcstate.requestSent.IsZero() {
 		if waitRTT := time.Since(c.hcstate.requestSent); waitRTT > rtt {
@@ -535,8 +535,8 @@ func (c *Conn) healthCheckNewFlowLocked(ctx *context.T, timeout time.Duration) {
 }
 
 func (c *Conn) healthCheckCloseDeadline() time.Time {
-	defer c.mu.Unlock()
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.hcstate.closeDeadline
 }
 
@@ -567,9 +567,8 @@ func (c *Conn) Dial(ctx *context.T, blessings security.Blessings, discharges map
 		// encoding of the publicKey can never error out.
 		blessings, _ = security.NamelessBlessing(v23.GetPrincipal(ctx).PublicKey())
 	}
-	defer c.mu.Unlock()
 	c.mu.Lock()
-
+	defer c.mu.Unlock()
 	// It may happen that in the case of bidirectional RPC the dialer of the connection
 	// has sent blessings,  but not yet discharges.  In this case we will wait for them
 	// to send the discharges before allowing a bidirectional flow dial.
@@ -654,8 +653,8 @@ func (c *Conn) CommonVersion() version.RPCVersion { return c.version }
 
 // LastUsed returns the time at which the Conn had bytes read or written on it.
 func (c *Conn) LastUsed() time.Time {
-	defer c.mu.Unlock()
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.lastUsedTime
 }
 
@@ -663,8 +662,8 @@ func (c *Conn) LastUsed() time.Time {
 // it is in lame duck mode indicating that new flows should not be dialed on this
 // conn.
 func (c *Conn) RemoteLameDuck() bool {
-	defer c.mu.Unlock()
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.remoteLameDuck
 }
 
@@ -689,8 +688,8 @@ func (c *Conn) Close(ctx *context.T, err error) {
 // CloseIfIdle closes the connection if the conn has been idle for idleExpiry,
 // returning true if it closed it.
 func (c *Conn) CloseIfIdle(ctx *context.T, idleExpiry time.Duration) bool {
-	defer c.mu.Unlock()
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.isIdleLocked(ctx, idleExpiry) {
 		c.internalCloseLocked(ctx, false, false, ErrIdleConnKilled.Errorf(ctx, "connection killed because idle expiry was reached"))
 		return true
@@ -699,8 +698,8 @@ func (c *Conn) CloseIfIdle(ctx *context.T, idleExpiry time.Duration) bool {
 }
 
 func (c *Conn) IsIdle(ctx *context.T, idleExpiry time.Duration) bool {
-	defer c.mu.Unlock()
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.isIdleLocked(ctx, idleExpiry)
 }
 
@@ -713,8 +712,8 @@ func (c *Conn) isIdleLocked(ctx *context.T, idleExpiry time.Duration) bool {
 }
 
 func (c *Conn) HasActiveFlows() bool {
-	defer c.mu.Unlock()
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.hasActiveFlowsLocked()
 }
 
@@ -1027,8 +1026,8 @@ func (c *Conn) sendMessageLocked(
 }
 
 func (c *Conn) DebugString() string {
-	defer c.mu.Unlock()
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	return fmt.Sprintf(`
 Remote:
   Endpoint   %v

--- a/x/ref/runtime/internal/flow/conn/message_pipe.go
+++ b/x/ref/runtime/internal/flow/conn/message_pipe.go
@@ -203,13 +203,10 @@ func (p *messagePipe) readClearText(ctx *context.T, plaintextBuf []byte) ([]byte
 }
 
 func (p *messagePipe) readMsg(ctx *context.T, plaintextBuf []byte) (message.Message, error) {
-	p.readMu.Lock()
 	plaintext, err := p.readClearText(ctx, plaintextBuf)
 	if err != nil {
-		p.readMu.Unlock()
 		return nil, err
 	}
-	p.readMu.Unlock()
 	return p.readAnyMessage(ctx, plaintext)
 }
 

--- a/x/ref/runtime/internal/flow/conn/message_pipe.go
+++ b/x/ref/runtime/internal/flow/conn/message_pipe.go
@@ -184,6 +184,8 @@ func (p *messagePipe) writeMsg(ctx *context.T, m message.Message) error {
 }
 
 func (p *messagePipe) readClearText(ctx *context.T, plaintextBuf []byte) ([]byte, error) {
+	p.readMu.Lock()
+	defer p.readMu.Unlock()
 	if p.open == nil {
 		return p.rw.ReadMsg2(plaintextBuf)
 	}
@@ -231,13 +233,10 @@ func (p *messagePipe) readAnyMessage(ctx *context.T, plaintext []byte) (message.
 }
 
 func (p *messagePipe) readDataMsg(ctx *context.T, plaintextBuf []byte, m *message.Data) (message.Message, error) {
-	p.readMu.Lock()
 	plaintext, err := p.readClearText(ctx, plaintextBuf)
 	if err != nil {
-		p.readMu.Unlock()
 		return nil, err
 	}
-	p.readMu.Unlock()
 	if ok, err := message.ReadData(ctx, plaintext, m); !ok {
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Tidy up locking in message_pipe.go and conn.go; the latter using the more usual 'lock; defer unlock' pattern rather than 'defer unlock; lock'. It also moves all sync.Pools into a single file, buffer_pools.go.