### PR TITLE
x/ref/runtime/internal/flow/conn: follow-on to PR #322

### DIFF
--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -170,7 +170,8 @@ func (co *Opts) initValues(protocol string) error {
 	}
 
 	if co.MTU > co.BytesBuffered {
-		return fmt.Errorf("mtu of: %v, is larger than bytes buffered per flow: %v\n", co.MTU, co.BytesBuffered)
+		d
+		return fmt.Errorf("mtu of: %v, is larger than bytes buffered per flow: %v", co.MTU, co.BytesBuffered)
 	}
 	return nil
 }

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -170,7 +170,7 @@ func (co *Opts) initValues(protocol string) error {
 	}
 
 	if co.MTU > co.BytesBuffered {
-		return fmt.Errorf("MTU %v is larger than bytes buffered per flow: %v\n", co.MTU, co.BytesBuffered)
+		return fmt.Errorf("mtu of: %v, is larger than bytes buffered per flow: %v\n", co.MTU, co.BytesBuffered)
 	}
 	return nil
 }

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -170,7 +170,6 @@ func (co *Opts) initValues(protocol string) error {
 	}
 
 	if co.MTU > co.BytesBuffered {
-		d
 		return fmt.Errorf("mtu of: %v, is larger than bytes buffered per flow: %v", co.MTU, co.BytesBuffered)
 	}
 	return nil

--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -272,7 +272,6 @@ func (f *flw) writeMsg(alsoClose bool, parts ...[]byte) (sent int, err error) {
 			// refragmenting.
 			need = totalSize
 		}
-
 		if wasOpened {
 			tokens, deduct, err := f.ensureTokens(ctx, debug, need)
 			parts, tosend, size = popFront(parts, tosend[:0], tokens)
@@ -292,6 +291,7 @@ func (f *flw) writeMsg(alsoClose bool, parts ...[]byte) (sent int, err error) {
 		if err := f.sendOpenFlowMessage(ctx, alsoClose, len(parts) == 0, tosend); err != nil {
 			return f.writeMsgDone(ctx, sent, alsoClose, err)
 		}
+		sent += size
 		wasOpened = true
 		f.conn.unopenedFlows.Done()
 	}
@@ -333,6 +333,11 @@ func (f *flw) sendOpenFlowMessage(ctx *context.T, alsoClose, finalPart bool, pay
 	}
 	err = f.conn.mp.writeMsg(ctx, d)
 	f.writeq.done(&f.writeqEntry)
+	/*	if len(payload) > 0 {
+			fmt.Fprintf(os.Stderr, "openflow: %v %v %v\n", bkey, dkey, len(payload[0]))
+		} else {
+			fmt.Fprintf(os.Stderr, "openflow: %v %v no payload\n", bkey, dkey)
+		}*/
 	return err
 }
 

--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -333,11 +333,6 @@ func (f *flw) sendOpenFlowMessage(ctx *context.T, alsoClose, finalPart bool, pay
 	}
 	err = f.conn.mp.writeMsg(ctx, d)
 	f.writeq.done(&f.writeqEntry)
-	/*	if len(payload) > 0 {
-			fmt.Fprintf(os.Stderr, "openflow: %v %v %v\n", bkey, dkey, len(payload[0]))
-		} else {
-			fmt.Fprintf(os.Stderr, "openflow: %v %v no payload\n", bkey, dkey)
-		}*/
 	return err
 }
 

