### PR TITLE
x/ref/runtime/internal/flow/conn: refactor how 'remote borrowing' is tracked

### DIFF
--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -853,17 +853,22 @@ func (c *Conn) fragmentReleaseMessage(ctx *context.T, toRelease map[uint64]uint6
 	return nil
 }
 
-func (c *Conn) sendRelease(ctx *context.T, f *flw, fid, count uint64) {
+func (c *Conn) sendRelease(ctx *context.T, fs *flowControlFlowStats, count uint64) {
+	fid := fs.id
 	c.mu.Lock()
-	_, ok := c.flows[fid]
-	c.mu.Unlock()
-	if ok {
-		// Handle the case where the flow is already closed but a message
-		// is received for it, hence only bump the toRelease value for
-		// that flow if it is still active.
-		c.flowControl.incrementToRelease(fid, count)
+	_, open := c.flows[fid]
+	toRelease := c.flowControl.determineReleaseMessageContents(fs, count, open)
+	if toRelease != nil {
+		c.flowControl.mu.Lock()
+		for _, f := range c.flows {
+			f.flowControl.clearRemoteBorrowingLocked()
+		}
+		fs.clearRemoteBorrowingLocked()
+		fs.shared.clearToReleaseLocked()
+		c.flowControl.mu.Unlock()
 	}
-	toRelease := c.flowControl.createReleaseMessageContents(fid, count)
+	c.mu.Unlock()
+
 	var err error
 	if toRelease != nil {
 		delete(toRelease, invalidFlowID)

--- a/x/ref/runtime/internal/flow/conn/flowcontrol_invariants_test.go
+++ b/x/ref/runtime/internal/flow/conn/flowcontrol_invariants_test.go
@@ -55,14 +55,14 @@ func flowID(f flow.Flow) uint64 {
 //  2. similarly for the accept side, the total number of counters available,
 //     ie. to be released should not exceed the total available.
 func flowControlReleasedInvariant(dc, ac *Conn) error {
-	dc.flowControl.mu.Lock()
-	defer dc.flowControl.mu.Unlock()
-	ac.flowControl.mu.Lock()
-	defer ac.flowControl.mu.Unlock()
 	dc.mu.Lock()
 	defer dc.mu.Unlock()
 	ac.mu.Lock()
 	defer ac.mu.Unlock()
+	dc.flowControl.mu.Lock()
+	defer dc.flowControl.mu.Unlock()
+	ac.flowControl.mu.Lock()
+	defer ac.flowControl.mu.Unlock()
 
 	// dial side released
 	totalReleased := 0

--- a/x/ref/runtime/internal/flow/conn/flowcontrol_invariants_test.go
+++ b/x/ref/runtime/internal/flow/conn/flowcontrol_invariants_test.go
@@ -13,10 +13,10 @@ import (
 // flowControlBorrowedInvariant checks the invariant that the sum of all borrowed
 // counters is equal to the amount by which the shared pool is decremented.
 func flowControlBorrowedInvariant(c *Conn) (totalBorrowed, shared uint64, err error) {
-	c.flowControl.mu.Lock()
-	defer c.flowControl.mu.Unlock()
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.flowControl.mu.Lock()
+	defer c.flowControl.mu.Unlock()
 
 	for _, f := range c.flows {
 		borrowing, borrowed := f.flowControl.borrowing, f.flowControl.borrowed
@@ -33,11 +33,10 @@ func flowControlBorrowedInvariant(c *Conn) (totalBorrowed, shared uint64, err er
 
 func flowControlBorrowed(c *Conn) map[uint64]uint64 {
 	borrowed := map[uint64]uint64{}
-	c.flowControl.mu.Lock()
-	defer c.flowControl.mu.Unlock()
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
+	c.flowControl.mu.Lock()
+	defer c.flowControl.mu.Unlock()
 	for _, f := range c.flows {
 		borrowed[f.id] = f.flowControl.borrowed
 	}


### PR DESCRIPTION
This PR refactors the flow control data structures to avoid the need to use a map to track which flows are using borrowed tokens on their remote ends to reduce the storage/gc overhead of maintaining this map. It moves the state for tracking which flows have remote ends that are borrowing tokens to flowControlFlowStats from flowControlConStats.

It also clarifies the fact that the locking order should be connection first and then flow control.
