### PR TITLE
x/ref/runtime/internal/flow/conn: refactor and rename 'popFront'

### DIFF
--- a/x/ref/runtime/internal/flow/conn/flow_test.go
+++ b/x/ref/runtime/internal/flow/conn/flow_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestPopFront(t *testing.T) {
+func TestPopFrontN(t *testing.T) {
 	input := [][]byte{
 		make([]byte, 64),
 		make([]byte, 32),
@@ -30,68 +30,73 @@ func TestPopFront(t *testing.T) {
 	}
 	_ = copyInput
 
-	var rem [][]byte
 	var send []byte
-	var size int
-	assert := func(wRem [][]byte, wSend []byte, wSize int) {
+	var nextSlice, nextOffset, size int
+	assert := func(wSend []byte, wNextSlice, wNextOffset, wSize int) {
 		_, _, line, _ := runtime.Caller(1)
+		if got, want := nextSlice, wNextSlice; got != want {
+			t.Errorf("line: %v, next slice: got %v, want %v", line, got, want)
+		}
+		if got, want := nextOffset, wNextOffset; got != want {
+			t.Errorf("line: %v, nextOffset: got %v, want %v", line, got, want)
+		}
 		if got, want := size, wSize; got != want {
 			t.Errorf("line: %v, size: got %v, want %v", line, got, want)
 		}
 		if got, want := size, len(wSend); got != want {
 			t.Errorf("line: %v, size: got %v, want %v", line, got, want)
 		}
-		if got, want := rem, wRem; !reflect.DeepEqual(got, want) {
-			t.Errorf("line: %v, rem: got % 02x, want % 02x", line, got, want)
-		}
 		if got, want := send, wSend; !reflect.DeepEqual(got, want) {
 			t.Errorf("line: %v, send: got % 02x, want % 02x", line, got, want)
 		}
 	}
-	rem, send, size = popFront(input[:1], 64)
-	assert(input[1:1], input[0], 64)
 
-	rem, send, size = popFront(input[:1], 100)
-	assert(input[1:1], input[0], 64)
+	send, nextSlice, nextOffset, size = readAtMost(input[:1], 0, 0, 1)
+	assert(input[0][0:1], 0, 1, 1)
+	send, nextSlice, nextOffset, size = readAtMost(input[:1], nextSlice, nextOffset, 100)
+	assert(input[0][1:], 1, 0, len(input[0])-1)
 
-	rem, send, size = popFront(input[:1], 63)
-	tmpRem := copyInput()[:1]
-	tmpRem[0] = tmpRem[0][63:]
-	assert(tmpRem, input[0][:63], 63)
+	send, nextSlice, nextOffset, size = readAtMost(input[:1], 0, 0, len(input[0]))
+	assert(input[0], 1, 0, len(input[0]))
 
-	rem, send, size = popFront(input, 33)
-	tmpRem = copyInput()
-	tmpRem[0] = tmpRem[0][33:]
-	assert(tmpRem, input[0][:33], 33)
+	send, nextSlice, nextOffset, size = readAtMost(input[:1], nextSlice, nextOffset, len(input[0]))
+	assert(nil, 0, 0, 0)
 
-	rem, send, size = popFront(input, len(input[0])+13)
-	tmpRem = copyInput()[1:]
-	tmpRem[0] = tmpRem[0][13:]
+	send, nextSlice, nextOffset, size = readAtMost(input[:1], 0, 0, len(input[0])+100)
+	assert(input[0], 1, 0, len(input[0]))
+	send, nextSlice, nextOffset, size = readAtMost(input[:1], nextSlice, nextOffset, 1)
+	assert(nil, 0, 0, 0)
+
+	send, nextSlice, nextOffset, size = readAtMost(input[:1], 0, 0, 33)
+	assert(input[0][:33], 0, 33, 33)
+	send, nextSlice, nextOffset, size = readAtMost(input[:1], nextSlice, nextOffset, 1)
+	assert(input[0][33:34], 0, 34, 1)
+	send, nextSlice, nextOffset, size = readAtMost(input[:1], nextSlice, nextOffset, 100)
+	assert(input[0][34:], 1, 0, 30)
+	send, nextSlice, nextOffset, size = readAtMost(input[:1], nextSlice, nextOffset, 100)
+	assert(nil, 0, 0, 0)
+
+	partial := len(input[1]) / 3
+	atMost := len(input[0]) + partial
+	send, nextSlice, nextOffset, size = readAtMost(input, 0, 0, atMost)
+	assert(append(input[0], input[1][:partial]...), 1, partial, atMost)
+
+	prevOffset := partial
+	partial = len(input[1]) - len(input[1])/3
+	atMost = partial + len(input[2])
+	send, nextSlice, nextOffset, size = readAtMost(input, nextSlice, nextOffset, atMost)
+	assert(append(input[1][prevOffset:], input[2]...), 3, 0, atMost)
+
+	send, nextSlice, nextOffset, size = readAtMost(input, nextSlice, nextOffset, 1000)
+	assert(input[3], 4, 0, len(input[3]))
+
+	send, nextSlice, nextOffset, size = readAtMost(input, nextSlice, nextOffset, 1000)
+	assert(nil, 0, 0, 0)
+
+	send, nextSlice, nextOffset, size = readAtMost(input, 0, 0, 1000)
 	tmpOut := input[0]
-	tmpOut = append(tmpOut, input[1][:13]...)
-	assert(tmpRem, tmpOut, len(input[0])+13)
-
-	rem, send, size = popFront(input, len(input[0])+len(input[1])+len(input[2])+2)
-	tmpRem = copyInput()[3:]
-	tmpRem[0] = tmpRem[0][2:]
-	tmpOut = input[0]
-	tmpOut = append(tmpOut, input[1]...)
-	tmpOut = append(tmpOut, input[2]...)
-	tmpOut = append(tmpOut, input[3][:2]...)
-	assert(tmpRem, tmpOut, len(tmpOut))
-
-	rem, send, size = popFront(input, len(input[0])+len(input[1])+len(input[2])+len(input[3]))
-	tmpOut = input[0]
 	tmpOut = append(tmpOut, input[1]...)
 	tmpOut = append(tmpOut, input[2]...)
 	tmpOut = append(tmpOut, input[3]...)
-	assert(nil, tmpOut, len(tmpOut))
-
-	rem, send, size = popFront(input, 1000)
-	tmpOut = input[0]
-	tmpOut = append(tmpOut, input[1]...)
-	tmpOut = append(tmpOut, input[2]...)
-	tmpOut = append(tmpOut, input[3]...)
-	assert(nil, tmpOut, len(tmpOut))
-
+	assert(tmpOut, 4, 0, totalSize(input))
 }


### PR DESCRIPTION
This PR reimplements and renames 'popFront' as 'removeAtMost' to avoid unnecessary memory allocations. Instead of creating a new slice of byte slices it returns an index into the slice of slices and an offset into the current slice. This leads to many fewer allocations for large (greater than MTU) sized payloads. A 1MB message now needs 298 vs 328 allocations and a 10M message 980 vs 1282.