### PR TITLE
x/ref/services/xproxy/xproxyd: extend timeout to deflake test

### DIFF
--- a/x/ref/services/xproxy/xproxyd/proxyd_v23_test.go
+++ b/x/ref/services/xproxy/xproxyd/proxyd_v23_test.go
@@ -839,7 +839,7 @@ func gatherStats(ctx *context.T, proxies []naming.MountedServer, servers ...stri
 	proxyRequests = make([]map[string]int64, len(proxies))
 	proxiedMessages = make([]map[string]int64, len(proxies))
 	proxiedBytes = make([]map[string]int64, len(proxies))
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	prefixes := make([]string, len(servers))
 	for i, s := range servers {


### PR DESCRIPTION
This PR extends the timeout for gathering proxy stats to avoid the integration tests failing when run on very slow CI runner instances.