### PR TITLE
v23/flow: use a slice rather than map for representing Discharges.

### DIFF
--- a/v23/flow/model.go
+++ b/v23/flow/model.go
@@ -138,13 +138,13 @@ type PeerAuthorizer interface {
 		localEndpoint naming.Endpoint,
 		remoteEndpoint naming.Endpoint,
 		remoteBlessings security.Blessings,
-		remoteDischarges map[string]security.Discharge,
+		remoteDischarges security.Discharges,
 	) (peerBlessingNames []string, rejectedPeerNames []security.RejectedBlessing, _ error)
 
 	// BlessingsForPeer returns the blessings and discharges that should be
 	// presented to the remote end with peerBlessingNames.
 	BlessingsForPeer(ctx *context.T, peerBlessingNames []string) (
-		security.Blessings, map[string]security.Discharge, error)
+		security.Blessings, security.Discharges, error)
 }
 
 // ManagedConn represents the connection onto which this flow is multiplexed.
@@ -166,12 +166,12 @@ type ManagedConn interface {
 	// connection during authentication.
 	//
 	// Discharges are organized in a map keyed by the discharge-identifier.
-	RemoteDischarges() map[string]security.Discharge
+	RemoteDischarges() security.Discharges
 	// LocalDischarges returns the discharges presented by the local end of the
 	// connection during authentication.
 	//
 	// Discharges are organized in a map keyed by the discharge-identifier.
-	LocalDischarges() map[string]security.Discharge
+	LocalDischarges() security.Discharges
 
 	// CommonVersion returns the RPCVersion negotiated between the local and remote endpoints.
 	CommonVersion() version.RPCVersion
@@ -265,12 +265,12 @@ type Flow interface {
 	// flow during authentication.
 	//
 	// Discharges are organized in a map keyed by the discharge-identifier.
-	LocalDischarges() map[string]security.Discharge
+	LocalDischarges() security.Discharges
 	// RemoteDischarges returns the discharges presented by the remote end of the
 	// flow during authentication.
 	//
 	// Discharges are organized in a map keyed by the discharge-identifier.
-	RemoteDischarges() map[string]security.Discharge
+	RemoteDischarges() security.Discharges
 
 	// Conn returns the connection the flow is multiplexed on.
 	Conn() ManagedConn

--- a/v23/security/authorizer_test.go
+++ b/v23/security/authorizer_test.go
@@ -25,7 +25,7 @@ func testDefaultAuthorizer(t *testing.T, pali, pbob, pche, pdis security.Princip
 
 		tpcav  = mkThirdPartyCaveat(t, pdis.PublicKey(), "someLocation", security.UnconstrainedUse())
 		dis, _ = pdis.MintDischarge(tpcav, security.UnconstrainedUse())
-		dismap = map[string]security.Discharge{dis.ID(): dis}
+		dismap = security.Discharges{dis}
 
 		// bless(ali, bob, "friend") will generate a blessing for ali, calling him "bob:friend".
 		bless = func(target, extend security.Blessings, extension string, caveats ...security.Caveat) security.Blessings {

--- a/v23/security/call.go
+++ b/v23/security/call.go
@@ -33,10 +33,10 @@ type CallParams struct {
 	LocalBlessings Blessings       // Blessings presented to the remote end.
 	LocalEndpoint  naming.Endpoint // Endpoint of local end of communication.
 
-	RemoteBlessings  Blessings            // Blessings presented by the remote end.
-	RemoteDischarges map[string]Discharge // Map of third-party caveat identifiers to corresponding discharges shared by the remote end.
-	LocalDischarges  map[string]Discharge // Map of third-party caveat identifiers to corresponding discharges shared by the local end.
-	RemoteEndpoint   naming.Endpoint      // Endpoint of the remote end of communication (as seen by the local end)
+	RemoteBlessings  Blessings       // Blessings presented by the remote end.
+	RemoteDischarges []Discharge     // Map of third-party caveat identifiers to corresponding discharges shared by the remote end.
+	LocalDischarges  []Discharge     // Map of third-party caveat identifiers to corresponding discharges shared by the local end.
+	RemoteEndpoint   naming.Endpoint // Endpoint of the remote end of communication (as seen by the local end)
 }
 
 // Copy fills in p with a copy of the values in c.
@@ -58,34 +58,22 @@ func (p *CallParams) Copy(c Call) {
 	p.RemoteBlessings = c.RemoteBlessings()
 	// TODO(ataly, suharshs): Is the copying of discharge maps
 	// really needed?
-	p.LocalDischarges = copyDischargeMap(c.LocalDischarges())
-	p.RemoteDischarges = copyDischargeMap(c.RemoteDischarges())
+	p.LocalDischarges = c.LocalDischarges().Copy()
+	p.RemoteDischarges = c.RemoteDischarges().Copy()
 	p.RemoteEndpoint = c.RemoteEndpoint()
-}
-
-func copyDischargeMap(discharges map[string]Discharge) map[string]Discharge {
-	// avoid unnecessary allocation.
-	if len(discharges) == 0 {
-		return nil
-	}
-	ret := make(map[string]Discharge, len(discharges))
-	for id, d := range discharges {
-		ret[id] = d
-	}
-	return ret
 }
 
 type ctxImpl struct{ params CallParams }
 
-func (c *ctxImpl) Timestamp() time.Time                   { return c.params.Timestamp }
-func (c *ctxImpl) Method() string                         { return c.params.Method }
-func (c *ctxImpl) MethodTags() []*vdl.Value               { return c.params.MethodTags }
-func (c *ctxImpl) Suffix() string                         { return c.params.Suffix }
-func (c *ctxImpl) LocalPrincipal() Principal              { return c.params.LocalPrincipal }
-func (c *ctxImpl) LocalBlessings() Blessings              { return c.params.LocalBlessings }
-func (c *ctxImpl) RemoteBlessings() Blessings             { return c.params.RemoteBlessings }
-func (c *ctxImpl) LocalEndpoint() naming.Endpoint         { return c.params.LocalEndpoint }
-func (c *ctxImpl) RemoteEndpoint() naming.Endpoint        { return c.params.RemoteEndpoint }
-func (c *ctxImpl) LocalDischarges() map[string]Discharge  { return c.params.LocalDischarges }
-func (c *ctxImpl) RemoteDischarges() map[string]Discharge { return c.params.RemoteDischarges }
-func (c *ctxImpl) String() string                         { return fmt.Sprintf("%+v", c.params) }
+func (c *ctxImpl) Timestamp() time.Time            { return c.params.Timestamp }
+func (c *ctxImpl) Method() string                  { return c.params.Method }
+func (c *ctxImpl) MethodTags() []*vdl.Value        { return c.params.MethodTags }
+func (c *ctxImpl) Suffix() string                  { return c.params.Suffix }
+func (c *ctxImpl) LocalPrincipal() Principal       { return c.params.LocalPrincipal }
+func (c *ctxImpl) LocalBlessings() Blessings       { return c.params.LocalBlessings }
+func (c *ctxImpl) RemoteBlessings() Blessings      { return c.params.RemoteBlessings }
+func (c *ctxImpl) LocalEndpoint() naming.Endpoint  { return c.params.LocalEndpoint }
+func (c *ctxImpl) RemoteEndpoint() naming.Endpoint { return c.params.RemoteEndpoint }
+func (c *ctxImpl) LocalDischarges() Discharges     { return c.params.LocalDischarges }
+func (c *ctxImpl) RemoteDischarges() Discharges    { return c.params.RemoteDischarges }
+func (c *ctxImpl) String() string                  { return fmt.Sprintf("%+v", c.params) }

--- a/v23/security/caveat_test.go
+++ b/v23/security/caveat_test.go
@@ -103,12 +103,11 @@ func testPublicKeyThirdPartyCaveat(t *testing.T, discharger,
 
 		ctxCancelAndCall = func(method string, discharges ...security.Discharge) (*context.T, context.CancelFunc, security.Call) {
 			params := &security.CallParams{
-				Timestamp:        now,
-				Method:           method,
-				RemoteDischarges: make(map[string]security.Discharge),
+				Timestamp: now,
+				Method:    method,
 			}
 			for _, d := range discharges {
-				params.RemoteDischarges[d.ID()] = d
+				params.RemoteDischarges = append(params.RemoteDischarges, d)
 			}
 			root, cancel := context.RootContext()
 			return root, cancel, security.NewCall(params)

--- a/v23/security/caveat_test.go
+++ b/v23/security/caveat_test.go
@@ -106,9 +106,7 @@ func testPublicKeyThirdPartyCaveat(t *testing.T, discharger,
 				Timestamp: now,
 				Method:    method,
 			}
-			for _, d := range discharges {
-				params.RemoteDischarges = append(params.RemoteDischarges, d)
-			}
+			params.RemoteDischarges = append(params.RemoteDischarges, discharges...)
 			root, cancel := context.RootContext()
 			return root, cancel, security.NewCall(params)
 		}

--- a/v23/security/discharge.go
+++ b/v23/security/discharge.go
@@ -24,6 +24,43 @@ type Discharge struct {
 	wire WireDischarge
 }
 
+// Discharges represents a set of Discharges.
+type Discharges []Discharge
+
+// Find returns the Discharge with the requested id.
+func (dl Discharges) Find(id string) (Discharge, bool) {
+	for _, d := range dl {
+		if d.ID() == id {
+			return d, true
+		}
+	}
+	return Discharge{}, false
+}
+
+// Equivalent returns true if discharges contains an equivalent discharge
+// to that requested, that is, one with the same ID and that satifies
+// discharge.Equivalent.
+func (dl Discharges) Equivalent(discharge Discharge) bool {
+	id := discharge.ID()
+	for _, d := range dl {
+		if d.ID() == id {
+			return discharge.Equivalent(d)
+		}
+	}
+	return false
+}
+
+// Copy returns a copy of the Discharges.
+func (dl Discharges) Copy() Discharges {
+	// avoid unnecessary allocation.
+	if len(dl) == 0 {
+		return nil
+	}
+	ret := make([]Discharge, len(dl))
+	copy(ret, dl)
+	return ret
+}
+
 // ID returns the identifier for the third-party caveat that d is a discharge
 // for.
 func (d Discharge) ID() string {

--- a/v23/security/discharge.go
+++ b/v23/security/discharge.go
@@ -38,7 +38,7 @@ func (dl Discharges) Find(id string) (Discharge, bool) {
 }
 
 // Equivalent returns true if discharges contains an equivalent discharge
-// to that requested, that is, one with the same ID and that satifies
+// to that requested, that is, one with the same ID and that satisfies
 // discharge.Equivalent.
 func (dl Discharges) Equivalent(discharge Discharge) bool {
 	id := discharge.ID()

--- a/v23/security/discharge_test.go
+++ b/v23/security/discharge_test.go
@@ -69,7 +69,7 @@ func testDischargeSignatureCaching(t *testing.T, p1, p2 security.Principal) {
 		ctx, cancel = context.RootContext()
 		mkCall      = func(d security.Discharge) security.Call {
 			return security.NewCall(&security.CallParams{
-				RemoteDischarges: map[string]security.Discharge{cav.ThirdPartyDetails().ID(): d},
+				RemoteDischarges: security.Discharges{d},
 			})
 		}
 	)
@@ -137,9 +137,7 @@ func benchmarkPublicKeyDischargeVerification(caching bool, b *testing.B, signer 
 	ctx, cancel := context.RootContext()
 	defer cancel()
 	call := security.NewCall(&security.CallParams{
-		RemoteDischarges: map[string]security.Discharge{
-			cav.ThirdPartyDetails().ID(): discharge,
-		}})
+		RemoteDischarges: security.Discharges{discharge}})
 	// Validate once for the initial expensive signature validation (not stored in the cache).
 	if err := cav.Validate(ctx, call); err != nil {
 		b.Fatal(err)

--- a/v23/security/init.go
+++ b/v23/security/init.go
@@ -56,7 +56,7 @@ func init() {
 	})
 
 	RegisterCaveatValidator(PublicKeyThirdPartyCaveat, func(ctx *context.T, call Call, params publicKeyThirdPartyCaveatParam) error {
-		discharge, ok := call.RemoteDischarges()[params.ID()]
+		discharge, ok := call.RemoteDischarges().Find(params.ID())
 		if !ok {
 			return fmt.Errorf("missing discharge for third party caveat(id=%v)", params.ID())
 		}

--- a/v23/security/model.go
+++ b/v23/security/model.go
@@ -378,11 +378,11 @@ type Call interface {
 	// LocalDischarges specify discharges for third-party caveats presented by
 	// the local end of the call. It maps a third-party caveat identifier to the
 	// corresponding discharge.
-	LocalDischarges() map[string]Discharge
+	LocalDischarges() Discharges
 	// RemoteDischarges specify discharges for third-party caveats presented by
 	// the remote end of the call. It maps a third-party caveat identifier to the
 	// corresponding discharge.
-	RemoteDischarges() map[string]Discharge
+	RemoteDischarges() Discharges
 	// LocalPrincipal returns the principal used to authenticate to the remote end.
 	LocalPrincipal() Principal
 	// LocalBlessings returns the blessings (bound to the local end)

--- a/x/ref/lib/security/prepare_discharges_test.go
+++ b/x/ref/lib/security/prepare_discharges_test.go
@@ -133,7 +133,7 @@ func TestPrepareDischarges(t *testing.T) { //nolint:gocyclo
 	if len(discharges) != 2 {
 		t.Errorf("Got %d discharges, expected 2.", len(discharges))
 	}
-	dis, has := discharges[tpid]
+	dis, has := discharges.Find(tpid)
 	if !has {
 		t.Errorf("Got %#v, Expected discharge for %s", discharges, tpid)
 	}
@@ -155,7 +155,7 @@ func TestPrepareDischarges(t *testing.T) { //nolint:gocyclo
 	if len(discharges) != 2 {
 		t.Errorf("Got %d discharges, expected 2.", len(discharges))
 	}
-	dis, has = discharges[tpid]
+	dis, has = discharges.Find(tpid)
 	if !has {
 		t.Errorf("Got %#v, Expected discharge for %s", discharges, tpid)
 	}

--- a/x/ref/runtime/internal/flow/conn/blessings_caches.go
+++ b/x/ref/runtime/internal/flow/conn/blessings_caches.go
@@ -14,7 +14,7 @@ type cachedBlessing struct {
 }
 
 type cachedDischarge struct {
-	discharges []security.Discharge
+	discharges security.Discharges
 	dkey, bkey uint64
 }
 
@@ -43,7 +43,7 @@ func (c *inCache) hasBlessings(bkey uint64) (security.Blessings, bool) {
 	return security.Blessings{}, false
 }
 
-func (c *inCache) addDischarges(bkey, dkey uint64, discharges []security.Discharge) {
+func (c *inCache) addDischarges(bkey, dkey uint64, discharges security.Discharges) {
 	c.discharges = append(c.discharges, cachedDischarge{dkey: dkey, bkey: bkey, discharges: discharges})
 }
 
@@ -84,6 +84,6 @@ func (c *outCache) hasDischarges(bkey uint64) ([]security.Discharge, uint64, boo
 	return nil, 0, false
 }
 
-func (c *outCache) addDischarges(bkey, dkey uint64, discharges []security.Discharge) {
+func (c *outCache) addDischarges(bkey, dkey uint64, discharges security.Discharges) {
 	c.discharges = append(c.discharges, cachedDischarge{dkey: dkey, bkey: bkey, discharges: discharges})
 }

--- a/x/ref/runtime/internal/flow/conn/blessings_flow.go
+++ b/x/ref/runtime/internal/flow/conn/blessings_flow.go
@@ -237,7 +237,7 @@ func (b *blessingsFlow) encodeDischargesLocked(ctx *context.T, discharges []secu
 func (b *blessingsFlow) send(
 	ctx *context.T,
 	blessings security.Blessings,
-	discharges []security.Discharge,
+	discharges security.Discharges,
 	peers []security.BlessingPattern) (bkey, dkey uint64, err error) {
 	if blessings.IsZero() {
 		return 0, 0, nil

--- a/x/ref/runtime/internal/flow/conn/blessings_flow.go
+++ b/x/ref/runtime/internal/flow/conn/blessings_flow.go
@@ -237,7 +237,7 @@ func (b *blessingsFlow) encodeDischargesLocked(ctx *context.T, discharges []secu
 func (b *blessingsFlow) send(
 	ctx *context.T,
 	blessings security.Blessings,
-	discharges map[string]security.Discharge,
+	discharges []namedDischarge,
 	peers []security.BlessingPattern) (bkey, dkey uint64, err error) {
 	if blessings.IsZero() {
 		return 0, 0, nil
@@ -289,14 +289,16 @@ func dischargeMap(in []security.Discharge) map[string]security.Discharge {
 	return out
 }
 
-func equalDischarges(m map[string]security.Discharge, s []security.Discharge) bool {
+func equalDischarges(m []namedDischarge, s []security.Discharge) bool {
 	if len(m) != len(s) {
 		return false
 	}
 	for _, d := range s {
-		inm, ok := m[d.ID()]
-		if !ok || !d.Equivalent(inm) {
-			return false
+		for i := range m {
+			inm, ok := m[d.ID()]
+			if !ok || !d.Equivalent(inm) {
+				return false
+			}
 		}
 	}
 	return true

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -82,11 +82,6 @@ type healthCheckState struct {
 	closeDeadline time.Time
 }
 
-type namedDischarge struct {
-	security.WireDischarge
-	key string
-}
-
 // A Conn acts as a multiplexing encrypted channel that can host Flows.
 type Conn struct {
 	// All the variables here are set before the constructor returns

--- a/x/ref/runtime/internal/flow/conn/conn.go
+++ b/x/ref/runtime/internal/flow/conn/conn.go
@@ -82,6 +82,11 @@ type healthCheckState struct {
 	closeDeadline time.Time
 }
 
+type namedDischarge struct {
+	security.WireDischarge
+	key string
+}
+
 // A Conn acts as a multiplexing encrypted channel that can host Flows.
 type Conn struct {
 	// All the variables here are set before the constructor returns
@@ -111,7 +116,7 @@ type Conn struct {
 	mu sync.Mutex // All the variables below here are protected by mu.
 
 	localBlessings, remoteBlessings   security.Blessings
-	localDischarges, remoteDischarges map[string]security.Discharge
+	localDischarges, remoteDischarges []namedDischarge
 	localValid                        <-chan struct{}
 	remoteValid                       chan struct{}
 	rPublicKey                        security.PublicKey

--- a/x/ref/runtime/internal/flow/conn/flow.go
+++ b/x/ref/runtime/internal/flow/conn/flow.go
@@ -23,7 +23,7 @@ type flw struct {
 	conn                              *Conn
 	q                                 *readq
 	localBlessings, remoteBlessings   security.Blessings
-	localDischarges, remoteDischarges map[string]security.Discharge
+	localDischarges, remoteDischarges security.Discharges
 	noEncrypt                         bool
 	noFragment                        bool
 	remote                            naming.Endpoint
@@ -63,7 +63,7 @@ func (c *Conn) newFlowLocked(
 	ctx *context.T,
 	id uint64,
 	localBlessings, remoteBlessings security.Blessings,
-	localDischarges, remoteDischarges map[string]security.Discharge,
+	localDischarges, remoteDischarges []security.Discharge,
 	remote naming.Endpoint,
 	dialed bool,
 	channelTimeout time.Duration,
@@ -418,7 +418,7 @@ func (f *flw) RemoteBlessings() security.Blessings {
 // flow during authentication.
 //
 // Discharges are organized in a map keyed by the discharge-identifier.
-func (f *flw) LocalDischarges() map[string]security.Discharge {
+func (f *flw) LocalDischarges() security.Discharges {
 	return f.localDischarges
 }
 
@@ -426,7 +426,7 @@ func (f *flw) LocalDischarges() map[string]security.Discharge {
 // flow during authentication.
 //
 // Discharges are organized in a map keyed by the discharge-identifier.
-func (f *flw) RemoteDischarges() map[string]security.Discharge {
+func (f *flw) RemoteDischarges() security.Discharges {
 	return f.remoteDischarges
 }
 

--- a/x/ref/runtime/internal/flow/conn/util_test.go
+++ b/x/ref/runtime/internal/flow/conn/util_test.go
@@ -154,7 +154,7 @@ func (a peerAuthorizer) AuthorizePeer(
 	ctx *context.T,
 	localEP, remoteEP naming.Endpoint,
 	remoteBlessings security.Blessings,
-	remoteDischarges map[string]security.Discharge,
+	remoteDischarges security.Discharges,
 ) ([]string, []security.RejectedBlessing, error) {
 	call := security.NewCall(&security.CallParams{
 		Timestamp:        time.Now(),
@@ -177,7 +177,7 @@ func (a peerAuthorizer) AuthorizePeer(
 }
 
 func (a peerAuthorizer) BlessingsForPeer(ctx *context.T, _ []string) (
-	security.Blessings, map[string]security.Discharge, error) {
+	security.Blessings, security.Discharges, error) {
 	dis, _ := securitylib.PrepareDischarges(ctx, a.blessings, nil, "", nil)
 	return a.blessings, dis, nil
 }

--- a/x/ref/runtime/internal/flow/flowtest/flowtest.go
+++ b/x/ref/runtime/internal/flow/flowtest/flowtest.go
@@ -56,12 +56,12 @@ func (AllowAllPeersAuthorizer) AuthorizePeer(
 	ctx *context.T,
 	localEndpoint, remoteEndpoint naming.Endpoint,
 	remoteBlessings security.Blessings,
-	remoteDischarges map[string]security.Discharge,
+	remoteDischarges security.Discharges,
 ) ([]string, []security.RejectedBlessing, error) {
 	return nil, nil, nil
 }
 
-func (AllowAllPeersAuthorizer) BlessingsForPeer(ctx *context.T, _ []string) (security.Blessings, map[string]security.Discharge, error) {
+func (AllowAllPeersAuthorizer) BlessingsForPeer(ctx *context.T, _ []string) (security.Blessings, security.Discharges, error) {
 	b, _ := v23.GetPrincipal(ctx).BlessingStore().Default()
 	return b, nil, nil
 }
@@ -79,7 +79,7 @@ func (p peersAuthorizer) AuthorizePeer(
 	ctx *context.T,
 	localEndpoint, remoteEndpoint naming.Endpoint,
 	remoteBlessings security.Blessings,
-	remoteDischarges map[string]security.Discharge,
+	remoteDischarges security.Discharges,
 ) ([]string, []security.RejectedBlessing, error) {
 	call := security.NewCall(&security.CallParams{
 		Timestamp:        time.Now(),
@@ -98,7 +98,7 @@ func (p peersAuthorizer) AuthorizePeer(
 	return peerNames, rejectedPeerNames, fmt.Errorf("not authorized")
 }
 
-func (peersAuthorizer) BlessingsForPeer(ctx *context.T, _ []string) (security.Blessings, map[string]security.Discharge, error) {
+func (peersAuthorizer) BlessingsForPeer(ctx *context.T, _ []string) (security.Blessings, security.Discharges, error) {
 	b, _ := v23.GetPrincipal(ctx).BlessingStore().Default()
 	return b, nil, nil
 }

--- a/x/ref/runtime/internal/flow/manager/conncache.go
+++ b/x/ref/runtime/internal/flow/manager/conncache.go
@@ -140,7 +140,7 @@ type CachedConn interface {
 	RemoteEndpoint() naming.Endpoint
 	LocalEndpoint() naming.Endpoint
 	RemoteBlessings() security.Blessings
-	RemoteDischarges() map[string]security.Discharge
+	RemoteDischarges() security.Discharges
 	RTT() time.Duration
 	LastUsed() time.Time
 	DebugString() string

--- a/x/ref/runtime/internal/flow/manager/conncache_test.go
+++ b/x/ref/runtime/internal/flow/manager/conncache_test.go
@@ -548,10 +548,10 @@ func (c *rttConn) RemoteBlessings() security.Blessings {
 	b, _ := v23.GetPrincipal(c.ctx).BlessingStore().Default()
 	return b
 }
-func (c *rttConn) RemoteDischarges() map[string]security.Discharge { return nil }
-func (c *rttConn) RTT() time.Duration                              { return c.rtt }
-func (c *rttConn) LastUsed() time.Time                             { return time.Now() }
-func (c *rttConn) DebugString() string                             { return "" }
+func (c *rttConn) RemoteDischarges() security.Discharges { return nil }
+func (c *rttConn) RTT() time.Duration                    { return c.rtt }
+func (c *rttConn) LastUsed() time.Time                   { return time.Now() }
+func (c *rttConn) DebugString() string                   { return "" }
 
 func isInCache(ctx *context.T, c *ConnCache, conn *connpackage.Conn) bool {
 	rep := conn.RemoteEndpoint()

--- a/x/ref/runtime/internal/flow/manager/manager.go
+++ b/x/ref/runtime/internal/flow/manager/manager.go
@@ -506,13 +506,13 @@ func (proxyAuthorizer) AuthorizePeer(
 	ctx *context.T,
 	localEndpoint, remoteEndpoint naming.Endpoint,
 	remoteBlessings security.Blessings,
-	remoteDischarges map[string]security.Discharge,
+	remoteDischarges security.Discharges,
 ) ([]string, []security.RejectedBlessing, error) {
 	return nil, nil, nil
 }
 
 func (a proxyAuthorizer) BlessingsForPeer(ctx *context.T, proxyBlessings []string) (
-	security.Blessings, map[string]security.Discharge, error) {
+	security.Blessings, security.Discharges, error) {
 	blessings := v23.GetPrincipal(ctx).BlessingStore().ForPeer(proxyBlessings...)
 	discharges, _ := slib.PrepareDischarges(ctx, blessings, proxyBlessings, "", nil)
 	return blessings, discharges, nil
@@ -1122,7 +1122,7 @@ func (x *peerAuthorizer) AuthorizePeer(
 	ctx *context.T,
 	localEP, remoteEP naming.Endpoint,
 	remoteBlessings security.Blessings,
-	remoteDischarges map[string]security.Discharge) ([]string, []security.RejectedBlessing, error) {
+	remoteDischarges security.Discharges) ([]string, []security.RejectedBlessing, error) {
 	localPrincipal := v23.GetPrincipal(ctx)
 	// The "Method" and "Suffix" fields of the call are not populated
 	// as they are considered irrelevant for authorizing server blessings.
@@ -1145,6 +1145,6 @@ func (x *peerAuthorizer) AuthorizePeer(
 }
 
 func (x *peerAuthorizer) BlessingsForPeer(ctx *context.T, peerNames []string) (
-	security.Blessings, map[string]security.Discharge, error) {
+	security.Blessings, security.Discharges, error) {
 	return x.auth.BlessingsForPeer(ctx, peerNames)
 }

--- a/x/ref/runtime/internal/rpc/client.go
+++ b/x/ref/runtime/internal/rpc/client.go
@@ -932,12 +932,12 @@ func (a typeFlowAuthorizer) AuthorizePeer(
 	ctx *context.T,
 	localEP, remoteEP naming.Endpoint,
 	remoteBlessings security.Blessings,
-	remoteDischarges map[string]security.Discharge) ([]string, []security.RejectedBlessing, error) {
+	remoteDischarges security.Discharges) ([]string, []security.RejectedBlessing, error) {
 	return nil, nil, nil
 }
 
 func (a typeFlowAuthorizer) BlessingsForPeer(ctx *context.T, peerNames []string) (
-	security.Blessings, map[string]security.Discharge, error) {
+	security.Blessings, security.Discharges, error) {
 	return security.Blessings{}, nil, nil
 }
 
@@ -951,7 +951,7 @@ func (x peerAuthorizer) AuthorizePeer(
 	ctx *context.T,
 	localEP, remoteEP naming.Endpoint,
 	remoteBlessings security.Blessings,
-	remoteDischarges map[string]security.Discharge) ([]string, []security.RejectedBlessing, error) {
+	remoteDischarges security.Discharges) ([]string, []security.RejectedBlessing, error) {
 	localPrincipal := v23.GetPrincipal(ctx)
 	// The "Method" and "Suffix" fields of the call are not populated
 	// as they are considered irrelevant for authorizing server blessings.
@@ -971,7 +971,7 @@ func (x peerAuthorizer) AuthorizePeer(
 }
 
 func (x peerAuthorizer) BlessingsForPeer(ctx *context.T, peerNames []string) (
-	security.Blessings, map[string]security.Discharge, error) {
+	security.Blessings, security.Discharges, error) {
 	localPrincipal := v23.GetPrincipal(ctx)
 	clientB := localPrincipal.BlessingStore().ForPeer(peerNames...)
 	dis, _ := slib.PrepareDischarges(ctx, clientB, peerNames, x.method, x.args)

--- a/x/ref/runtime/internal/rpc/server.go
+++ b/x/ref/runtime/internal/rpc/server.go
@@ -1019,10 +1019,10 @@ func (fs *flowServer) Recv(itemptr interface{}) error {
 func (fs *flowServer) Security() security.Call {
 	return fs
 }
-func (fs *flowServer) LocalDischarges() map[string]security.Discharge {
+func (fs *flowServer) LocalDischarges() security.Discharges {
 	return fs.flow.LocalDischarges()
 }
-func (fs *flowServer) RemoteDischarges() map[string]security.Discharge {
+func (fs *flowServer) RemoteDischarges() security.Discharges {
 	return fs.flow.RemoteDischarges()
 }
 func (fs *flowServer) Server() rpc.Server {

--- a/x/ref/runtime/internal/rpc/testutil_test.go
+++ b/x/ref/runtime/internal/rpc/testutil_test.go
@@ -43,11 +43,11 @@ func (c *mockCall) Timestamp() (t time.Time) { return }
 func (c *mockCall) Method() string           { return c.m }
 func (c *mockCall) MethodTags() []*vdl.Value { return nil }
 func (c *mockCall) Suffix() string           { return "" }
-func (c *mockCall) LocalDischarges() map[string]security.Discharge {
-	return map[string]security.Discharge{c.ld.ID(): c.ld}
+func (c *mockCall) LocalDischarges() security.Discharges {
+	return security.Discharges{c.ld}
 }
-func (c *mockCall) RemoteDischarges() map[string]security.Discharge {
-	return map[string]security.Discharge{c.rd.ID(): c.rd}
+func (c *mockCall) RemoteDischarges() security.Discharges {
+	return security.Discharges{c.rd}
 }
 func (c *mockCall) LocalEndpoint() naming.Endpoint      { return c.lep }
 func (c *mockCall) RemoteEndpoint() naming.Endpoint     { return c.rep }

--- a/x/ref/services/xproxy/xproxy/util.go
+++ b/x/ref/services/xproxy/xproxy/util.go
@@ -22,13 +22,13 @@ func (proxyAuthorizer) AuthorizePeer(
 	ctx *context.T,
 	localEndpoint, remoteEndpoint naming.Endpoint,
 	remoteBlessings security.Blessings,
-	remoteDischarges map[string]security.Discharge,
+	remoteDischarges security.Discharges,
 ) ([]string, []security.RejectedBlessing, error) {
 	return nil, nil, nil
 }
 
 func (a proxyAuthorizer) BlessingsForPeer(ctx *context.T, serverBlessings []string) (
-	security.Blessings, map[string]security.Discharge, error) {
+	security.Blessings, security.Discharges, error) {
 	blessings := v23.GetPrincipal(ctx).BlessingStore().ForPeer(serverBlessings...)
 	discharges, _ := slib.PrepareDischarges(ctx, blessings, serverBlessings, "", nil)
 	return blessings, discharges, nil


### PR DESCRIPTION
Discharges are generally small in number and hence a slice is a more appropriate representation for them than a map. The map was originally used to avoid writing a simple 'Find' function but this has led to conversion to/from maps/slices. This PR uses a slice representation throughout but otherwise has no impact on performance or memory allocations.