### PR TITLE
x/ref/runtime/internal/flow/conn: the handshake channel needs a buffer size of 1

### DIFF
--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -372,7 +372,7 @@ func NewAccepted(
 	c.initWriters()
 	c.flowControl.init(opts.BytesBuffered)
 
-	handshakeCh := make(chan acceptHandshakeResult)
+	handshakeCh := make(chan acceptHandshakeResult, 1)
 	var handshakeResult acceptHandshakeResult
 
 	c.loopWG.Add(1)


### PR DESCRIPTION
This PR fixes NewAccepted to use a channel with a buffer size of 1 for use with acceptHandshake. Without this a deadlock can occur.