### PR TITLE
x/ref/runtime/internal/flow/conn: continued test improvements

### DIFF
--- a/x/ref/runtime/internal/flow/conn/flowcontrol_invariants_test.go
+++ b/x/ref/runtime/internal/flow/conn/flowcontrol_invariants_test.go
@@ -91,8 +91,6 @@ func flowControlBorrowed(c *Conn, fid uint64) uint64 {
 
 func countRemoteBorrowing(c *Conn) int {
 	rb := 0
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	for _, f := range c.flows {
 		if f.flowControl.remoteBorrowing {
 			rb++
@@ -102,8 +100,6 @@ func countRemoteBorrowing(c *Conn) int {
 }
 
 func countToRelease(c *Conn) int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	nc := len(c.flowControl.toReleaseClosed)
 	for _, f := range c.flows {
 		if f.flowControl.toRelease > 0 {

--- a/x/ref/runtime/internal/flow/conn/flowcontrol_test.go
+++ b/x/ref/runtime/internal/flow/conn/flowcontrol_test.go
@@ -493,7 +493,6 @@ func testCountersOpts(t *testing.T, ctx *context.T, count int, dialClose, accept
 		t.Fatal(err)
 	}
 
-<<<<<<< HEAD
 	err := waitFor(time.Minute, func() error {
 		_, _, err := flowControlBorrowedClosedInvariant(dc)
 		return err
@@ -509,23 +508,6 @@ func testCountersOpts(t *testing.T, ctx *context.T, count int, dialClose, accept
 	if err != nil {
 		t.Errorf("dial: %v", err)
 	}
-=======
-	waitFor(func() bool {
-		_, _, err := flowControlBorrowedClosedInvariant(dc)
-		if err != nil {
-			t.Logf("dial: %v", err)
-		}
-		return err == nil
-	})
-
-	waitFor(func() bool {
-		_, _, err := flowControlBorrowedClosedInvariant(ac)
-		if err != nil {
-			t.Logf("accept: %v", err)
-		}
-		return err == nil
-	})
->>>>>>> main
 
 	dc.mu.Lock()
 	dc.flowControl.mu.Lock()

--- a/x/ref/runtime/internal/flow/conn/writeq_test.go
+++ b/x/ref/runtime/internal/flow/conn/writeq_test.go
@@ -201,11 +201,11 @@ func TestWriteqErrors(t *testing.T) {
 	}()
 
 	ready.Wait()
+	wq.done(&fe1.writer)
 	err := wq.wait(nil, &fe3.writer, expressPriority)
 	if err == nil || !strings.Contains(err.Error(), "already exists in the writeq") {
 		t.Fatalf("missing or unexpected error: %v", err)
 	}
-	wq.done(&fe1.writer)
 	wq.done(&fe2.writer)
 	wq.done(&fe3.writer)
 	done.Wait()

--- a/x/ref/runtime/internal/flow/conn/writeq_test.go
+++ b/x/ref/runtime/internal/flow/conn/writeq_test.go
@@ -244,7 +244,7 @@ func waitForActiveAndQueued(t *testing.T, wq *writeq, priority int, a, b *writeq
 		wq.mu.Lock()
 		defer wq.mu.Unlock()
 		if wq.active != &a.writer {
-			return fmt.Errorf("%p is not active: %s:", &a.writer, wq.stringLocked())
+			return fmt.Errorf("%p is not active: %s", &a.writer, wq.stringLocked())
 		}
 		for w := wq.activeWriters[priority]; w != nil; w = w.next {
 			if w == &b.writer {


### PR DESCRIPTION
This PR reduces the flakiness of TestWriteqErrors and improves the reporting offered by the 'waitFor' test utility function.