### PR TITLE
x/ref/runtime/internal/flow/conn: fix race condition with canceled writeq entries

### DIFF
--- a/x/ref/runtime/internal/flow/conn/blessings_flow.go
+++ b/x/ref/runtime/internal/flow/conn/blessings_flow.go
@@ -92,7 +92,7 @@ func newBlessingsFlow(conn blessingsCon) *blessingsFlow {
 	b.encBuf = writeBuffer{conn: conn, wr: &b.writer, buf: make([]byte, 0, 4096)}
 	b.dec = vom.NewDecoder(&b.decBuf)
 	b.enc = vom.NewEncoder(&b.encBuf)
-	b.writer.notify = make(chan struct{})
+	b.writer.notify = make(chan struct{}, 1)
 	return b
 }
 

--- a/x/ref/runtime/internal/flow/conn/blessings_flow.go
+++ b/x/ref/runtime/internal/flow/conn/blessings_flow.go
@@ -92,7 +92,7 @@ func newBlessingsFlow(conn blessingsCon) *blessingsFlow {
 	b.encBuf = writeBuffer{conn: conn, wr: &b.writer, buf: make([]byte, 0, 4096)}
 	b.dec = vom.NewDecoder(&b.decBuf)
 	b.enc = vom.NewEncoder(&b.encBuf)
-	b.writer.notify = make(chan struct{}, 1)
+	b.writer.notify = make(chan struct{})
 	return b
 }
 

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -971,7 +971,7 @@ func (c *Conn) sendMessage(
 	// from many different flows concurrently to send flow control
 	// release messages.
 	var w writer
-	w.notify = make(chan struct{})
+	w.notify = make(chan struct{}, 1)
 	if err := c.writeq.wait(cctx, &w, priority); err != nil {
 		return err
 	}

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -971,7 +971,8 @@ func (c *Conn) sendMessage(
 	// from many different flows concurrently to send flow control
 	// release messages.
 	var w writer
-	w.notify = make(chan struct{}, 1)
+	w.close = true
+	w.notify = make(chan struct{})
 	if err := c.writeq.wait(cctx, &w, priority); err != nil {
 		return err
 	}


### PR DESCRIPTION
There appears to be a race when connections enter lameduck mode and a flow is closed. Both require sending a message to the connection/flow's peer using conn.sendMessage. The message sent for lameduck mode via conn.handleEnterLameDuck is cancelable, whereas the one sent from conn.internalCloseLocked is not. This allows for a deadlock between the cancelable one attempting to acquire the writeq's lock in handleCancel, and the non-cancelable one calling writeq.wait and then writeq.done where it can block attempting to send over the channel for another writeq entry that has been canceled whilst holding the writeq's lock. The fixes are two fold:
1. never to hold the writeq's lock whilst sending over a channel
2. allow for writeq to be closed channels to be closed in addition to sending an empty struct{}, this is now used by conn.sendMessage for its 'one-shot' use of the writeq.

```
goroutine 4229 [semacquire, 13 minutes]:
sync.runtime_SemacquireMutex(0x64475f500010000, 0x0, 0x2)
	/usr/local/go/src/runtime/sema.go:71 +0x25
sync.(*Mutex).lockSlow(0xc000480780)
	/usr/local/go/src/sync/mutex.go:138 +0x21d
sync.(*Mutex).Lock(0xc000480780)
	/usr/local/go/src/sync/mutex.go:81 +0x65
v.io/x/ref/runtime/internal/flow/conn.(*writeq).handleCancel(0xc000480780, 0xc0002625e8, 0x0)
	/home/circleci/project/x/ref/runtime/internal/flow/conn/writeq.go:176 +0x5a
v.io/x/ref/runtime/internal/flow/conn.(*writeq).signalWait(0xc000480780, 0xc0009d8f00, 0xc0002625e8, 0x0)
	/home/circleci/project/x/ref/runtime/internal/flow/conn/writeq.go:200 +0x12d
v.io/x/ref/runtime/internal/flow/conn.(*writeq).wait(0xc000480780, 0x0, 0xc0002625e8, 0x0)
	/home/circleci/project/x/ref/runtime/internal/flow/conn/writeq.go:214 +0x42e
v.io/x/ref/runtime/internal/flow/conn.(*Conn).sendMessage(0xc000480600, 0xc0009d8f00, 0x1, 0x1, {0x11190d0, 0x1669b38})
	/home/circleci/project/x/ref/runtime/internal/flow/conn/conn.go:975 +0x13e
v.io/x/ref/runtime/internal/flow/conn.(*Conn).handleEnterLameDuck.func1()
	/home/circleci/project/x/ref/runtime/internal/flow/conn/handle_message.go:140 +0x8f
created by v.io/x/ref/runtime/internal/flow/conn.(*Conn).handleEnterLameDuck
	/home/circleci/project/x/ref/runtime/internal/flow/conn/handle_message.go:136 +0x119

goroutine 1889 [chan send, 13 minutes]:
v.io/x/ref/runtime/internal/flow/conn.(*writeq).done(0xc000480780, 0xc00000e0a8)
	/home/circleci/project/x/ref/runtime/internal/flow/conn/writeq.go:240 +0x20a
v.io/x/ref/runtime/internal/flow/conn.(*Conn).sendMessage(0xc000480600, 0xc000421450, 0x0, 0xc0004214a0, {0x1119340, 0xc0008181c0})
	/home/circleci/project/x/ref/runtime/internal/flow/conn/conn.go:979 +0x1b6
v.io/x/ref/runtime/internal/flow/conn.(*Conn).internalCloseLocked.func1(0xc000480600)
	/home/circleci/project/x/ref/runtime/internal/flow/conn/conn.go:764 +0x27f
created by v.io/x/ref/runtime/internal/flow/conn.(*Conn).internalCloseLocked
	/home/circleci/project/x/ref/runtime/internal/flow/conn/conn.go:754 +0x6a8
```
