### PR TITLE
x/ref/runtime/internal/flow/conn: fix race condition in the writeq implementation

### DIFF
--- a/x/ref/runtime/internal/flow/conn/flowcontrol_test.go
+++ b/x/ref/runtime/internal/flow/conn/flowcontrol_test.go
@@ -94,7 +94,7 @@ func (r *readConn) ReadMsg2([]byte) ([]byte, error) {
 	return r.ReadMsg()
 }
 
-func TestOrdering(t *testing.T) {
+func TestFlowMessageOrdering(t *testing.T) {
 	// We will send nmessages*mtu bytes on each flow.
 	// For the test to work properly we should send < defaultBufferSize(2^20) bytes.
 	// If we don't then it's possible for the teardown message to be sent before some


### PR DESCRIPTION
This PR addresses a race condition in the writeq implementation between normal notification of writeq writers and cancelations of those writers. When cancelations are mixed in with normal operation the cancelations could lead to situations where the writeq invariants are violated. In particular, a writer may have both a normal notification and a cancelation in flight and the receiving select statement may chose one or the other. If it choses the cancelation then its necessary to drain the notification channel. Similarly, notifications are sent whilst holding the writeq's lock to ensure that only one notification may be sent at a time.