--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -288,7 +288,7 @@ func (f *flw) writeMsg(alsoClose bool, parts ...[]byte) (sent int, err error) {
 		avail, deduct := f.flowControl.tokens(ctx, f.encapsulated)
 		parts, tosend, size = popFront(parts, tosend[:0], avail)
 		deduct(size)
-		if err := f.sendOpenFlowMessage(ctx, alsoClose, len(parts) == 0, tosend); err != nil {
+		if err := f.handleOpenFlow(ctx, alsoClose, len(parts) == 0, tosend); err != nil {
 			return f.writeMsgDone(ctx, sent, alsoClose, err)
 		}
 		sent += size
@@ -312,7 +312,7 @@ func (f *flw) messageFlags(alsoClose, finalPart bool) uint64 {
 	return flags
 }
 
-func (f *flw) sendOpenFlowMessage(ctx *context.T, alsoClose, finalPart bool, payload [][]byte) error {
+func (f *flw) handleOpenFlow(ctx *context.T, alsoClose, finalPart bool, payload [][]byte) error {
 	bkey, dkey, err := f.conn.blessingsFlow.send(ctx, f.localBlessings, f.localDischarges, nil)
 	if err != nil {
 		return err

--- a/x/ref/runtime/internal/flow/conn/flowcontrol_test.go
+++ b/x/ref/runtime/internal/flow/conn/flowcontrol_test.go
@@ -184,9 +184,8 @@ func TestFlowControl(t *testing.T) {
 	defer shutdown()
 
 	for _, nflows := range []int{1, 2, 20, 100} {
-		for _, bytesBuffered := range []uint64{4096, DefaultBytesBuffered} {
+		for _, bytesBuffered := range []uint64{DefaultMTU, DefaultBytesBuffered} {
 			for _, mtu := range []uint64{1024, DefaultMTU} {
-
 				t.Logf("starting: #%v flows, buffered %#v bytes\n", nflows, bytesBuffered)
 				dfs, flows, ac, dc := setupFlowsOpts(t, "local", "", ctx, ctx, true, nflows, Opts{
 					MTU:           mtu,
@@ -205,7 +204,7 @@ func TestFlowControl(t *testing.T) {
 					go func(i int) {
 						err := doWrite(dfs[i], randData)
 						if err != nil {
-							fmt.Printf("unexpected error: %v\n", err)
+							fmt.Printf("dial: doWrite: flow: %v/%v, mtu: %v, buffered: %v, unexpected error: %v\n", i, nflows, mtu, bytesBuffered, err)
 						}
 						errs <- err
 						wg.Done()
@@ -213,7 +212,7 @@ func TestFlowControl(t *testing.T) {
 					go func(i int) {
 						err := doRead(dfs[i], randData, nil)
 						if err != nil {
-							fmt.Printf("unexpected error: %v\n", err)
+							fmt.Printf("dial: doRead: flow: %v/%v, mtu: %v, buffered: %v, unexpected error: %v\n", i, nflows, mtu, bytesBuffered, err)
 						}
 						errs <- err
 						wg.Done()
@@ -224,7 +223,7 @@ func TestFlowControl(t *testing.T) {
 					go func() {
 						err := doRead(af, randData, nil)
 						if err != nil {
-							fmt.Printf("unexpected error: %v\n", err)
+							fmt.Printf("accept: doRead: flow: %v/%v, mtu: %v, buffered: %v, unexpected error: %v\n", i, nflows, mtu, bytesBuffered, err)
 						}
 						errs <- err
 						wg.Done()
@@ -232,7 +231,7 @@ func TestFlowControl(t *testing.T) {
 					go func() {
 						err := doWrite(af, randData)
 						if err != nil {
-							fmt.Printf("unexpected error: %v\n", err)
+							fmt.Printf("accept: doWrite: flow: %v/%v, mtu: %v, buffered: %v, unexpected error: %v\n", i, nflows, mtu, bytesBuffered, err)
 						}
 						errs <- err
 						wg.Done()

--- a/x/ref/runtime/internal/flow/conn/flowcontrol_test.go
+++ b/x/ref/runtime/internal/flow/conn/flowcontrol_test.go
@@ -220,22 +220,22 @@ func TestFlowControl(t *testing.T) {
 				}
 				for i := 0; i < nflows; i++ {
 					af := <-flows
-					go func() {
+					go func(i int) {
 						err := doRead(af, randData, nil)
 						if err != nil {
 							fmt.Printf("accept: doRead: flow: %v/%v, mtu: %v, buffered: %v, unexpected error: %v\n", i, nflows, mtu, bytesBuffered, err)
 						}
 						errs <- err
 						wg.Done()
-					}()
-					go func() {
+					}(i)
+					go func(i int) {
 						err := doWrite(af, randData)
 						if err != nil {
 							fmt.Printf("accept: doWrite: flow: %v/%v, mtu: %v, buffered: %v, unexpected error: %v\n", i, nflows, mtu, bytesBuffered, err)
 						}
 						errs <- err
 						wg.Done()
-					}()
+					}(i)
 				}
 
 				wg.Wait()

--- a/x/ref/runtime/internal/flow/conn/readq.go
+++ b/x/ref/runtime/internal/flow/conn/readq.go
@@ -79,7 +79,7 @@ func (r *readq) put(ctx *context.T, bufs [][]byte) error {
 
 	newSize := uint64(l) + r.size
 	if newSize > r.bytesBufferedPerFlow {
-		return ErrCounterOverflow.Errorf(ctx, "a remote process has sent more data than allowed")
+		return ErrCounterOverflow.Errorf(ctx, "a remote process has sent more data than allowed: max bytes buffered is %v, current buffered is %v + received: %v", r.bytesBufferedPerFlow, r.size, l)
 	}
 	newBufs := r.nbufs + len(bufs)
 	r.reserveLocked(newBufs)


### PR DESCRIPTION
This PR is a follow-on to #322 that fixes a performance bug and reduces the overhead of sending blessings.
1. #322 inadvertently disabled sending data with an openflow message, this PR fixes that. Note that openflow messages do not wait for flow control tokens, but will simply send as much data as they can.
2. the blessingsflow.send method is only invoked when a flow is first opened thus saving the overhead of map lookups and key generation.