### PR TITLE
Add a go.work and remove the replace directives from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,9 +30,3 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 )
-
-replace v.io/x/ref/lib/flags/sitedefaults => ./x/ref/lib/flags/sitedefaults
-
-replace v.io/x/ref/internal/logger => ./x/ref/internal/logger
-
-replace v.io/x/ref/test/compatibility/modules/simple => ./x/ref/test/compatibility/modules/simple

--- a/go.work
+++ b/go.work
@@ -1,0 +1,10 @@
+go 1.18
+
+use (
+	.
+	./x/ref/aws
+	./x/ref/examples
+	./x/ref/internal/logger
+	./x/ref/lib/flags/sitedefaults
+	./x/ref/test/compatibility/modules/simple
+)

--- a/x/ref/aws/go.mod
+++ b/x/ref/aws/go.mod
@@ -2,8 +2,6 @@ module v.io/x/ref/aws
 
 go 1.18
 
-replace v.io => ../../..
-
 require (
 	github.com/aws/aws-xray-sdk-go v1.8.0
 	v.io v0.1.21

--- a/x/ref/examples/go.mod
+++ b/x/ref/examples/go.mod
@@ -2,8 +2,6 @@ module v.io/x/ref/examples
 
 go 1.18
 
-replace v.io => ../../..
-
 require (
 	github.com/creack/pty v1.1.18
 	v.io v0.1.21

--- a/x/ref/runtime/internal/rpc/benchmark/go.mod
+++ b/x/ref/runtime/internal/rpc/benchmark/go.mod
@@ -2,8 +2,6 @@ module v.io/x/ref/runtime/internal/rpc/benchmark
 
 go 1.18
 
-replace v.io => ../../../../../..
-
 require (
 	google.golang.org/protobuf v1.28.1
 	v.io v0.1.21

--- a/x/ref/test/compatibility/modules/simple/go.mod
+++ b/x/ref/test/compatibility/modules/simple/go.mod
@@ -2,8 +2,6 @@ module v.io/x/ref/test/compatibility/modules/simple
 
 go 1.18
 
-replace v.io => ../../../../../..
-
 require (
 	v.io v0.1.21
 	v.io/x/lib v0.1.14


### PR DESCRIPTION
The replace directives from the root go.mod makes it difficult to do a `go install` on the binaries provided by v.io
(https://go.dev/issue/44840 is one place where this is discussed). This commit is trying to fix this by using the Go workspaces added in go 1.18.